### PR TITLE
Add safe methods from @md-5's offlineUtil.

### DIFF
--- a/Bukkit/OfflineUtil.patch
+++ b/Bukkit/OfflineUtil.patch
@@ -1,0 +1,43 @@
+From 0039d44db1ca9c9e90a447a009f4b2f27c365810 Mon Sep 17 00:00:00 2001
+From: Chad Waters <authorblues@gmail.com>
+Date: Wed, 6 Feb 2013 14:42:01 -0500
+Subject: [PATCH] Add safe methods from @md-5's offlineUtil
+
+---
+ src/main/java/org/bukkit/OfflinePlayer.java | 15 +++++++++++++++
+ 1 file changed, 15 insertions(+)
+
+diff --git a/src/main/java/org/bukkit/OfflinePlayer.java b/src/main/java/org/bukkit/OfflinePlayer.java
+index 9146771..48df59a 100644
+--- a/src/main/java/org/bukkit/OfflinePlayer.java
++++ b/src/main/java/org/bukkit/OfflinePlayer.java
+@@ -3,6 +3,7 @@ package org.bukkit;
+ import org.bukkit.configuration.serialization.ConfigurationSerializable;
+ import org.bukkit.entity.AnimalTamer;
+ import org.bukkit.entity.Player;
++import org.bukkit.inventory.PlayerInventory;
+ import org.bukkit.permissions.ServerOperator;
+ 
+ public interface OfflinePlayer extends ServerOperator, AnimalTamer, ConfigurationSerializable {
+@@ -93,4 +94,18 @@ public interface OfflinePlayer extends ServerOperator, AnimalTamer, Configuratio
+      */
+     public Location getBedSpawnLocation();
+ 
++    /**
++     * Get the player's inventory. This inventory will not save upon modification, it must be saved using the saveInventory() method.
++     * This inventory will also have a null owner.
++     *
++     * @return The inventory of the player, this also contains the armor slots.
++     */
++    public PlayerInventory getInventory();
++
++     /**
++     * Gets the last Location where the player was before he logged out of the server.
++     *
++     * @return Last Location of the player.
++     */
++    public Location getLocation();
+ }
+-- 
+1.7.12.2
+

--- a/CraftBukkit/OfflineUtil.patch
+++ b/CraftBukkit/OfflineUtil.patch
@@ -1,0 +1,88 @@
+From c6391a8394637353ecf0fea4d7b94cf53d58feeb Mon Sep 17 00:00:00 2001
+From: Chad Waters <authorblues@gmail.com>
+Date: Wed, 6 Feb 2013 14:45:43 -0500
+Subject: [PATCH] Add safe methods from @md-5's offlineUtil
+
+---
+ .../org/bukkit/craftbukkit/CraftOfflinePlayer.java | 40 ++++++++++++++++++++++
+ 1 file changed, 40 insertions(+)
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayer.java b/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayer.java
+index c43773d..53732ed 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayer.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayer.java
+@@ -4,19 +4,27 @@ import java.io.File;
+ import java.util.LinkedHashMap;
+ import java.util.List;
+ import java.util.Map;
++import java.util.UUID;
+ 
+ import net.minecraft.server.BanEntry;
+ import net.minecraft.server.EntityPlayer;
++import net.minecraft.server.NBTCompressedStreamTools;
+ import net.minecraft.server.NBTTagCompound;
++import net.minecraft.server.NBTTagDouble;
++import net.minecraft.server.NBTTagFloat;
++import net.minecraft.server.NBTTagList;
+ import net.minecraft.server.WorldNBTStorage;
+ 
+ import org.bukkit.Bukkit;
+ import org.bukkit.Location;
+ import org.bukkit.OfflinePlayer;
+ import org.bukkit.Server;
++import org.bukkit.World;
+ import org.bukkit.configuration.serialization.ConfigurationSerializable;
+ import org.bukkit.configuration.serialization.SerializableAs;
++import org.bukkit.craftbukkit.inventory.CraftInventoryPlayer;
+ import org.bukkit.entity.Player;
++import org.bukkit.inventory.PlayerInventory;
+ import org.bukkit.metadata.MetadataValue;
+ import org.bukkit.plugin.Plugin;
+ 
+@@ -25,6 +33,7 @@ public class CraftOfflinePlayer implements OfflinePlayer, ConfigurationSerializa
+     private final String name;
+     private final CraftServer server;
+     private final WorldNBTStorage storage;
++    private CraftInventoryPlayer inventory;
+ 
+     protected CraftOfflinePlayer(CraftServer server, String name) {
+         this.server = server;
+@@ -225,4 +234,35 @@ public class CraftOfflinePlayer implements OfflinePlayer, ConfigurationSerializa
+     public void removeMetadata(String metadataKey, Plugin plugin) {
+         server.getPlayerMetadata().removeMetadata(this, metadataKey, plugin);
+     }
++
++    public PlayerInventory getInventory() {
++        if (inventory == null) {
++            NBTTagList nbttaglist = getData().getList("Inventory");
++            net.minecraft.server.PlayerInventory inv = new net.minecraft.server.PlayerInventory(null);
++            inv.b(nbttaglist);
++            inventory = new CraftInventoryPlayer(inv);
++        }
++        return inventory;
++    }
++
++    public Location getLocation() {
++        NBTTagCompound data = getData();
++        Location location = null;
++        if (data.hasKey("Pos") && data.hasKey("Rotation")) {
++            NBTTagList pos = data.getList("Pos");
++            NBTTagList rot = data.getList("Rotation");
++            double locX = ((NBTTagDouble) pos.get(0)).data;
++            double locY = ((NBTTagDouble) pos.get(1)).data;
++            double locZ = ((NBTTagDouble) pos.get(2)).data;
++            float yaw = ((NBTTagFloat) rot.get(0)).data;
++            float pitch = ((NBTTagFloat) rot.get(1)).data;
++            World world = null;
++            if (data.hasKey("WorldUUIDMost") && data.hasKey("WorldUUIDLeast")) {
++                UUID uid = new UUID(data.getLong("WorldUUIDMost"), data.getLong("WorldUUIDLeast"));
++                world = server.getWorld(uid);
++            }
++            location = new Location(world, locX, locY, locZ, yaw, pitch);
++        }
++        return location;
++    }
+ }
+-- 
+1.7.12.2
+


### PR DESCRIPTION
Adds in the safe (well, safer) methods of @md-5's offlineUtil branch of CraftBukkit-Bleeding. These methods read information about a player from the offline records. OfflinePlayer does not have an associated datawatcher, so if the player logs in while a copy of the corresponding OfflinePlayer is held, the data is no longer expected to be correct (though it should still be safe).

Thrown out were the set and write methods of this util, since there seems to be a poor understanding of what should and would happen if these methods were called in the same tick that a player logs in (since OfflinePlayer does no promotion to Player). For that reason, those methods are considered to be unsafe, and were discarded.
