### PR TITLE
Fix leash interaction bugs

### DIFF
--- a/CraftBukkit/0102-Fix-leash-interaction-bugs.patch
+++ b/CraftBukkit/0102-Fix-leash-interaction-bugs.patch
@@ -1,29 +1,32 @@
-From c837e185635228db524d837ceb0d45383e0d0d6f Mon Sep 17 00:00:00 2001
+From dd71fdd4c4a85c81f0805bc19962cdb9e5013336 Mon Sep 17 00:00:00 2001
 From: ShinyDialga45 <shinydialga45@gmail.com>
-Date: Sun, 30 Nov 2014 10:53:44 -0600
+Date: Tue, 2 Dec 2014 21:25:10 -0600
 Subject: [PATCH] Fix leash interaction bugs
 
 
 diff --git a/src/main/java/net/minecraft/server/PlayerInteractManager.java b/src/main/java/net/minecraft/server/PlayerInteractManager.java
-index 325b87e..261b69c 100644
+index 325b87e..b0bd5ed 100644
 --- a/src/main/java/net/minecraft/server/PlayerInteractManager.java
 +++ b/src/main/java/net/minecraft/server/PlayerInteractManager.java
-@@ -397,6 +397,19 @@ public class PlayerInteractManager {
+@@ -397,6 +397,22 @@ public class PlayerInteractManager {
                  result = (event.useItemInHand() != Event.Result.ALLOW);
              } else if (!entityhuman.isSneaking() || itemstack == null) {
                  result = block.interact(world, i, j, k, entityhuman, l, f, f1, f2);
-+                ItemStack heldItem = entityhuman.be();
-+                //Checks if the player has a leash attached, if not it checks if they clicked a fence and their item is banned to prevent a glitch.
-+                if (heldItem != null && heldItem.getItem() == Items.LEASH && this.world.isStatic) {
-+                    result = false;
-+                } else if (block == Blocks.FENCE || block == Blocks.NETHER_FENCE) {
-+                    Item[] bannedItems = {Items.BOW, Items.WOOD_SWORD, Items.GOLD_SWORD, Items.STONE_SWORD,
-+                            Items.IRON_SWORD, Items.DIAMOND_SWORD};
-+                    for (Item item : bannedItems) {
-+                        if (itemstack != null && itemstack.getItem() == item) {
++                //Checks if the player has a leash attached, if not it sees if they are holding an item that will cause a visual glitch.
++                try {
++                    Item heldItem = entityhuman.be().getItem();
++                    if (heldItem == Items.LEASH && this.world.isStatic) {
++                        result = false;
++                    } else if (block == Blocks.FENCE || block == Blocks.NETHER_FENCE) {
++                        if (heldItem instanceof ItemFood
++                                || heldItem instanceof ItemSeedFood
++                                || heldItem instanceof ItemSword
++                                || heldItem instanceof ItemBow) {
 +                            return result;
 +                        }
 +                    }
++                } catch (NullPointerException e) {
++                    //If heldItem is the player's arm or null, continue on.
 +                }
              }
  

--- a/CraftBukkit/0102-Fix-leash-interaction-bugs.patch
+++ b/CraftBukkit/0102-Fix-leash-interaction-bugs.patch
@@ -1,0 +1,33 @@
+From c837e185635228db524d837ceb0d45383e0d0d6f Mon Sep 17 00:00:00 2001
+From: ShinyDialga45 <shinydialga45@gmail.com>
+Date: Sun, 30 Nov 2014 10:53:44 -0600
+Subject: [PATCH] Fix leash interaction bugs
+
+
+diff --git a/src/main/java/net/minecraft/server/PlayerInteractManager.java b/src/main/java/net/minecraft/server/PlayerInteractManager.java
+index 325b87e..261b69c 100644
+--- a/src/main/java/net/minecraft/server/PlayerInteractManager.java
++++ b/src/main/java/net/minecraft/server/PlayerInteractManager.java
+@@ -397,6 +397,19 @@ public class PlayerInteractManager {
+                 result = (event.useItemInHand() != Event.Result.ALLOW);
+             } else if (!entityhuman.isSneaking() || itemstack == null) {
+                 result = block.interact(world, i, j, k, entityhuman, l, f, f1, f2);
++                ItemStack heldItem = entityhuman.be();
++                //Checks if the player has a leash attached, if not it checks if they clicked a fence and their item is banned to prevent a glitch.
++                if (heldItem != null && heldItem.getItem() == Items.LEASH && this.world.isStatic) {
++                    result = false;
++                } else if (block == Blocks.FENCE || block == Blocks.NETHER_FENCE) {
++                    Item[] bannedItems = {Items.BOW, Items.WOOD_SWORD, Items.GOLD_SWORD, Items.STONE_SWORD,
++                            Items.IRON_SWORD, Items.DIAMOND_SWORD};
++                    for (Item item : bannedItems) {
++                        if (itemstack != null && itemstack.getItem() == item) {
++                            return result;
++                        }
++                    }
++                }
+             }
+ 
+             if (itemstack != null && !result) {
+-- 
+1.9.4.msysgit.2
+


### PR DESCRIPTION
Currently, there is a bug where if you right click a fence with a certain item it glitches. This due to the fact leashes allow the player to interact with fences, even though they don't need to hold a leash. This patch fixes it by checking their held item, and if it is one that causes a glitch, then end it there instead of going on to start the glitch. It also checks if the player has a leash attached to them to make sure that it won't cancel the leash being attached when they interact a fence. I had good results after testing this several times on my local, but feel free to test it out to find any potential bugs that could arise from this. While testing, I attempted to re-create 1.7.10 behavior, and it seems to be functioning properly so far. Thanks.