### PR TITLE
Fix unknown command message for players

### DIFF
--- a/CraftBukkit/0054-Fix-unknown-command-message-for-players.patch
+++ b/CraftBukkit/0054-Fix-unknown-command-message-for-players.patch
@@ -1,0 +1,25 @@
+From edb6cedc9337f153f9fd24053e03764b1603f70c Mon Sep 17 00:00:00 2001
+From: Isaac Moore <rmsy@me.com>
+Date: Sat, 27 Jul 2013 14:54:16 -0500
+Subject: [PATCH] Fix unknown command message for players
+
+---
+ src/main/java/org/bukkit/craftbukkit/CraftServer.java | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+index 6cb50b7..800c78c 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+@@ -524,7 +524,7 @@ public final class CraftServer implements Server {
+             return true;
+         }
+ 
+-        sender.sendMessage("Unknown command. Type \"help\" for help.");
++        sender.sendMessage("Unknown command. Type " + ((sender instanceof ConsoleCommandSender) ? "\"help\"" : "\"/help\"") + " for help.");
+ 
+         return false;
+     }
+-- 
+1.7.11.1
+


### PR DESCRIPTION
If a player types 'help', nothing will occur.
