### PR TITLE
Update .gitignore with more filetypes, cross OS and Editor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,30 @@
 # Mac OSX generated files
 .DS_Store
+.AppleDouble
+.LSOverride
+Icon
+
+# Other OSX Files
+.Spotlight-V100
+.Trashes
+._*
+
+# Sublime Text
+*.sublime-workspace
 
 # Vim generated files
 *~
 *.swp
+*.un~
+Session.vim
+.netrwhist
+*~
+
+# Windows
+Thumbs.db
+ehthumbs.db
+Desktop.ini
+$RECYCLE.BIN/
 
 # Miscellaneous
 build


### PR DESCRIPTION
Added Sublime Text project files, more Miscellaneous Mac OSX filetypes and other waste VIM and Windows files.

This allows for cross-operating system and editor usage.
