### PR TITLE
Updated indirect redstone patch for 1.5.1

### DIFF
--- a/CraftBukkit/RedstoneUpdateFix.patch
+++ b/CraftBukkit/RedstoneUpdateFix.patch
@@ -1,36 +1,28 @@
-From 033c25e921dd4653bbe0f3b50071252348e4f784 Mon Sep 17 00:00:00 2001
+From 8b4c703e9000be6a1d7f505deeb73eae32492f9e Mon Sep 17 00:00:00 2001
 From: Chad Waters <authorblues@gmail.com>
-Date: Wed, 27 Jun 2012 02:15:57 -0400
-Subject: [PATCH] Update physics for Attachable for redstone updates. Fixes
+Date: Tue, 26 Mar 2013 07:47:43 -0400
+Subject: [PATCH] Update physics for Attachable to update redstone. Fixes
  BUKKIT-1858
 
 ---
- src/main/java/org/bukkit/craftbukkit/block/CraftBlockState.java |    5 +++++
+ src/main/java/org/bukkit/craftbukkit/block/CraftBlockState.java | 5 +++++
  1 file changed, 5 insertions(+)
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlockState.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlockState.java
-index 8164d7d..a846db3 100644
+index 2072db2..65cb405 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlockState.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlockState.java
-@@ -9,6 +9,7 @@
- import org.bukkit.craftbukkit.CraftChunk;
- import org.bukkit.craftbukkit.CraftWorld;
+@@ -11,2 +11,3 @@ import org.bukkit.craftbukkit.CraftWorld;
  import org.bukkit.material.MaterialData;
 +import org.bukkit.material.Attachable;
  import org.bukkit.metadata.MetadataValue;
- import org.bukkit.plugin.Plugin;
- 
-@@ -125,6 +126,10 @@ public boolean update(boolean force) {
-             }
- 
-             block.setData(getRawData());
-+            if (data instanceof Attachable) {
-+                Block rel = block.getRelative(((Attachable) data).getFacing(), -1);
-+                world.getHandle().applyPhysics(rel.getX(), rel.getY(), rel.getZ(), block.getTypeId());
-+            }
-             world.getHandle().notify(x, y, z);
-         }
- 
+@@ -130,2 +131,6 @@ public class CraftBlockState implements BlockState {
+         block.setData(getRawData(), applyPhysics);
++        if (data instanceof Attachable) {
++            Block rel = block.getRelative(((Attachable) data).getFacing(), -1);
++            world.getHandle().applyPhysics(rel.getX(), rel.getY(), rel.getZ(), block.getTypeId());
++        }
+         world.getHandle().notify(x, y, z);
 -- 
-1.7.10
+1.8.2
 


### PR DESCRIPTION
Patch context changed to match BlockState. This patch wont be accepted by CraftBukkit upstream, but I have another Pull Request in the works to make this patch irrelevant.
