### PR TITLE
Fix damageEntity cancelling in vehicles

### DIFF
--- a/CraftBukkit/0097-Fix-damageEntity-cancelling-in-vehicles.patch
+++ b/CraftBukkit/0097-Fix-damageEntity-cancelling-in-vehicles.patch
@@ -1,0 +1,35 @@
+From e75540ed31d0d5b33c67af71ace36ec5bd6b7a0b Mon Sep 17 00:00:00 2001
+From: ShinyDialga45 <shinydialga45@gmail.com>
+Date: Sat, 25 Oct 2014 16:04:15 -0500
+Subject: [PATCH] Fix damageEntity cancelling in vehicles
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityBoat.java b/src/main/java/net/minecraft/server/EntityBoat.java
+index 8a3ea63..4918a62 100644
+--- a/src/main/java/net/minecraft/server/EntityBoat.java
++++ b/src/main/java/net/minecraft/server/EntityBoat.java
+@@ -104,7 +104,7 @@ public class EntityBoat extends Entity {
+             this.world.getServer().getPluginManager().callEvent(event);
+ 
+             if (event.isCancelled()) {
+-                return true;
++                return false;
+             }
+             // f = event.getDamage(); // TODO Why don't we do this?
+             // CraftBukkit end
+diff --git a/src/main/java/net/minecraft/server/EntityMinecartAbstract.java b/src/main/java/net/minecraft/server/EntityMinecartAbstract.java
+index 22c9eca..608394e 100644
+--- a/src/main/java/net/minecraft/server/EntityMinecartAbstract.java
++++ b/src/main/java/net/minecraft/server/EntityMinecartAbstract.java
+@@ -121,7 +121,7 @@ public abstract class EntityMinecartAbstract extends Entity {
+                 this.world.getServer().getPluginManager().callEvent(event);
+ 
+                 if (event.isCancelled()) {
+-                    return true;
++                    return false;
+                 }
+ 
+                 f = (float) event.getDamage();
+-- 
+1.8.4.msysgit.0
+


### PR DESCRIPTION
Currently the damageEntity() method doesn't cancel properly as it returns true instead of returning false. If it returns true, then it still thinks that it got damaged, but it doesn't take any damage. There is at least one bug that occurs when it returns true.
