### PR TITLE
Add verbose error messages on failed player login

### DIFF
--- a/Bukkit/0003-Make-AsyncPlayerPreLoginEvent-more-versatile.patch
+++ b/Bukkit/0003-Make-AsyncPlayerPreLoginEvent-more-versatile.patch
@@ -1,42 +1,14 @@
-From 03891816f7c4f1a82360125ae01e7f33e6da3877 Mon Sep 17 00:00:00 2001
+From 240af66c45804ff9ac8a9d4f8220f62793b45719 Mon Sep 17 00:00:00 2001
 From: mrapple <tony@oc.tc>
 Date: Sat, 17 Nov 2012 12:42:05 -0600
 Subject: [PATCH] Make AsyncPlayerPreLoginEvent more versatile
 
 
 diff --git a/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java b/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
-index 1d57188..01c41f1 100644
+index 1d57188..78c5ea2 100644
 --- a/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
 +++ b/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
-@@ -20,17 +20,23 @@ public class AsyncPlayerPreLoginEvent extends Event {
-     private final UUID uniqueId;
- 
-     @Deprecated
--    public AsyncPlayerPreLoginEvent(final String name, final InetAddress ipAddress) {
--        this(name, ipAddress, null);
-+    public AsyncPlayerPreLoginEvent(final String name, final InetAddress ipAddress, final boolean allowed) {
-+        this(name, ipAddress, null, allowed);
-     }
- 
--    public AsyncPlayerPreLoginEvent(final String name, final InetAddress ipAddress, final UUID uniqueId) {
-+    public AsyncPlayerPreLoginEvent(final String name, final InetAddress ipAddress, final UUID uniqueId, final boolean allowed) {
-         super(true);
--        this.result = Result.ALLOWED;
-         this.message = "";
-         this.name = name;
-         this.ipAddress = ipAddress;
-         this.uniqueId = uniqueId;
-+
-+        if(allowed) {
-+            this.result = Result.ALLOWED;
-+        } else {
-+            this.result = Result.KICK_VERIFY;
-+            this.message = "Failed to verify username!";
-+        }
-     }
- 
-     /**
-@@ -189,6 +195,10 @@ public class AsyncPlayerPreLoginEvent extends Event {
+@@ -189,6 +189,10 @@ public class AsyncPlayerPreLoginEvent extends Event {
           */
          KICK_WHITELIST,
          /**
@@ -63,5 +35,5 @@ index e8553f0..aa49dfa 100644
           */
          KICK_OTHER
 -- 
-1.8.5.1
+1.7.9
 

--- a/CraftBukkit/0004-Make-AsyncPlayerPreLoginEvent-more-versatile.patch
+++ b/CraftBukkit/0004-Make-AsyncPlayerPreLoginEvent-more-versatile.patch
@@ -1,50 +1,37 @@
-From 2a62413a2c70593b89417bd6278bd25815c6f63e Mon Sep 17 00:00:00 2001
+From 025a35f5d286aab2a9316156c688a086235d2d4f Mon Sep 17 00:00:00 2001
 From: mrapple <tony@oc.tc>
 Date: Sat, 17 Nov 2012 12:41:06 -0600
 Subject: [PATCH] Make AsyncPlayerPreLoginEvent more versatile
 
 
 diff --git a/src/main/java/net/minecraft/server/ThreadPlayerLookupUUID.java b/src/main/java/net/minecraft/server/ThreadPlayerLookupUUID.java
-index 496b7c9..1aa2ce4 100644
+index 496b7c9..cc072d5 100644
 --- a/src/main/java/net/minecraft/server/ThreadPlayerLookupUUID.java
 +++ b/src/main/java/net/minecraft/server/ThreadPlayerLookupUUID.java
-@@ -1,6 +1,7 @@
- package net.minecraft.server;
- 
- import java.math.BigInteger;
-+import java.net.HttpURLConnection; // CraftBukkit
- 
- import net.minecraft.util.com.mojang.authlib.GameProfile;
- import net.minecraft.util.com.mojang.authlib.exceptions.AuthenticationUnavailableException;
-@@ -21,63 +22,55 @@ class ThreadPlayerLookupUUID extends Thread {
+@@ -21,63 +21,69 @@ class ThreadPlayerLookupUUID extends Thread {
      }
  
      public void run() {
-+        boolean allowed = false; // CraftBukkit
++        String errorMessage = null;
++
          try {
              String s = (new BigInteger(MinecraftEncryption.a(LoginListener.a(this.a), LoginListener.b(this.a).J().getPublic(), LoginListener.c(this.a)))).toString(16);
  
              LoginListener.a(this.a, LoginListener.b(this.a).at().hasJoinedServer(new GameProfile((String) null, LoginListener.d(this.a).getName()), s));
--            if (LoginListener.d(this.a) != null) {
+             if (LoginListener.d(this.a) != null) {
 -                // CraftBukkit start - fire PlayerPreLoginEvent
--                if (!this.a.networkManager.isConnected()) {
--                    return;
--                }
- 
+                 if (!this.a.networkManager.isConnected()) {
+                     return;
+                 }
+-
 -                String playerName = LoginListener.d(this.a).getName();
 -                java.net.InetAddress address = ((java.net.InetSocketAddress) a.networkManager.getSocketAddress()).getAddress();
 -                java.util.UUID uniqueId = UtilUUID.b(LoginListener.d(this.a).getId());
 -                final org.bukkit.craftbukkit.CraftServer server = LoginListener.b(this.a).server;
-+            // CraftBukkit start - fire PlayerPreLoginEvent
-+            allowed = LoginListener.d(this.a) != null;
-+        } catch(Exception exception) {}
- 
+-
 -                AsyncPlayerPreLoginEvent asyncEvent = new AsyncPlayerPreLoginEvent(playerName, address, uniqueId);
 -                server.getPluginManager().callEvent(asyncEvent);
-+        if (!this.a.networkManager.isConnected()) {
-+            return;
-+        }
- 
+-
 -                if (PlayerPreLoginEvent.getHandlerList().getRegisteredListeners().length != 0) {
 -                    final PlayerPreLoginEvent event = new PlayerPreLoginEvent(playerName, address, uniqueId);
 -                    if (asyncEvent.getResult() != PlayerPreLoginEvent.Result.ALLOWED) {
@@ -56,10 +43,7 @@ index 496b7c9..1aa2ce4 100644
 -                            server.getPluginManager().callEvent(event);
 -                            return event.getResult();
 -                        }};
-+        String playerName = LoginListener.d(this.a).getName();
-+        java.net.InetAddress address = ((java.net.InetSocketAddress) a.networkManager.getSocketAddress()).getAddress();
-+        final org.bukkit.craftbukkit.CraftServer server = LoginListener.b(this.a).server;
- 
+-
 -                    LoginListener.b(this.a).processQueue.add(waitable);
 -                    if (waitable.get() != PlayerPreLoginEvent.Result.ALLOWED) {
 -                        this.a.disconnect(event.getKickMessage());
@@ -72,16 +56,40 @@ index 496b7c9..1aa2ce4 100644
 -                    }
 -                }
 -                // CraftBukkit end
-+        AsyncPlayerPreLoginEvent asyncEvent = new AsyncPlayerPreLoginEvent(playerName, address, allowed);
-+        server.getPluginManager().callEvent(asyncEvent);
- 
+-
 -                LoginListener.e().info("UUID of player " + LoginListener.d(this.a).getName() + " is " + LoginListener.d(this.a).getId());
 -                LoginListener.a(this.a, EnumProtocolState.READY_TO_ACCEPT);
--            } else {
+             } else {
 -                this.a.disconnect("Failed to verify username!");
--                LoginListener.e().error("Username \'" + LoginListener.d(this.a).getName() + "\' tried to join with an invalid session");
++                errorMessage = "Failed to verify username: invalid session";
+                 LoginListener.e().error("Username \'" + LoginListener.d(this.a).getName() + "\' tried to join with an invalid session");
+             }
+         } catch (AuthenticationUnavailableException authenticationunavailableexception) {
+-            this.a.disconnect("Authentication servers are down. Please try again later, sorry!");
++            errorMessage = "Authentication servers are down. Please try again later, sorry!";
+             LoginListener.e().error("Couldn\'t verify username because servers are unavailable");
+             // CraftBukkit start - catch all exceptions
+         } catch (Exception exception) {
+-            this.a.disconnect("Failed to verify username!");
++            errorMessage = "Failed to verify username: internal server error";
+             LoginListener.b(this.a).server.getLogger().log(java.util.logging.Level.WARNING, "Exception verifying " + LoginListener.d(this.a).getName(), exception);
+             // CraftBukkit end
+         }
++
++        // CraftBukkit start - fire PlayerPreLoginEvent
++        String playerName = LoginListener.d(this.a).getName();
++        java.net.InetAddress address = ((java.net.InetSocketAddress) a.networkManager.getSocketAddress()).getAddress();
++        java.util.UUID uniqueId = UtilUUID.b(LoginListener.d(this.a).getId());
++        final org.bukkit.craftbukkit.CraftServer server = LoginListener.b(this.a).server;
++
++        AsyncPlayerPreLoginEvent asyncEvent = new AsyncPlayerPreLoginEvent(playerName, address, uniqueId);
++        if (errorMessage != null) {
++            asyncEvent.disallow(AsyncPlayerPreLoginEvent.Result.KICK_VERIFY, errorMessage);
++        }
++        server.getPluginManager().callEvent(asyncEvent);
++
 +        if (PlayerPreLoginEvent.getHandlerList().getRegisteredListeners().length != 0) {
-+            final PlayerPreLoginEvent event = new PlayerPreLoginEvent(playerName, address);
++            final PlayerPreLoginEvent event = new PlayerPreLoginEvent(playerName, address, uniqueId);
 +            if (asyncEvent.getResult() != PlayerPreLoginEvent.Result.ALLOWED) {
 +                event.disallow(asyncEvent.getResult(), asyncEvent.getKickMessage());
 +            }
@@ -90,29 +98,20 @@ index 496b7c9..1aa2ce4 100644
 +                protected PlayerPreLoginEvent.Result evaluate() {
 +                    server.getPluginManager().callEvent(event);
 +                    return event.getResult();
-+                }};
++                }
++            };
 +
 +            LoginListener.b(this.a).processQueue.add(waitable);
-+            try {
-+                if (waitable.get() != PlayerPreLoginEvent.Result.ALLOWED) {
-+                    this.a.disconnect(event.getKickMessage());
-+                    return;
-+                }
-+            } catch(Exception exception) {}
++            if (waitable.get() != PlayerPreLoginEvent.Result.ALLOWED) {
++                this.a.disconnect(event.getKickMessage());
++                return;
++            }
 +        } else {
 +            if (asyncEvent.getLoginResult() != AsyncPlayerPreLoginEvent.Result.ALLOWED) {
 +                this.a.disconnect(asyncEvent.getKickMessage());
 +                return;
-             }
--        } catch (AuthenticationUnavailableException authenticationunavailableexception) {
--            this.a.disconnect("Authentication servers are down. Please try again later, sorry!");
--            LoginListener.e().error("Couldn\'t verify username because servers are unavailable");
--            // CraftBukkit start - catch all exceptions
--        } catch (Exception exception) {
--            this.a.disconnect("Failed to verify username!");
--            LoginListener.b(this.a).server.getLogger().log(java.util.logging.Level.WARNING, "Exception verifying " + LoginListener.d(this.a).getName(), exception);
--            // CraftBukkit end
-         }
++            }
++        }
 +        // CraftBukkit end
 +
 +        LoginListener.e().info("UUID of player " + LoginListener.d(this.a).getName() + " is " + LoginListener.d(this.a).getId());
@@ -120,5 +119,5 @@ index 496b7c9..1aa2ce4 100644
      }
  }
 -- 
-1.8.5.1
+1.7.9
 

--- a/CraftBukkit/0025-Call-AsyncPlayerPreLoginEvent-regardless-of-online-m.patch
+++ b/CraftBukkit/0025-Call-AsyncPlayerPreLoginEvent-regardless-of-online-m.patch
@@ -1,4 +1,4 @@
-From 8bc5409575d6ec70ac4a510c45779bd7ba5cab18 Mon Sep 17 00:00:00 2001
+From 515e911056987c47beefe1e2ff67c830ceb70eb8 Mon Sep 17 00:00:00 2001
 From: mrapple <tony@oc.tc>
 Date: Tue, 23 Apr 2013 19:45:55 -0500
 Subject: [PATCH] Call AsyncPlayerPreLoginEvent regardless of online-mode
@@ -19,46 +19,64 @@ index 44a6bfe..3a6f269 100644
      }
  
 diff --git a/src/main/java/net/minecraft/server/ThreadPlayerLookupUUID.java b/src/main/java/net/minecraft/server/ThreadPlayerLookupUUID.java
-index 1aa2ce4..ab470dd 100644
+index cc072d5..9a62052 100644
 --- a/src/main/java/net/minecraft/server/ThreadPlayerLookupUUID.java
 +++ b/src/main/java/net/minecraft/server/ThreadPlayerLookupUUID.java
-@@ -22,15 +22,21 @@ class ThreadPlayerLookupUUID extends Thread {
-     }
+@@ -22,34 +22,36 @@ class ThreadPlayerLookupUUID extends Thread {
  
      public void run() {
--        boolean allowed = false; // CraftBukkit
+         String errorMessage = null;
++        final org.bukkit.craftbukkit.CraftServer server = LoginListener.b(this.a).server;
+ 
 -        try {
 -            String s = (new BigInteger(MinecraftEncryption.a(LoginListener.a(this.a), LoginListener.b(this.a).J().getPublic(), LoginListener.c(this.a)))).toString(16);
-+        // CraftBukkit start
-+        final org.bukkit.craftbukkit.CraftServer server = LoginListener.b(this.a).server;
-+        boolean allowed = false;
- 
--            LoginListener.a(this.a, LoginListener.b(this.a).at().hasJoinedServer(new GameProfile((String) null, LoginListener.d(this.a).getName()), s));
 +        if (server.getOnlineMode()) {
 +            try {
 +                String s = (new BigInteger(MinecraftEncryption.a(LoginListener.a(this.a), LoginListener.b(this.a).J().getPublic(), LoginListener.c(this.a)))).toString(16);
  
--            // CraftBukkit start - fire PlayerPreLoginEvent
--            allowed = LoginListener.d(this.a) != null;
--        } catch(Exception exception) {}
+-            LoginListener.a(this.a, LoginListener.b(this.a).at().hasJoinedServer(new GameProfile((String) null, LoginListener.d(this.a).getName()), s));
+-            if (LoginListener.d(this.a) != null) {
+-                if (!this.a.networkManager.isConnected()) {
+-                    return;
 +                LoginListener.a(this.a, LoginListener.b(this.a).at().hasJoinedServer(new GameProfile((String) null, LoginListener.d(this.a).getName()), s));
-+
-+                allowed = LoginListener.d(this.a) != null;
-+            } catch(Exception exception) {}
-+        } else {
-+            allowed = true;
-+        }
++                if (LoginListener.d(this.a) != null) {
++                    if (!this.a.networkManager.isConnected()) {
++                        return;
++                    }
++                } else {
++                    errorMessage = "Failed to verify username: invalid session";
++                    LoginListener.e().error("Username \'" + LoginListener.d(this.a).getName() + "\' tried to join with an invalid session");
+                 }
+-            } else {
+-                errorMessage = "Failed to verify username: invalid session";
+-                LoginListener.e().error("Username \'" + LoginListener.d(this.a).getName() + "\' tried to join with an invalid session");
++            } catch (AuthenticationUnavailableException authenticationunavailableexception) {
++                errorMessage = "Authentication servers are down. Please try again later, sorry!";
++                LoginListener.e().error("Couldn\'t verify username because servers are unavailable");
++                // CraftBukkit start - catch all exceptions
++            } catch (Exception exception) {
++                errorMessage = "Failed to verify username: internal server error";
++                LoginListener.b(this.a).server.getLogger().log(java.util.logging.Level.WARNING, "Exception verifying " + LoginListener.d(this.a).getName(), exception);
++                // CraftBukkit end
+             }
+-        } catch (AuthenticationUnavailableException authenticationunavailableexception) {
+-            errorMessage = "Authentication servers are down. Please try again later, sorry!";
+-            LoginListener.e().error("Couldn\'t verify username because servers are unavailable");
+-            // CraftBukkit start - catch all exceptions
+-        } catch (Exception exception) {
+-            errorMessage = "Failed to verify username: internal server error";
+-            LoginListener.b(this.a).server.getLogger().log(java.util.logging.Level.WARNING, "Exception verifying " + LoginListener.d(this.a).getName(), exception);
+-            // CraftBukkit end
+         }
  
-         if (!this.a.networkManager.isConnected()) {
-             return;
-@@ -38,7 +44,6 @@ class ThreadPlayerLookupUUID extends Thread {
- 
+         // CraftBukkit start - fire PlayerPreLoginEvent
          String playerName = LoginListener.d(this.a).getName();
          java.net.InetAddress address = ((java.net.InetSocketAddress) a.networkManager.getSocketAddress()).getAddress();
+         java.util.UUID uniqueId = UtilUUID.b(LoginListener.d(this.a).getId());
 -        final org.bukkit.craftbukkit.CraftServer server = LoginListener.b(this.a).server;
  
-         AsyncPlayerPreLoginEvent asyncEvent = new AsyncPlayerPreLoginEvent(playerName, address, allowed);
-         server.getPluginManager().callEvent(asyncEvent);
+         AsyncPlayerPreLoginEvent asyncEvent = new AsyncPlayerPreLoginEvent(playerName, address, uniqueId);
+         if (errorMessage != null) {
 -- 
-1.8.5.1
+1.7.9
 


### PR DESCRIPTION
Basically it sets the error message on the (Async)PlayerPreLoginEvent to whatever it was going to kick the user for. This allows both the player and the server to know why the player can't connect, instead of just ignoring errors without actually logging them, which makes fixing an error quite hard.
