### PR TITLE
Fix head rotation packet spam

### DIFF
--- a/CraftBukkit/0076-Fix-head-rotation-packet-spam.patch
+++ b/CraftBukkit/0076-Fix-head-rotation-packet-spam.patch
@@ -1,0 +1,26 @@
+From 588373c5c8e4862e893851263f13aafe9aef9984 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Tue, 3 Jun 2014 08:02:58 -0400
+Subject: [PATCH] Fix head rotation packet spam
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityTrackerEntry.java b/src/main/java/net/minecraft/server/EntityTrackerEntry.java
+index 7515540..02fcff8 100644
+--- a/src/main/java/net/minecraft/server/EntityTrackerEntry.java
++++ b/src/main/java/net/minecraft/server/EntityTrackerEntry.java
+@@ -437,8 +437,10 @@ public class EntityTrackerEntry {
+                     }
+ 
+                     // CraftBukkit start - Fix for nonsensical head yaw
+-                    this.i = MathHelper.d(this.tracker.getHeadRotation() * 256.0F / 360.0F);
+-                    this.broadcast(new PacketPlayOutEntityHeadRotation(this.tracker, (byte) i));
++                    if(this.tracker instanceof EntityLiving) {
++                        this.i = MathHelper.d(this.tracker.getHeadRotation() * 256.0F / 360.0F);
++                        entityplayer.playerConnection.sendPacket(new PacketPlayOutEntityHeadRotation(this.tracker, (byte) i));
++                    }
+                     // CraftBukkit end
+ 
+                     if (this.tracker instanceof EntityLiving) {
+-- 
+1.8.5.2 (Apple Git-48)
+


### PR DESCRIPTION
Fix this packet being sent n^2 times for the number of players, and for entities without heads.
