### PR TITLE
Changes needed for custom player list in 1.8

### DIFF
--- a/Bukkit/0033-Skin-parts-API.patch
+++ b/Bukkit/0033-Skin-parts-API.patch
@@ -1,0 +1,85 @@
+From c8b12514efdce385a38d3a181bde2ee5bb72df27 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Sat, 20 Sep 2014 23:20:08 -0400
+Subject: [PATCH] Skin parts API
+
+
+diff --git a/src/main/java/org/bukkit/Skin.java b/src/main/java/org/bukkit/Skin.java
+index b11f962..5dc9cef 100644
+--- a/src/main/java/org/bukkit/Skin.java
++++ b/src/main/java/org/bukkit/Skin.java
+@@ -5,6 +5,17 @@ package org.bukkit;
+  * A self-contained skin
+  */
+ public class Skin {
++    // NOTE: ordinals must match bit positions in packet data
++    public static enum Part {
++        CAPE,
++        JACKET,
++        LEFT_SLEEVE,
++        RIGHT_SLEEVE,
++        LEFT_PANTS_LEG,
++        RIGHT_PANTS_LEG,
++        HAT
++    }
++
+     public static final Skin EMPTY = new Skin(null, null);
+ 
+     private final String data;
+diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
+index 6e63c94..224d597 100644
+--- a/src/main/java/org/bukkit/entity/Player.java
++++ b/src/main/java/org/bukkit/entity/Player.java
+@@ -195,6 +195,11 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
+     public void setSkin(Skin newSkin);
+ 
+     /**
++     * Get the set of skin parts that are currently visible on the player
++     */
++    public Set<Skin.Part> getSkinParts();
++
++    /**
+      * Simultaneously set this player's fake name and {@link Skin} for the given viewer.
+      * This method only refreshes the player entity once, whereas calling
+      * {@link #setFakeName} and {@link #setFakeSkin} seperately would refresh it twice.
+diff --git a/src/main/java/org/bukkit/event/player/PlayerSkinPartsChangeEvent.java b/src/main/java/org/bukkit/event/player/PlayerSkinPartsChangeEvent.java
+new file mode 100644
+index 0000000..a222f21
+--- /dev/null
++++ b/src/main/java/org/bukkit/event/player/PlayerSkinPartsChangeEvent.java
+@@ -0,0 +1,32 @@
++package org.bukkit.event.player;
++
++import org.bukkit.Skin;
++import org.bukkit.entity.Player;
++import org.bukkit.event.HandlerList;
++
++import java.util.Set;
++
++public class PlayerSkinPartsChangeEvent extends PlayerEvent {
++
++    private final Set<Skin.Part> parts;
++
++    public PlayerSkinPartsChangeEvent(Player who, Set<Skin.Part> parts) {
++        super(who);
++        this.parts = parts;
++    }
++
++    public Set<Skin.Part> getParts() {
++        return parts;
++    }
++
++    private static final HandlerList handlers = new HandlerList();
++
++    @Override
++    public HandlerList getHandlers() {
++        return handlers;
++    }
++
++    public static HandlerList getHandlerList() {
++        return handlers;
++    }
++}
+-- 
+1.8.5.2 (Apple Git-48)
+

--- a/CraftBukkit/0091-Skin-parts-API.patch
+++ b/CraftBukkit/0091-Skin-parts-API.patch
@@ -1,0 +1,110 @@
+From 0105f6109394db637ff52321e61e2f383f5d212f Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Sat, 20 Sep 2014 23:15:32 -0400
+Subject: [PATCH] Skin parts API
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
+index 53f58c8..0689ea8 100644
+--- a/src/main/java/net/minecraft/server/EntityPlayer.java
++++ b/src/main/java/net/minecraft/server/EntityPlayer.java
+@@ -24,6 +24,8 @@ import org.bukkit.craftbukkit.entity.CraftPlayer;
+ import org.bukkit.craftbukkit.event.CraftEventFactory;
+ import org.bukkit.craftbukkit.inventory.CraftItemStack;
+ import org.bukkit.event.inventory.InventoryType;
++import org.bukkit.craftbukkit.util.Skins;
++import org.bukkit.event.player.PlayerSkinPartsChangeEvent;
+ import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
+ // CraftBukkit end
+ import org.spigotmc.ProtocolData; // Spigot - protocol patch
+@@ -1026,7 +1028,12 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+         } else
+         {
+             this.b( 1, false, packetplayinsettings.version );
+-            datawatcher.watch( 10, new ProtocolData.HiddenByte( (byte) packetplayinsettings.flags ) );
++
++            int skinFlags = datawatcher.getInt(10);
++            if(skinFlags != packetplayinsettings.flags) {
++                datawatcher.watch( 10, new ProtocolData.HiddenByte( (byte) packetplayinsettings.flags ) );
++                Bukkit.getPluginManager().callEvent(new PlayerSkinPartsChangeEvent(this.getBukkitEntity(), Skins.partsFromFlags(skinFlags)));
++            }
+         }
+         // Spigot end
+     }
+diff --git a/src/main/java/net/minecraft/server/PacketPlayInSettings.java b/src/main/java/net/minecraft/server/PacketPlayInSettings.java
+index ea51d91..f095500 100644
+--- a/src/main/java/net/minecraft/server/PacketPlayInSettings.java
++++ b/src/main/java/net/minecraft/server/PacketPlayInSettings.java
+@@ -13,6 +13,16 @@ public class PacketPlayInSettings extends Packet {
+ 
+     // Spigot start - protocol patch
+     public int version;
++
++    /**
++     * 0x01 - cape
++     * 0x02 - jacket
++     * 0x04 - left sleeve
++     * 0x08 - right sleeve
++     * 0x10 - left pants leg
++     * 0x20 - right pants leg
++     * 0x40 - hat
++     */
+     public int flags;
+     // Spigot end
+ 
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+index 8ba890d..5bfbced 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+@@ -183,6 +183,11 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+     }
+ 
+     @Override
++    public Set<Skin.Part> getSkinParts() {
++        return Skins.partsFromFlags(this.getHandle().getDataWatcher().getInt(10));
++    }
++
++    @Override
+     public boolean hasFakeSkin(CommandSender viewer) {
+         return viewer != null && this.fakeSkins.containsKey(viewer);
+     }
+diff --git a/src/main/java/org/bukkit/craftbukkit/util/Skins.java b/src/main/java/org/bukkit/craftbukkit/util/Skins.java
+index 9003fb2..729169f 100644
+--- a/src/main/java/org/bukkit/craftbukkit/util/Skins.java
++++ b/src/main/java/org/bukkit/craftbukkit/util/Skins.java
+@@ -4,6 +4,9 @@ import net.minecraft.util.com.mojang.authlib.properties.Property;
+ import net.minecraft.util.com.mojang.authlib.properties.PropertyMap;
+ import org.bukkit.Skin;
+ 
++import java.util.EnumSet;
++import java.util.Set;
++
+ public abstract class Skins {
+     public static Skin fromProperties(PropertyMap profile) {
+         for(Property property : profile.get("textures")) {
+@@ -37,4 +40,22 @@ public abstract class Skins {
+     public static PropertyMap toProperties(Skin skin) {
+         return setProperties(skin, new PropertyMap());
+     }
++
++    public static Set<Skin.Part> partsFromFlags(int flags) {
++        EnumSet<Skin.Part> parts = EnumSet.noneOf(Skin.Part.class);
++        for(Skin.Part part : Skin.Part.values()) {
++            if((flags & (1 << part.ordinal())) != 0) {
++                parts.add(part);
++            }
++        }
++        return parts;
++    }
++
++    public static int flagsFromParts(Iterable<Skin.Part> parts) {
++        int flags = 0;
++        for(Skin.Part part : parts) {
++            flags |= 1 << part.ordinal();
++        }
++        return flags;
++    }
+ }
+-- 
+1.8.5.2 (Apple Git-48)
+

--- a/CraftBukkit/0092-Custom-player-list-changes.patch
+++ b/CraftBukkit/0092-Custom-player-list-changes.patch
@@ -1,0 +1,362 @@
+From 8e1dcf6afe21d73059280e28716fb922925d632c Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Sat, 20 Sep 2014 23:24:06 -0400
+Subject: [PATCH] Custom player list changes
+
+
+diff --git a/src/main/java/net/minecraft/server/PacketPlayOutNamedEntitySpawn.java b/src/main/java/net/minecraft/server/PacketPlayOutNamedEntitySpawn.java
+index 5600407..2ee8cad 100644
+--- a/src/main/java/net/minecraft/server/PacketPlayOutNamedEntitySpawn.java
++++ b/src/main/java/net/minecraft/server/PacketPlayOutNamedEntitySpawn.java
+@@ -11,16 +11,18 @@ import java.io.IOException; // CraftBukkit
+ 
+ public class PacketPlayOutNamedEntitySpawn extends Packet {
+ 
+-    private int a;
+-    public GameProfile b; // CraftBukkit - private -> public
+-    private int c;
+-    private int d;
+-    private int e;
+-    private byte f;
+-    private byte g;
+-    private int h;
+-    private DataWatcher i;
+-    private List j;
++    // CraftBukkit start - private -> public
++    public int a; // Entity ID
++    public GameProfile b;
++    public int c; // X
++    public int d; // Y
++    public int e; // Z
++    public byte f; // yaw
++    public byte g; // pitch
++    public int h; // held item ID
++    public DataWatcher i;
++    public List j;
++    // CraftBukkit end
+ 
+     public PacketPlayOutNamedEntitySpawn() {}
+ 
+@@ -94,7 +96,7 @@ public class PacketPlayOutNamedEntitySpawn extends Packet {
+         packetdataserializer.writeByte(this.f);
+         packetdataserializer.writeByte(this.g);
+         packetdataserializer.writeShort(this.h);
+-        this.i.a(packetdataserializer);
++        this.i.a(packetdataserializer, packetdataserializer.version);
+     }
+ 
+     public void a(PacketPlayOutListener packetplayoutlistener) {
+diff --git a/src/main/java/net/minecraft/server/PacketPlayOutPlayerInfo.java b/src/main/java/net/minecraft/server/PacketPlayOutPlayerInfo.java
+index 4858f0e..9486772 100644
+--- a/src/main/java/net/minecraft/server/PacketPlayOutPlayerInfo.java
++++ b/src/main/java/net/minecraft/server/PacketPlayOutPlayerInfo.java
+@@ -6,23 +6,53 @@ import net.minecraft.util.com.mojang.authlib.properties.Property;
+ import net.minecraft.util.com.mojang.authlib.properties.PropertyMap;
+ import org.bukkit.craftbukkit.util.CraftChatMessage;
+ 
++import java.io.IOException;
+ import java.util.*;
+ 
+ public class PacketPlayOutPlayerInfo extends Packet {
+ 
+-    private static final int ADD_PLAYER = 0;
+-    private static final int UPDATE_GAMEMODE = 1;
+-    private static final int UPDATE_LATENCY = 2;
+-    private static final int UPDATE_DISPLAY_NAME = 3;
+-    private static final int REMOVE_PLAYER = 4;
++    // private -> public
++    public static final int ADD_PLAYER = 0;
++    public static final int UPDATE_GAMEMODE = 1;
++    public static final int UPDATE_LATENCY = 2;
++    public static final int UPDATE_DISPLAY_NAME = 3;
++    public static final int REMOVE_PLAYER = 4;
++
++    public static class Entry {
++        public UUID uuid;
++        public String name;
++        public String displayName;
++        public int gamemode;
++        public int ping;
++        public PropertyMap properties;
++
++        public Entry(UUID uuid, String name, String displayName, int gamemode, int ping, PropertyMap properties) {
++            this.uuid = uuid;
++            this.name = name;
++            this.displayName = displayName;
++            this.gamemode = gamemode;
++            this.ping = ping;
++            this.properties = properties;
++        }
++
++        public Entry(UUID uuid, String displayName) {
++            this.uuid = uuid;
++            this.displayName = displayName;
++        }
++
++        public Entry(UUID uuid, int gamemode, int ping) {
++            this.uuid = uuid;
++            this.gamemode = gamemode;
++            this.ping = ping;
++        }
++
++        public Entry(UUID uuid) {
++            this.uuid = uuid;
++        }
++    }
+ 
+     public int action;
+-    public String name;
+-    public String displayName;
+-    public UUID uuid;
+-    public int gamemode;
+-    public int ping;
+-    public PropertyMap properties;
++    public List<Entry> entries;
+ 
+     public PacketPlayOutPlayerInfo() {}
+ 
+@@ -37,18 +67,21 @@ public class PacketPlayOutPlayerInfo extends Packet {
+     // CraftBukkit start
+     public PacketPlayOutPlayerInfo(boolean add, UUID uuid, String name, String displayName, int ping, Map<String, String> properties) {
+         this.action = add ? 0 : 4;
+-        this.name = name;
+-        this.displayName = displayName;
+-        this.uuid = uuid;
+-        this.gamemode = 0;
+-        this.ping = ping;
+ 
+-        this.properties = new PropertyMap();
++        PropertyMap propertyMap = new PropertyMap();
+         if(properties != null) {
+             for(Map.Entry<String, String> property : properties.entrySet()) {
+-                this.properties.put(property.getKey(), new Property(property.getKey(), property.getValue()));
++                propertyMap.put(property.getKey(), new Property(property.getKey(), property.getValue()));
+             }
+         }
++
++        Entry entry = new Entry(uuid, name, displayName, 0, ping, propertyMap);
++        this.entries = Collections.singletonList(entry);
++    }
++
++    public PacketPlayOutPlayerInfo(int action, List<Entry> entries) {
++        this.action = action;
++        this.entries = entries;
+     }
+     // CraftBukkit end
+ 
+@@ -76,12 +109,14 @@ public class PacketPlayOutPlayerInfo extends Packet {
+         PacketPlayOutPlayerInfo packet = new PacketPlayOutPlayerInfo();
+ 
+         packet.action = action;
+-        packet.name = player.getName();
+-        packet.displayName = player.listName;
+-        packet.uuid = player.getProfile().getId();
+-        packet.properties = player.getProfile().getProperties();
+-        packet.ping = player.ping;
+-        packet.gamemode = player.playerInteractManager.getGameMode().getId();
++        packet.entries = Collections.singletonList(new Entry(
++            player.getProfile().getId(),
++            player.listName,
++            ChatSerializer.a(CraftChatMessage.fromString(player.listName)[0]),
++            player.playerInteractManager.getGameMode().getId(),
++            player.ping,
++            player.getProfile().getProperties()
++        ));
+ 
+         return packet;
+     }
+@@ -94,52 +129,59 @@ public class PacketPlayOutPlayerInfo extends Packet {
+         if ( packetdataserializer.version >= 20 )
+         {
+             packetdataserializer.b( action );
+-            packetdataserializer.b( 1 );
+-            packetdataserializer.writeUUID( uuid );
+-            switch ( action )
+-            {
+-                case ADD_PLAYER:
+-                    packetdataserializer.a( name );
+-                    packetdataserializer.b( properties.size() );
+-                    for ( Property property : properties.values() )
+-                    {
+-                        packetdataserializer.a( property.getName() );
+-                        packetdataserializer.a( property.getValue() );
+-                        packetdataserializer.writeBoolean( property.hasSignature() );
+-                        if ( property.hasSignature() )
++            packetdataserializer.b( this.entries.size() );
++
++            for(Entry entry : this.entries) {
++                packetdataserializer.writeUUID( entry.uuid );
++                switch ( action )
++                {
++                    case ADD_PLAYER:
++                        packetdataserializer.a( entry.name );
++                        packetdataserializer.b( entry.properties.size() );
++                        for ( Property property : entry.properties.values() )
++                        {
++                            packetdataserializer.a( property.getName() );
++                            packetdataserializer.a( property.getValue() );
++                            packetdataserializer.writeBoolean( property.hasSignature() );
++                            if ( property.hasSignature() )
++                            {
++                                packetdataserializer.a( property.getSignature() );
++                            }
++                        }
++                        packetdataserializer.b( entry.gamemode );
++                        packetdataserializer.b( entry.ping );
++                        packetdataserializer.writeBoolean( entry.displayName != null );
++                        if ( entry.displayName != null )
++                        {
++                            packetdataserializer.a(entry.displayName);
++                        }
++                        break;
++                    case UPDATE_GAMEMODE:
++                        packetdataserializer.b( entry.gamemode );
++                        break;
++                    case UPDATE_LATENCY:
++                        packetdataserializer.b( entry.ping );
++                        break;
++                    case UPDATE_DISPLAY_NAME:
++                        packetdataserializer.writeBoolean( entry.displayName != null );
++                        if ( entry.displayName != null )
+                         {
+-                            packetdataserializer.a( property.getSignature() );
++                            packetdataserializer.a(entry.displayName);
+                         }
+-                    }
+-                    packetdataserializer.b( gamemode );
+-                    packetdataserializer.b( ping );
+-                    packetdataserializer.writeBoolean( displayName != null );
+-                    if ( displayName != null )
+-                    {
+-                        packetdataserializer.a( ChatSerializer.a( CraftChatMessage.fromString( displayName )[0] ) );
+-                    }
+-                    break;
+-                case UPDATE_GAMEMODE:
+-                    packetdataserializer.b( gamemode );
+-                    break;
+-                case UPDATE_LATENCY:
+-                    packetdataserializer.b( ping );
+-                    break;
+-                case UPDATE_DISPLAY_NAME:
+-                    packetdataserializer.writeBoolean( displayName != null );
+-                    if ( displayName != null )
+-                    {
+-                        packetdataserializer.a( ChatSerializer.a( CraftChatMessage.fromString( displayName )[0] ) );
+-                    }
+-                    break;
+-                case REMOVE_PLAYER:
+-                    break;
++                        break;
++                    case REMOVE_PLAYER:
++                        break;
+ 
++                }
+             }
+         } else {
+-            packetdataserializer.a( displayName );
++            if(this.entries.size() != 1) {
++                throw new IOException("Cannot send multiple player list items in a single packet to 1.7 client");
++            }
++            Entry entry = this.entries.get(0);
++            packetdataserializer.a( entry.name );
+             packetdataserializer.writeBoolean( action != REMOVE_PLAYER );
+-            packetdataserializer.writeShort( ping );
++            packetdataserializer.writeShort( entry.ping );
+         }
+     }
+ 
+diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
+index 8246bfd..6baae0c 100644
+--- a/src/main/java/net/minecraft/server/PlayerConnection.java
++++ b/src/main/java/net/minecraft/server/PlayerConnection.java
+@@ -910,21 +910,27 @@ public class PlayerConnection implements PacketPlayInListener {
+             Player viewer = this.getPlayer();
+             if (viewer != null) {
+                 PacketPlayOutPlayerInfo infoPacket = (PacketPlayOutPlayerInfo) packet;
+-                Player player = this.server.getPlayerExact(infoPacket.name);
+-                if(player != null) {
+-                    String fakeName = player.getFakeName(viewer);
+-                    if(fakeName != null) {
+-                        infoPacket.name = fakeName;
+-                        infoPacket.displayName = fakeName;
+-                    }
++                if(this.networkManager.getVersion() < 20 || infoPacket.action == 0) {
++                    for(PacketPlayOutPlayerInfo.Entry entry : infoPacket.entries) {
++                        if(entry.name != null) {
++                            Player player = this.server.getPlayerExact(entry.name);
++                            if(player != null) {
++                                String fakeName = player.getFakeName(viewer);
++                                if(fakeName != null) {
++                                    entry.name = fakeName;
++                                    entry.displayName = fakeName;
++                                }
+ 
+-                    if(this.networkManager.getVersion() >= 20 && infoPacket.action == 0) {
+-                        Skin fakeSkin = player.getFakeSkin(viewer);
+-                        if(fakeSkin != null) {
+-                            PropertyMap properties = new PropertyMap();
+-                            properties.putAll(infoPacket.properties);
+-                            Skins.setProperties(fakeSkin, properties);
+-                            infoPacket.properties = properties;
++                                if(this.networkManager.getVersion() >= 20 && infoPacket.action == 0) {
++                                    Skin fakeSkin = player.getFakeSkin(viewer);
++                                    if(fakeSkin != null) {
++                                        PropertyMap properties = new PropertyMap();
++                                        properties.putAll(entry.properties);
++                                        Skins.setProperties(fakeSkin, properties);
++                                        entry.properties = properties;
++                                    }
++                                }
++                            }
+                         }
+                     }
+                 }
+diff --git a/src/main/java/org/spigotmc/ProtocolInjector.java b/src/main/java/org/spigotmc/ProtocolInjector.java
+index 0e30463..da81ae8 100644
+--- a/src/main/java/org/spigotmc/ProtocolInjector.java
++++ b/src/main/java/org/spigotmc/ProtocolInjector.java
+@@ -18,6 +18,7 @@ public class ProtocolInjector
+         {
+             addPacket( EnumProtocol.LOGIN, true, 0x3, PacketLoginCompression.class );
+ 
++            addPacket( EnumProtocol.PLAY, true, 0x47, PacketPlayOutPlayerListHeaderFooter.class );
+             addPacket( EnumProtocol.PLAY, true, 0x48, PacketPlayResourcePackSend.class );
+             addPacket( EnumProtocol.PLAY, false, 0x19, PacketPlayResourcePackStatus.class );
+         } catch ( NoSuchFieldException e )
+@@ -126,4 +127,33 @@ public class ProtocolInjector
+ 
+         }
+     }
++
++    public static class PacketPlayOutPlayerListHeaderFooter extends Packet {
++
++        public String header, footer;
++
++        public PacketPlayOutPlayerListHeaderFooter(String header, String footer) {
++            this.header = header;
++            this.footer = footer;
++        }
++
++        @Override
++        public void a(PacketDataSerializer packetdataserializer) throws IOException
++        {
++
++        }
++
++        @Override
++        public void b(PacketDataSerializer packetdataserializer) throws IOException
++        {
++            packetdataserializer.a( this.header );
++            packetdataserializer.a( this.footer );
++        }
++
++        @Override
++        public void handle(PacketListener packetlistener)
++        {
++
++        }
++    }
+ }
+-- 
+1.8.5.2 (Apple Git-48)
+


### PR DESCRIPTION
- First patch is a "skin parts" API that lets you query which skin parts a player has enabled, and fires an event when this changes
- Second patch is miscellaneous things needed to make the new player list work

Downstream:
- OvercastNetwork/PGM#498
- OvercastNetwork/Commons#52
