### PR TITLE
Parameterize update to allow the specification of a specific tag

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,8 @@
 task :default => [:update, :build, :compile]
 
-task :update do
-    run("scripts/update.sh")
+task :update, :tag do |t, args|
+    args.with_defaults(:tag => 'HEAD')
+    run("scripts/update.sh #{args.tag}")
 end
 
 task :build do

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -20,12 +20,16 @@ function update {
         cd $DIR/build/$1
 
         $DIR/scripts/checkout.sh $1
-        git pull origin master
+        git pull --tags origin master
     else
         cd $DIR/build
         git clone git://github.com/Bukkit/$1.git
     fi
+
+    if [ ! -z $2 ]; then
+        git reset --hard $2
+    fi
 }
 
-update Bukkit
-update CraftBukkit
+update Bukkit $1
+update CraftBukkit $1


### PR DESCRIPTION
Supports the following syntax:

`rake update[1.4.7-R1.0] build compile`

May want to figure out how to specify the tag under the simple `rake`, if there is a way.
