### PR TITLE
Do not load chunks when calling world.getChunk

### DIFF
--- a/CraftBukkit/0075-Do-not-load-chunks-by-default-when-calling-world.get.patch
+++ b/CraftBukkit/0075-Do-not-load-chunks-by-default-when-calling-world.get.patch
@@ -1,0 +1,40 @@
+From 0036de4dc066819175c83e5c9316cbf143d73e8e Mon Sep 17 00:00:00 2001
+From: Marcos Vives Del Sol <socram8888@gmail.com>
+Date: Wed, 23 Apr 2014 19:52:00 +0200
+Subject: [PATCH] Do not load chunks when calling world.getChunk
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
+index 55f5225..0b70b9f 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
+@@ -37,6 +37,14 @@ public class CraftChunk implements Chunk {
+         z = getHandle().locZ;
+     }
+ 
++    public CraftChunk(WorldServer worldServer, int x, int z) {
++        this.worldServer = worldServer;
++        this.x = x;
++        this.z = z;
++
++        weakChunk = new WeakReference<net.minecraft.server.Chunk>(null);
++    }
++
+     public World getWorld() {
+         return worldServer.getWorld();
+     }
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+index 98e2711..61ea1cc 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+@@ -116,7 +116,7 @@ public class CraftWorld implements World {
+     }
+ 
+     public Chunk getChunkAt(int x, int z) {
+-        return this.world.chunkProviderServer.getChunkAt(x, z).bukkitChunk;
++        return new CraftChunk(world, x, z);
+     }
+ 
+     public Chunk getChunkAt(Block block) {
+-- 
+1.9.1


### PR DESCRIPTION
By default, when you call world.getChunk(x, z), it loads the chunk in memory. This is really slow, and pointless unless you actually want the chunk data, which is not the case for protection plugins and the like, which use them only as a data types, without actually needing its blocks.

This patch disables this, and only loads chunks when the plugin actually access them.
