### PR TITLE
Keep players in the player list while respawning

### DIFF
--- a/CraftBukkit/0086-Keep-players-in-the-player-list-while-respawning.patch
+++ b/CraftBukkit/0086-Keep-players-in-the-player-list-while-respawning.patch
@@ -1,0 +1,35 @@
+From 8ac58c961bb5f1f739a27623bc7646089eca5c4d Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Sun, 7 Sep 2014 21:17:24 -0400
+Subject: [PATCH] Keep players in the player list while respawning
+
+
+diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
+index 7df2ada..e8aacd2 100644
+--- a/src/main/java/net/minecraft/server/PlayerList.java
++++ b/src/main/java/net/minecraft/server/PlayerList.java
+@@ -494,6 +494,7 @@ public abstract class PlayerList {
+         ChunkCoordinates chunkcoordinates1;
+ 
+         // CraftBukkit start - fire PlayerRespawnEvent
++        this.players.add(entityplayer1); // Add player back to this list earlier than vanilla does
+         if (location == null) {
+             boolean isBedSpawn = false;
+             CraftWorld cworld = (CraftWorld) this.server.server.getWorld(entityplayer.spawnWorld);
+@@ -550,10 +551,11 @@ public abstract class PlayerList {
+         this.b(entityplayer1, worldserver);
+         // CraftBukkit start
+         // Don't re-add player to player list if disconnected
+-        if (!entityplayer.playerConnection.isDisconnected()) {
++        if (entityplayer.playerConnection.isDisconnected()) {
++            this.players.remove(entityplayer1);
++        } else {
+             worldserver.getPlayerChunkMap().addPlayer(entityplayer1);
+             worldserver.addEntity(entityplayer1);
+-            this.players.add(entityplayer1);
+         }
+         // Added from changeDimension
+         this.updateClient(entityplayer1); // Update health, etc...
+-- 
+1.8.5.2 (Apple Git-48)
+


### PR DESCRIPTION
Fixes nicked players ending up teamless, and probably some other things. I didn't notice any adverse effects, but we should keep an eye out. Some of the stuff in that method could be expecting the player to not be in the list.
