### PR TITLE
Fix combustion events

### DIFF
--- a/Bukkit/0035-Fix-combustion-events.patch
+++ b/Bukkit/0035-Fix-combustion-events.patch
@@ -1,0 +1,40 @@
+From 5b2ddef00969fcf2d3e81c9383621325996bd258 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Thu, 30 Oct 2014 00:40:30 -0400
+Subject: [PATCH] Fix combustion events
+
+
+diff --git a/src/main/java/org/bukkit/event/entity/EntityExtinguishEvent.java b/src/main/java/org/bukkit/event/entity/EntityExtinguishEvent.java
+new file mode 100644
+index 0000000..5833ab7
+--- /dev/null
++++ b/src/main/java/org/bukkit/event/entity/EntityExtinguishEvent.java
+@@ -0,0 +1,25 @@
++package org.bukkit.event.entity;
++
++import org.bukkit.entity.Entity;
++import org.bukkit.event.HandlerList;
++
++/**
++ * Called when a burning entity is extinguished.
++ */
++public class EntityExtinguishEvent extends EntityEvent {
++
++    public EntityExtinguishEvent(Entity combustee) {
++        super(combustee);
++    }
++
++    @Override
++    public HandlerList getHandlers() {
++        return handlers;
++    }
++
++    private static final HandlerList handlers = new HandlerList();
++
++    public static HandlerList getHandlerList() {
++        return handlers;
++    }
++}
+-- 
+1.9.0
+

--- a/CraftBukkit/0098-Fix-combustion-events.patch
+++ b/CraftBukkit/0098-Fix-combustion-events.patch
@@ -1,0 +1,148 @@
+From 02b44262876f9ad68ead37c9e84e4d129db39f3d Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Thu, 30 Oct 2014 00:40:07 -0400
+Subject: [PATCH] Fix combustion events
+
+
+diff --git a/src/main/java/net/minecraft/server/DispenseBehaviorFireball.java b/src/main/java/net/minecraft/server/DispenseBehaviorFireball.java
+index 11fbd73..62a666f 100644
+--- a/src/main/java/net/minecraft/server/DispenseBehaviorFireball.java
++++ b/src/main/java/net/minecraft/server/DispenseBehaviorFireball.java
+@@ -28,6 +28,7 @@ final class DispenseBehaviorFireball extends DispenseBehaviorItem {
+         org.bukkit.block.Block block = world.getWorld().getBlockAt(isourceblock.getBlockX(), isourceblock.getBlockY(), isourceblock.getBlockZ());
+         CraftItemStack craftItem = CraftItemStack.asCraftMirror(itemstack1);
+         EntitySmallFireball entitysmallfireball = new EntitySmallFireball(world, d0, d1, d2, d3, d4, d5);
++        entitysmallfireball.projectileSource = new org.bukkit.craftbukkit.projectiles.CraftBlockProjectileSource((TileEntityDispenser) isourceblock.getTileEntity());
+ 
+         BlockDispenseEntityEvent event = new BlockDispenseEntityEvent(block, craftItem.clone(), new org.bukkit.util.Vector(d3, d4, d5), entitysmallfireball.getBukkitEntity());
+         if (!BlockDispenser.eventFired) {
+@@ -50,7 +51,6 @@ final class DispenseBehaviorFireball extends DispenseBehaviorItem {
+             }
+         }
+ 
+-        entitysmallfireball.projectileSource = new org.bukkit.craftbukkit.projectiles.CraftBlockProjectileSource((TileEntityDispenser) isourceblock.getTileEntity());
+         entitysmallfireball.setDirection(event.getVelocity().getX(), event.getVelocity().getY(), event.getVelocity().getZ());
+ 
+         world.addEntity(entitysmallfireball);
+diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
+index 183c0d6..a122b23 100644
+--- a/src/main/java/net/minecraft/server/Entity.java
++++ b/src/main/java/net/minecraft/server/Entity.java
+@@ -15,6 +15,8 @@ import org.bukkit.entity.Hanging;
+ import org.bukkit.entity.LivingEntity;
+ import org.bukkit.entity.Painting;
+ import org.bukkit.entity.Vehicle;
++import org.bukkit.event.entity.EntityExtinguishEvent;
++import org.bukkit.event.entity.EntityCombustByBlockEvent;
+ import org.bukkit.event.entity.EntityCombustByEntityEvent;
+ import org.bukkit.event.entity.EntityDespawnInVoidEvent;
+ import org.bukkit.event.hanging.HangingBreakByEntityEvent;
+@@ -90,6 +92,7 @@ public abstract class Entity {
+     public int ticksLived;
+     public int maxFireTicks;
+     public int fireTicks; // CraftBukkit - private -> public
++    public boolean wasOnFire; // CraftBukkit - to detect when the fire goes out
+     protected boolean inWater;
+     public int noDamageTicks;
+     private boolean justCreated;
+@@ -355,8 +358,8 @@ public abstract class Entity {
+             if (this instanceof EntityLiving) {
+                 if (this.fireTicks <= 0) {
+                     // not on fire yet
+-                    // TODO: shouldn't be sending null for the block.
+-                    org.bukkit.block.Block damager = null; // ((WorldServer) this.l).getWorld().getBlockAt(i, j, k);
++                    Vec3D lavaPos = this.world.getLargestBlockIntersection(this.boundingBox.shrink(0.001D, 0.001D, 0.001D), Material.LAVA);
++                    org.bukkit.block.Block damager = this.world.getWorld().getBlockAt((int) lavaPos.a, (int) lavaPos.b, (int) lavaPos.c);
+                     org.bukkit.entity.Entity damagee = this.getBukkitEntity();
+                     EntityCombustEvent combustEvent = new org.bukkit.event.entity.EntityCombustByBlockEvent(damager, damagee, 15);
+                     this.world.getServer().getPluginManager().callEvent(combustEvent);
+@@ -700,13 +703,19 @@ public abstract class Entity {
+             // CraftBukkit end
+             boolean flag2 = this.L();
+ 
+-            if (this.world.e(this.boundingBox.shrink(0.001D, 0.001D, 0.001D))) {
++            // CraftBukkit start - get the location of the fire block
++            Vec3D firePos = this.world.getLargestBlockIntersection(this.boundingBox.shrink(0.001D, 0.001D, 0.001D), Material.FIRE);
++            if (firePos != null) {
++            // CraftBukkit end
+                 this.burn(1);
+                 if (!flag2) {
+                     ++this.fireTicks;
+                     // CraftBukkit start - Not on fire yet
+                     if (this.fireTicks <= 0) { // Only throw events on the first combust, otherwise it spams
+-                        EntityCombustEvent event = new EntityCombustEvent(this.getBukkitEntity(), 8);
++                        EntityCombustByBlockEvent event = new EntityCombustByBlockEvent(
++                            this.bukkitEntity.getWorld().getBlockAt((int) firePos.a, (int) firePos.b, (int) firePos.c),
++                            this.getBukkitEntity(), 8);
++
+                         this.world.getServer().getPluginManager().callEvent(event);
+ 
+                         if (!event.isCancelled()) {
+@@ -726,6 +735,15 @@ public abstract class Entity {
+                 this.fireTicks = -this.maxFireTicks;
+             }
+ 
++            // CraftBukkit start
++            if(this.fireTicks > 0) {
++                this.wasOnFire = true;
++            } else if(this.wasOnFire && this.fireTicks <= 0) {
++                this.wasOnFire = false;
++                this.world.getServer().getPluginManager().callEvent(new EntityExtinguishEvent(this.getBukkitEntity()));
++            }
++            // CraftBukkit end
++
+             this.world.methodProfiler.b();
+         }
+     }
+diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
+index c561053..bbdf888 100644
+--- a/src/main/java/net/minecraft/server/World.java
++++ b/src/main/java/net/minecraft/server/World.java
+@@ -1647,6 +1647,44 @@ public abstract class World implements IBlockAccess {
+         return false;
+     }
+ 
++    // CraftBukkit start
++    public Vec3D getLargestBlockIntersection(AxisAlignedBB aabb, Material material) {
++        int xMin = MathHelper.floor(aabb.a);
++        int xMax = MathHelper.floor(aabb.d + 1.0D);
++        int yMin = MathHelper.floor(aabb.b);
++        int yMax = MathHelper.floor(aabb.e + 1.0D);
++        int zMin = MathHelper.floor(aabb.c);
++        int zMax = MathHelper.floor(aabb.f + 1.0D);
++
++        double maxVolume = 0;
++        Vec3D block = null;
++
++        for (int x = xMin; x < xMax; ++x) {
++            for (int y = yMin; y < yMax; ++y) {
++                for (int z = zMin; z < zMax; ++z) {
++                    Block type = this.getType(x, y, z);
++                    if (material == type.getMaterial()) {
++                        AxisAlignedBB i = new AxisAlignedBB(x, x+1, y, y+1, z, z+1).a(aabb);
++                        double volume = (i.d - i.a) * (i.e - i.b) * (i.f - i.c);
++                        if(volume > maxVolume) {
++                            maxVolume = volume;
++                            if(block == null) {
++                                block = new Vec3D(x, y, z);
++                            } else {
++                                block.a = x;
++                                block.b = y;
++                                block.c = z;
++                            }
++                        }
++                    }
++                }
++            }
++        }
++
++        return block;
++    }
++    // CraftBukkit end
++
+     public boolean b(AxisAlignedBB axisalignedbb, Material material) {
+         int i = MathHelper.floor(axisalignedbb.a);
+         int j = MathHelper.floor(axisalignedbb.d + 1.0D);
+-- 
+1.9.0
+


### PR DESCRIPTION
- Actually set the block in `EntityCombustByBlockEvent` instead of it always being `null`
- Call `EntityCombustByBlockEvent` for fire blocks, instead of `EntityCombustEvent`
- Add `EntityExtinguishEvent`
