### PR TITLE
Fix client-server desync when a player hits an entity while sprinting

### DIFF
--- a/CraftBukkit/0073-Fix-client-server-desync-when-a-player-hits-an-entit.patch
+++ b/CraftBukkit/0073-Fix-client-server-desync-when-a-player-hits-an-entit.patch
@@ -1,0 +1,66 @@
+From a5f36b3b77d602eec27d4ffb9d133df4ad16216d Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Sun, 11 May 2014 06:58:02 -0400
+Subject: [PATCH] Fix client-server desync when a player hits an entity while
+ sprinting
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityHuman.java b/src/main/java/net/minecraft/server/EntityHuman.java
+index 1efde90..422e460 100644
+--- a/src/main/java/net/minecraft/server/EntityHuman.java
++++ b/src/main/java/net/minecraft/server/EntityHuman.java
+@@ -926,11 +926,26 @@ public abstract class EntityHuman extends EntityLiving implements ICommandListen
+                     boolean flag2 = entity.damageEntity(DamageSource.playerAttack(this), f);
+ 
+                     if (flag2) {
++                        // CraftBukkit start
++                        long now = this.world.getTime();
++
+                         if (i > 0) {
++                            // Implement a 20 tick cooldown for sprint knockback, to compensate for the fix below.
++                            // This is 2x the damage cooldown, so you have to wait twice as long between hits to get the extra KB.
++                            if(this.isSprinting() && this.getBukkitEntity().getLastKnockbackTime() + 20 > now) {
++                                i--;
++                            }
++                            this.getBukkitEntity().setLastKnockbackTime(now);
++                            // CraftBukkit end
++
+                             entity.g((double) (-MathHelper.sin(this.yaw * 3.1415927F / 180.0F) * (float) i * 0.5F), 0.1D, (double) (MathHelper.cos(this.yaw * 3.1415927F / 180.0F) * (float) i * 0.5F));
+-                            this.motX *= 0.6D;
+-                            this.motZ *= 0.6D;
+-                            this.setSprinting(false);
++
++                            // CraftBukkit start
++                            // Don't try to stop the player's sprint because the client will ignore it if the sprint key is held down
++                            //this.motX *= 0.6D;
++                            //this.motZ *= 0.6D;
++                            //this.setSprinting(false);
++                            // CraftBukkit end
+                         }
+ 
+                         // CraftBukkit start
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
+index 2717a81..9a7cc1a 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
+@@ -45,6 +45,17 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
+     private boolean op;
+     private GameMode mode;
+ 
++    // World tick-time when this entity last gave extra knockback to another entity by hitting them while sprinting
++    private long lastKnockbackTime;
++
++    public long getLastKnockbackTime() {
++        return lastKnockbackTime;
++    }
++
++    public void setLastKnockbackTime(long lastKnockbackTime) {
++        this.lastKnockbackTime = lastKnockbackTime;
++    }
++
+     public CraftHumanEntity(final CraftServer server, final EntityHuman entity) {
+         super(server, entity);
+         mode = server.getDefaultGameMode();
+-- 
+1.8.5.2 (Apple Git-48)
+


### PR DESCRIPTION
This uses the 20 tick cooldown from the last hit
