### PR TITLE
Waterproof

### DIFF
--- a/CraftBukkit/0076-Check-waterproofness-of-blocks-when-using-buckets.patch
+++ b/CraftBukkit/0076-Check-waterproofness-of-blocks-when-using-buckets.patch
@@ -1,6 +1,6 @@
-From 0f3b5b8b815c5f6626defcbe42d7097431cb3869 Mon Sep 17 00:00:00 2001
+From e369c2d4acc95011d480a80ef1f2bf8256ecacd4 Mon Sep 17 00:00:00 2001
 From: Marcos Vives Del Sol <socram8888@gmail.com>
-Date: Mon, 23 Jun 2014 11:49:17 +0200
+Date: Mon, 23 Jun 2014 12:15:49 +0200
 Subject: [PATCH] Check waterproofness of blocks when using buckets
 
 
@@ -20,33 +20,36 @@ index f0661d5..b6b64ba 100644
      }
  
 diff --git a/src/main/java/net/minecraft/server/DispenseBehaviorFilledBucket.java b/src/main/java/net/minecraft/server/DispenseBehaviorFilledBucket.java
-index 4a3691a..7200b60 100644
+index 4a3691a..b9cc173 100644
 --- a/src/main/java/net/minecraft/server/DispenseBehaviorFilledBucket.java
 +++ b/src/main/java/net/minecraft/server/DispenseBehaviorFilledBucket.java
-@@ -23,7 +23,7 @@ final class DispenseBehaviorFilledBucket extends DispenseBehaviorItem {
+@@ -23,7 +23,9 @@ final class DispenseBehaviorFilledBucket extends DispenseBehaviorItem {
          int x = i + enumfacing.getAdjacentX();
          int y = j + enumfacing.getAdjacentY();
          int z = k + enumfacing.getAdjacentZ();
 -        if (world.isEmpty(x, y, z) || !world.getType(x, y, z).getMaterial().isBuildable()) {
-+        if (world.isEmpty(x, y, z) || !BlockFlowing.isWaterproof(world.getType(x, y, z))) {
++        Block nmsBlock = world.getType(x, y, z);
++        // Special-case PORTAL, as some Redstone circuits rely on water buckets to disable Nether Portals.
++        if (nmsBlock.getMaterial() == Material.AIR || nmsBlock == Blocks.PORTAL || !BlockFlowing.isWaterproof(nmsBlock)) {
              org.bukkit.block.Block block = world.getWorld().getBlockAt(i, j, k);
              CraftItemStack craftItem = CraftItemStack.asCraftMirror(itemstack);
  
 diff --git a/src/main/java/net/minecraft/server/ItemBucket.java b/src/main/java/net/minecraft/server/ItemBucket.java
-index 402f9b1..0a5efdb 100644
+index 402f9b1..8e6184f 100644
 --- a/src/main/java/net/minecraft/server/ItemBucket.java
 +++ b/src/main/java/net/minecraft/server/ItemBucket.java
-@@ -109,7 +109,8 @@ public class ItemBucket extends Item {
+@@ -109,7 +109,9 @@ public class ItemBucket extends Item {
  
                      // CraftBukkit start
                      // Check that the bucket can be emptied before firing the event
 -                    if (world.isEmpty(i, j, k) || !world.getType(i, j, k).getMaterial().isBuildable()) {
 +                    Block block = world.getType(i, j, k);
-+                    if (world.isEmpty(i, j, k) || block == Blocks.PORTAL || !BlockFlowing.isWaterproof(block)) {
++                    // Special-case PORTAL, as some Redstone circuits rely on water buckets to disable Nether Portals.
++                    if (block.getMaterial() == Material.AIR || block == Blocks.PORTAL || !BlockFlowing.isWaterproof(block)) {
                          PlayerBucketEmptyEvent event = CraftEventFactory.callPlayerBucketEmptyEvent(entityhuman, clickedX, clickedY, clickedZ, movingobjectposition.face, itemstack);
                          if(event.isCancelled()) {
                              return itemstack;
-@@ -146,8 +147,10 @@ public class ItemBucket extends Item {
+@@ -146,10 +148,11 @@ public class ItemBucket extends Item {
          if (this.a == Blocks.AIR) {
              return false;
          } else {
@@ -54,11 +57,13 @@ index 402f9b1..0a5efdb 100644
 -            boolean flag = !material.isBuildable();
 +            Block block = world.getType(i, j, k);
 +            Material material = block.getMaterial();
-+            // Special-case PORTAL, as some redstone circuits rely on water buckets to disable Nether Portals.
 +            boolean flag = block == Blocks.PORTAL || !BlockFlowing.isWaterproof(block);
  
-             if (!world.isEmpty(i, j, k) && !flag) {
+-            if (!world.isEmpty(i, j, k) && !flag) {
++            if (block.getMaterial() != Material.AIR && !flag) {
                  return false;
+             } else {
+                 if (world.worldProvider.f && this.a == Blocks.WATER) {
 -- 
 1.7.9
 


### PR DESCRIPTION
Basically this prevents ***holes from placing water buckets on End portals to destroy them. It also special-cases Nether portals so existing Redstone circuits which employ buckets to disable them will still work.

This could be probably fixed on the Bukkit side using a plugin, but I feel that being able to break a block as hard as bedrock by placing a water bucket is a bug and should be fixed on the NMS side.
