### PR TITLE
Normalize offline player's name before creating an UUID

### DIFF
--- a/CraftBukkit/0077-Normalize-offline-player-s-name-case-before-creating.patch
+++ b/CraftBukkit/0077-Normalize-offline-player-s-name-case-before-creating.patch
@@ -1,0 +1,57 @@
+From 62748eb14546da69ff532270b708b6e74c6a1d43 Mon Sep 17 00:00:00 2001
+From: Marcos Vives Del Sol <socram8888@gmail.com>
+Date: Thu, 5 Jun 2014 22:02:07 +0200
+Subject: [PATCH] Normalize offline player's name case before creating an UUID
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityHuman.java b/src/main/java/net/minecraft/server/EntityHuman.java
+index 751a32d..adff9ef 100644
+--- a/src/main/java/net/minecraft/server/EntityHuman.java
++++ b/src/main/java/net/minecraft/server/EntityHuman.java
+@@ -1600,7 +1600,7 @@ public abstract class EntityHuman extends EntityLiving implements ICommandListen
+         UUID uuid = gameprofile.getId();
+ 
+         if (uuid == null) {
+-            uuid = UUID.nameUUIDFromBytes(("OfflinePlayer:" + gameprofile.getName()).getBytes(Charsets.UTF_8));
++            uuid = UUID.nameUUIDFromBytes(("OfflinePlayer:" + gameprofile.getName().toLowerCase()).getBytes(Charsets.UTF_8));
+         }
+ 
+         return uuid;
+diff --git a/src/main/java/net/minecraft/server/LoginListener.java b/src/main/java/net/minecraft/server/LoginListener.java
+index 0f6682e..5a24f80 100644
+--- a/src/main/java/net/minecraft/server/LoginListener.java
++++ b/src/main/java/net/minecraft/server/LoginListener.java
+@@ -65,7 +65,7 @@ public class LoginListener implements PacketLoginInListener {
+         if (networkManager.spoofedUUID != null) {
+             uuid = networkManager.spoofedUUID;
+         } else {
+-            uuid = UUID.nameUUIDFromBytes(("OfflinePlayer:" + this.i.getName()).getBytes(Charsets.UTF_8));
++            uuid = UUID.nameUUIDFromBytes(("OfflinePlayer:" + this.i.getName().toLowerCase()).getBytes(Charsets.UTF_8));
+         }
+ 
+         this.i = new GameProfile(uuid, this.i.getName());
+@@ -137,7 +137,7 @@ public class LoginListener implements PacketLoginInListener {
+     }
+ 
+     protected GameProfile a(GameProfile gameprofile) {
+-        UUID uuid = UUID.nameUUIDFromBytes(("OfflinePlayer:" + gameprofile.getName()).getBytes(Charsets.UTF_8));
++        UUID uuid = UUID.nameUUIDFromBytes(("OfflinePlayer:" + gameprofile.getName().toLowerCase()).getBytes(Charsets.UTF_8));
+ 
+         return new GameProfile(uuid, gameprofile.getName());
+     }
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+index a9b7944..4200fb5 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+@@ -1333,7 +1333,7 @@ public final class CraftServer implements Server {
+             GameProfile profile = MinecraftServer.getServer().getUserCache().a(name);
+             if (profile == null) {
+                 // Make an OfflinePlayer using an offline mode UUID since the name has no profile
+-                result = getOfflinePlayer(new GameProfile(UUID.nameUUIDFromBytes(("OfflinePlayer:" + name).getBytes(Charsets.UTF_8)), name));
++                result = getOfflinePlayer(new GameProfile(UUID.nameUUIDFromBytes(("OfflinePlayer:" + name.toLowerCase()).getBytes(Charsets.UTF_8)), name));
+             } else {
+                 // Use the GameProfile even when we get a UUID so we ensure we still have a name
+                 result = getOfflinePlayer(profile);
+-- 
+1.7.9
+


### PR DESCRIPTION
This is a somewhat breaking change, so I will understand if you don't want to get this pulled.

This converts player's name to lower case when generating their UUID if the server is in offline mode, so "User", "uSer", "user"... all have the same UUID.

This matches not only the behaviour of most plugins, which ignore the casing, but also the Minecraft login system before UUIDs were introduced, where the case didn't matter either.

Right now banning an user is hard, as they can just change the case, therefore having the same nick to most plugins, while still be able to bypass the UUID ban.
