### PR TITLE
Fix pistons checking redstone power two blocks above them

### DIFF
--- a/CraftBukkit/0077-Fix-pistons-checking-redstone-power-two-blocks-above.patch
+++ b/CraftBukkit/0077-Fix-pistons-checking-redstone-power-two-blocks-above.patch
@@ -1,0 +1,22 @@
+From 455056413688b7c4c23b32e7b86efe15cbe7c0d4 Mon Sep 17 00:00:00 2001
+From: Marcos Vives Del Sol <socram8888@gmail.com>
+Date: Sun, 15 Jun 2014 17:00:50 +0200
+Subject: [PATCH] Fix pistons checking redstone power two blocks above them
+
+
+diff --git a/src/main/java/net/minecraft/server/BlockPiston.java b/src/main/java/net/minecraft/server/BlockPiston.java
+index 7822de7..2510d5b 100644
+--- a/src/main/java/net/minecraft/server/BlockPiston.java
++++ b/src/main/java/net/minecraft/server/BlockPiston.java
+@@ -93,7 +93,7 @@ public class BlockPiston extends Block {
+     }
+ 
+     private boolean a(World world, int i, int j, int k, int l) {
+-        return l != 0 && world.isBlockFacePowered(i, j - 1, k, 0) ? true : (l != 1 && world.isBlockFacePowered(i, j + 1, k, 1) ? true : (l != 2 && world.isBlockFacePowered(i, j, k - 1, 2) ? true : (l != 3 && world.isBlockFacePowered(i, j, k + 1, 3) ? true : (l != 5 && world.isBlockFacePowered(i + 1, j, k, 5) ? true : (l != 4 && world.isBlockFacePowered(i - 1, j, k, 4) ? true : (world.isBlockFacePowered(i, j, k, 0) ? true : (world.isBlockFacePowered(i, j + 2, k, 1) ? true : (world.isBlockFacePowered(i, j + 1, k - 1, 2) ? true : (world.isBlockFacePowered(i, j + 1, k + 1, 3) ? true : (world.isBlockFacePowered(i - 1, j + 1, k, 4) ? true : world.isBlockFacePowered(i + 1, j + 1, k, 5)))))))))));
++        return l != 0 && world.isBlockFacePowered(i, j - 1, k, 0) ? true : (l != 1 && world.isBlockFacePowered(i, j + 1, k, 1) ? true : (l != 2 && world.isBlockFacePowered(i, j, k - 1, 2) ? true : (l != 3 && world.isBlockFacePowered(i, j, k + 1, 3) ? true : (l != 5 && world.isBlockFacePowered(i + 1, j, k, 5) ? true : (l != 4 && world.isBlockFacePowered(i - 1, j, k, 4) ? true : (world.isBlockFacePowered(i, j, k, 0) ? true : (world.isBlockFacePowered(i, j + 1, k - 1, 2) ? true : (world.isBlockFacePowered(i, j + 1, k + 1, 3) ? true : (world.isBlockFacePowered(i - 1, j + 1, k, 4) ? true : world.isBlockFacePowered(i + 1, j + 1, k, 5))))))))));
+     }
+ 
+     public boolean a(World world, int i, int j, int k, int l, int i1) {
+-- 
+1.7.9
+


### PR DESCRIPTION
Basically this fixes the following bug:

When you power a piston, like this:
![Circuit 1](http://i.imgur.com/1UDJzrE.png)

If you power both redstone wires at once:
![Circuit 2](http://i.imgur.com/M7rIIUZ.png)

The piston gets stuck as extended because of the upper redstone wire.
![Circuit 3](http://i.imgur.com/a8P0r1y.png)

This affects not only SportBukkit but also CraftBukkit and even vanilla Minecraft.
