### PR TITLE
Force UTF-8 encoding for config files

### DIFF
--- a/Bukkit/0029-Force-UTF-8-encoding-for-config-files.patch
+++ b/Bukkit/0029-Force-UTF-8-encoding-for-config-files.patch
@@ -1,0 +1,41 @@
+From 0d4fdd09085f33cb5a5cc416418ab3718f63dc34 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Sat, 1 Feb 2014 02:26:31 -0500
+Subject: [PATCH] Force UTF-8 encoding for config files
+
+
+diff --git a/src/main/java/org/bukkit/configuration/file/FileConfiguration.java b/src/main/java/org/bukkit/configuration/file/FileConfiguration.java
+index 33aac31..85ac977 100644
+--- a/src/main/java/org/bukkit/configuration/file/FileConfiguration.java
++++ b/src/main/java/org/bukkit/configuration/file/FileConfiguration.java
+@@ -8,7 +8,8 @@ import java.io.BufferedReader;
+ import java.io.File;
+ import java.io.FileInputStream;
+ import java.io.FileNotFoundException;
+-import java.io.FileWriter;
++import java.io.FileOutputStream;
++import java.io.OutputStreamWriter;
+ import java.io.IOException;
+ import java.io.InputStream;
+ import java.io.InputStreamReader;
+@@ -53,7 +54,7 @@ public abstract class FileConfiguration extends MemoryConfiguration {
+ 
+         String data = saveToString();
+ 
+-        FileWriter writer = new FileWriter(file);
++        OutputStreamWriter writer = new OutputStreamWriter(new FileOutputStream(file), "UTF-8");
+ 
+         try {
+             writer.write(data);
+@@ -119,7 +120,7 @@ public abstract class FileConfiguration extends MemoryConfiguration {
+     public void load(InputStream stream) throws IOException, InvalidConfigurationException {
+         Validate.notNull(stream, "Stream cannot be null");
+ 
+-        InputStreamReader reader = new InputStreamReader(stream);
++        InputStreamReader reader = new InputStreamReader(stream, "UTF-8");
+         StringBuilder builder = new StringBuilder();
+         BufferedReader input = new BufferedReader(reader);
+ 
+-- 
+1.7.3.5
+


### PR DESCRIPTION
Use UTF-8 for all config file reading and writing, with both files and resources.

Fixes an issue with weird characters showing up in chat formatting. Bukkit was simply using the local default encoding for config file I/O, so if, for example, you compiled a plugin on Linux/OSX and then ran it on Windows, the YAML files in the jar would be UTF-8 but would be read as ISO-8559-1 and chars above 127 would get mangled.

Any existing config files that are not UTF-8 encoded will have to be converted, though if they only contain strings from the default config, they are probably already correct when read as UTF-8.

Also, any plugins used with SportBukkit must have config file resources encoded as UTF-8, which should be the case if they are compiled on most non-Windows platforms.
