### PR TITLE
Change URL scheme from git:// to https:// to prevent timing out

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -53,7 +53,7 @@ def update(project, tag)
     if File.directory?(project)
         g = Git.open(project)
     else
-        uri = "git://github.com/Bukkit/" + project + ".git"
+        uri = "https://github.com/Bukkit/" + project + ".git"
         g = Git.clone(uri, project)
     end
 


### PR DESCRIPTION
I kept timing out when using `git://`, but `https://` works fine for me.
