### PR TITLE
Option to disable player list updates for a Player

### DIFF
--- a/Bukkit/0031-Option-to-disable-player-list-updates-for-a-Player.patch
+++ b/Bukkit/0031-Option-to-disable-player-list-updates-for-a-Player.patch
@@ -1,0 +1,32 @@
+From 6908ad4686719c7618a894c698238a643074ae91 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Sun, 9 Mar 2014 04:39:21 -0400
+Subject: [PATCH] Option to disable player list updates for a Player
+
+
+diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
+index aee5244..98ee38a 100644
+--- a/src/main/java/org/bukkit/entity/Player.java
++++ b/src/main/java/org/bukkit/entity/Player.java
+@@ -155,6 +155,18 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
+     public void setOverheadName(String name);
+ 
+     /**
++     * Enables/disables default player (TAB) list updates. It is enabled by default. When it's disabled,
++     * the player's list will be cleared and the server will not send any further updates for it, giving
++     * plugins complete control.
++     */
++    public void setPlayerListUpdates(boolean enabled);
++
++    /**
++     * Getter for {@link #setPlayerListUpdates}
++     */
++    public boolean getPlayerListUpdates();
++
++    /**
+      * Set the target of the player's compass.
+      *
+      * @param loc Location to point to
+-- 
+1.7.3.5
+

--- a/CraftBukkit/0077-Disable-player-list-updates.patch
+++ b/CraftBukkit/0077-Disable-player-list-updates.patch
@@ -1,0 +1,137 @@
+From 406da5f7204d32c335aab31aa8c1e718dca395c6 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Sun, 9 Mar 2014 04:38:32 -0400
+Subject: [PATCH] Disable player list updates
+
+
+diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
+index 3889157..49b8466 100644
+--- a/src/main/java/net/minecraft/server/PlayerList.java
++++ b/src/main/java/net/minecraft/server/PlayerList.java
+@@ -247,7 +247,9 @@ public abstract class PlayerList {
+         for (int i = 0; i < this.players.size(); ++i) {
+             EntityPlayer entityplayer1 = (EntityPlayer) this.players.get(i);
+ 
+-            if (entityplayer1.getBukkitEntity().canSee(entityplayer.getBukkitEntity())) {
++            if (entityplayer1.getBukkitEntity().canSee(entityplayer.getBukkitEntity()) &&
++                entityplayer1.getBukkitEntity().getPlayerListUpdates()) {
++
+                 entityplayer1.playerConnection.sendPacket(packet);
+             }
+         }
+@@ -257,7 +259,9 @@ public abstract class PlayerList {
+             EntityPlayer entityplayer1 = (EntityPlayer) this.players.get(i);
+ 
+             // CraftBukkit start - .name -> .listName
+-            if (entityplayer.getBukkitEntity().canSee(entityplayer1.getBukkitEntity())) {
++            if (entityplayer.getBukkitEntity().canSee(entityplayer1.getBukkitEntity()) &&
++                entityplayer.getBukkitEntity().getPlayerListUpdates()) {
++
+                 entityplayer.playerConnection.sendPacket(new Packet201PlayerInfo(entityplayer1.listName, true, entityplayer1.ping));
+             }
+             // CraftBukkit end
+@@ -297,7 +301,9 @@ public abstract class PlayerList {
+         for (int i = 0; i < this.players.size(); ++i) {
+             EntityPlayer entityplayer1 = (EntityPlayer) this.players.get(i);
+ 
+-            if (entityplayer1.getBukkitEntity().canSee(entityplayer.getBukkitEntity())) {
++            if (entityplayer1.getBukkitEntity().canSee(entityplayer.getBukkitEntity()) &&
++                entityplayer1.getBukkitEntity().getPlayerListUpdates()) {
++
+                 entityplayer1.playerConnection.sendPacket(packet);
+             }
+         }
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+index 384ee9f..fd48a97 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+@@ -76,6 +76,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+     private double health = 20;
+     private boolean scaledHealth = false;
+     private double healthScale = 20;
++    private boolean playerListUpdates = true;
+ 
+     private final Map<CommandSender, String> fakeNames = new WeakHashMap<CommandSender, String>();
+     private final Map<CommandSender, String> fakeDisplayNames = new WeakHashMap<CommandSender, String>();
+@@ -238,7 +239,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+             CraftPlayer craftViewer = (CraftPlayer) viewer;
+             EntityPlayer viewerEntity  = craftViewer.getHandle();
+             if(viewerEntity.playerConnection != null) {
+-                if(craftViewer.canSee(this)) {
++                if(craftViewer.canSee(this) && craftViewer.getPlayerListUpdates()) {
+                     viewerEntity.playerConnection.sendPacket(new Packet201PlayerInfo(this.getName(), false, 9999));
+                 }
+ 
+@@ -258,7 +259,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+             CraftPlayer craftViewer = (CraftPlayer) viewer;
+             EntityPlayer viewerEntity  = craftViewer.getHandle();
+             if(viewerEntity.playerConnection != null) {
+-                if(craftViewer.canSee(this)) {
++                if(craftViewer.canSee(this) && craftViewer.getPlayerListUpdates()) {
+                     viewerEntity.playerConnection.sendPacket(new Packet201PlayerInfo(this.getName(), true, this.getHandle().ping));
+                 }
+ 
+@@ -398,7 +399,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+             EntityPlayer entityplayer = (EntityPlayer) server.getHandle().players.get(i);
+             if (entityplayer.playerConnection == null) continue;
+ 
+-            if (entityplayer.getBukkitEntity().canSee(this)) {
++            if (entityplayer.getBukkitEntity().canSee(this) && entityplayer.getBukkitEntity().getPlayerListUpdates()) {
+                 entityplayer.playerConnection.sendPacket(oldpacket);
+                 entityplayer.playerConnection.sendPacket(packet);
+             }
+@@ -918,7 +919,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+         }
+ 
+         //remove the hidden player from this player user list
+-        if(other instanceof EntityPlayer) {
++        if(other instanceof EntityPlayer && this.getPlayerListUpdates()) {
+             getHandle().playerConnection.sendPacket(new Packet201PlayerInfo(((CraftPlayer) entity).getPlayerListName(), false, 9999));
+         }
+     }
+@@ -941,7 +942,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+             entry.updatePlayer(getHandle());
+         }
+ 
+-        if(other instanceof EntityPlayer) {
++        if(other instanceof EntityPlayer && this.getPlayerListUpdates()) {
+             getHandle().playerConnection.sendPacket(new Packet201PlayerInfo(((CraftPlayer) entity).getPlayerListName(), true, getHandle().ping));
+         }
+     }
+@@ -1284,6 +1285,33 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+     }
+ 
+     @Override
++    public void setPlayerListUpdates(boolean enabled) {
++        // Note that fake names are handled by the packet translator in PlayerConnection,
++        // so we should always use real names here.
++        if(this.playerListUpdates && !enabled) {
++            // Clear the player list
++            for(Player player : this.getServer().getOnlinePlayers()) {
++                if(this.canSee(player)) {
++                    this.getHandle().playerConnection.sendPacket(new Packet201PlayerInfo(player.getPlayerListName(), false, 0));
++                }
++            }
++        } else if(!this.playerListUpdates && enabled) {
++            // Restore the player list
++            for(Player player : this.getServer().getOnlinePlayers()) {
++                if(this.canSee(player)) {
++                    this.getHandle().playerConnection.sendPacket(new Packet201PlayerInfo(player.getPlayerListName(), true, this.getHandle().ping));
++                }
++            }
++        }
++        this.playerListUpdates = enabled;
++    }
++
++    @Override
++    public boolean getPlayerListUpdates() {
++        return this.playerListUpdates;
++    }
++
++    @Override
+     public void setMaxHealth(double amount) {
+         super.setMaxHealth(amount);
+         this.health = Math.min(this.health, health);
+-- 
+1.8.5.2 (Apple Git-48)
+


### PR DESCRIPTION
Set this flag true and CB will clear the player list and not touch it at all. We use this so it doesn't interfere with our custom display.
