### PR TITLE
Threadsafe metadata

### DIFF
--- a/CraftBukkit/0099-Don-t-share-mutable-metadata-across-threads.patch
+++ b/CraftBukkit/0099-Don-t-share-mutable-metadata-across-threads.patch
@@ -1,0 +1,107 @@
+From 08a1de71893401e70974afb96158bbba31c0d505 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Fri, 20 Mar 2015 01:21:22 -0400
+Subject: [PATCH] Don't share mutable metadata across threads
+
+
+diff --git a/src/main/java/net/minecraft/server/DataWatcher.java b/src/main/java/net/minecraft/server/DataWatcher.java
+index 20d4d64..7e3b740 100644
+--- a/src/main/java/net/minecraft/server/DataWatcher.java
++++ b/src/main/java/net/minecraft/server/DataWatcher.java
+@@ -196,6 +196,22 @@ public class DataWatcher {
+         return arraylist;
+     }
+ 
++    // SportBukkit start - Make deep copies of the WatchableObjects so they are not shared across threads
++    public static void deepCopy(List<WatchableObject> watchableObjects) {
++        for(int j = 0; j < watchableObjects.size(); j++) {
++            WatchableObject original = watchableObjects.get(j);
++            Object obj = original.b();
++            if(obj instanceof ItemStack) {
++                // All the watchable types are immutable except ItemStack, which we have to clone
++                obj = ((ItemStack) obj).cloneItemStack();
++            }
++            WatchableObject copy = new WatchableObject(original.c(), original.a(), obj);
++            copy.a(original.d());
++            watchableObjects.set(j, copy);
++        }
++    }
++    // SportBukkit end
++
+     private static void a(PacketDataSerializer packetdataserializer, WatchableObject watchableobject) {
+         int i = (watchableobject.c() << 5 | watchableobject.a() & 31) & 255;
+ 
+diff --git a/src/main/java/net/minecraft/server/PacketPlayOutEntityMetadata.java b/src/main/java/net/minecraft/server/PacketPlayOutEntityMetadata.java
+index d48d5c9..4cc166b 100644
+--- a/src/main/java/net/minecraft/server/PacketPlayOutEntityMetadata.java
++++ b/src/main/java/net/minecraft/server/PacketPlayOutEntityMetadata.java
+@@ -18,7 +18,7 @@ public class PacketPlayOutEntityMetadata implements Packet {
+         } else {
+             this.b = datawatcher.b();
+         }
+-
++        DataWatcher.deepCopy(this.b); // SportBukkit - send unshared copy of metadata
+     }
+ 
+     public void a(PacketDataSerializer packetdataserializer) {
+diff --git a/src/main/java/net/minecraft/server/PacketPlayOutNamedEntitySpawn.java b/src/main/java/net/minecraft/server/PacketPlayOutNamedEntitySpawn.java
+index 910d518..3e6355b 100644
+--- a/src/main/java/net/minecraft/server/PacketPlayOutNamedEntitySpawn.java
++++ b/src/main/java/net/minecraft/server/PacketPlayOutNamedEntitySpawn.java
+@@ -32,6 +32,11 @@ public class PacketPlayOutNamedEntitySpawn implements Packet {
+ 
+         this.h = itemstack == null ? 0 : Item.getId(itemstack.getItem());
+         this.i = entityhuman.getDataWatcher();
++
++        // SportBukkit start - send unshared copy of metadata
++        this.j = this.i.c();
++        DataWatcher.deepCopy(this.j);
++        // SportBukkit end
+     }
+ 
+     public void a(PacketDataSerializer packetdataserializer) {
+@@ -55,7 +60,11 @@ public class PacketPlayOutNamedEntitySpawn implements Packet {
+         packetdataserializer.writeByte(this.f);
+         packetdataserializer.writeByte(this.g);
+         packetdataserializer.writeShort(this.h);
+-        this.i.a(packetdataserializer);
++
++        // SportBukkit start - send unshared copy of metadata
++        // this.i.a(packetdataserializer);
++        DataWatcher.a(this.j, packetdataserializer);
++        // SportBukkit end
+     }
+ 
+     public void a(PacketListenerPlayOut packetlistenerplayout) {
+diff --git a/src/main/java/net/minecraft/server/PacketPlayOutSpawnEntityLiving.java b/src/main/java/net/minecraft/server/PacketPlayOutSpawnEntityLiving.java
+index 80815f9..a037487 100644
+--- a/src/main/java/net/minecraft/server/PacketPlayOutSpawnEntityLiving.java
++++ b/src/main/java/net/minecraft/server/PacketPlayOutSpawnEntityLiving.java
+@@ -63,6 +63,11 @@ public class PacketPlayOutSpawnEntityLiving implements Packet {
+         this.g = (int) (d2 * 8000.0D);
+         this.h = (int) (d3 * 8000.0D);
+         this.l = entityliving.getDataWatcher();
++
++        // SportBukkit start - send unshared copy of metadata
++        this.m = this.l.c();
++        DataWatcher.deepCopy(this.m);
++        // SportBukkit end
+     }
+ 
+     public void a(PacketDataSerializer packetdataserializer) throws java.io.IOException { // CraftBukkit - throws
+@@ -92,7 +97,11 @@ public class PacketPlayOutSpawnEntityLiving implements Packet {
+         packetdataserializer.writeShort(this.f);
+         packetdataserializer.writeShort(this.g);
+         packetdataserializer.writeShort(this.h);
+-        this.l.a(packetdataserializer);
++
++        // SportBukkit start - send unshared copy of metadata
++        // this.l.a(packetdataserializer);
++        DataWatcher.a(this.m, packetdataserializer);
++        // SportBukkit end
+     }
+ 
+     public void a(PacketListenerPlayOut packetlistenerplayout) {
+-- 
+1.9.0
+


### PR DESCRIPTION
As far as I can tell, the way the vanilla server serializes entity metadata is not threadsafe at all. `WatchableObject`s are stored in the packet, and because they are mutable, can change value before or during serialization. `DataWatcher` uses a lock to synchronize access to the container that holds the `WatchableObject`s, but the `WO`s themselves have no synchronization.

Also, one of the types that `WO` can wrap is `ItemStack` which can also be mutated while the IO thread is serializing it. We have seen a `ConcurrentModificationException` on our servers that seems to be a symptom of this.

This patch clones all `WatchableObject`s when the packets containing them are created, as well as any `ItemStack`s they contain. This should ensure that what is serialized is always a snapshot of the metadata when the packet was instantiated on the main thread.