### PR TITLE
Send absolute position the first time an entity is seen

### DIFF
--- a/CraftBukkit/0100-Send-absolute-position-the-first-time-an-entity-is-s.patch
+++ b/CraftBukkit/0100-Send-absolute-position-the-first-time-an-entity-is-s.patch
@@ -1,0 +1,88 @@
+From 99cf66cf1f6ff5c88f6d9aee20243e5bcea6f87c Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Fri, 3 Apr 2015 17:26:21 -0400
+Subject: [PATCH] Send absolute position the first time an entity is seen
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityTrackerEntry.java b/src/main/java/net/minecraft/server/EntityTrackerEntry.java
+index a351982..f1ce408 100644
+--- a/src/main/java/net/minecraft/server/EntityTrackerEntry.java
++++ b/src/main/java/net/minecraft/server/EntityTrackerEntry.java
+@@ -40,6 +40,7 @@ public class EntityTrackerEntry {
+     private boolean y;
+     public boolean n;
+     public Set trackedPlayers = Sets.newHashSet();
++    public Set<EntityPlayer> freshViewers = Sets.newHashSet(); // SportBukkit
+ 
+     public EntityTrackerEntry(Entity entity, int i, int j, boolean flag) {
+         this.tracker = entity;
+@@ -121,20 +122,20 @@ public class EntityTrackerEntry {
+                 boolean flag = Math.abs(j1) >= 4 || Math.abs(k1) >= 4 || Math.abs(l1) >= 4 || this.m % 60 == 0;
+                 boolean flag1 = Math.abs(l - this.yRot) >= 4 || Math.abs(i1 - this.xRot) >= 4;
+                 
+-                // CraftBukkit start - Code moved from below
+-                if (flag) {
+-                    this.xLoc = i;
+-                    this.yLoc = j;
+-                    this.zLoc = k;
+-                }
++                if (this.m > 0 || this.tracker instanceof EntityArrow) {
++                    // CraftBukkit start - Code moved from below
++                    if (flag) {
++                        this.xLoc = i;
++                        this.yLoc = j;
++                        this.zLoc = k;
++                    }
+ 
+-                if (flag1) {
+-                    this.yRot = l;
+-                    this.xRot = i1;
+-                }
+-                // CraftBukkit end
++                    if (flag1) {
++                        this.yRot = l;
++                        this.xRot = i1;
++                    }
++                    // CraftBukkit end
+ 
+-                if (this.m > 0 || this.tracker instanceof EntityArrow) {
+                     if (j1 >= -128 && j1 < 128 && k1 >= -128 && k1 < 128 && l1 >= -128 && l1 < 128 && this.v <= 400 && !this.x && this.y == this.tracker.onGround) {
+                         if (flag && flag1) {
+                             object = new PacketPlayOutRelEntityMoveLook(this.tracker.getId(), (byte) j1, (byte) k1, (byte) l1, (byte) l, (byte) i1, this.tracker.onGround);
+@@ -171,7 +172,24 @@ public class EntityTrackerEntry {
+                 }
+ 
+                 if (object != null) {
+-                    this.broadcast((Packet) object);
++                    // SportBukkit start - ensure fresh viewers get an absolute position on their first update,
++                    // since we can't be certain what position they received in the spawn packet.
++                    if(object instanceof PacketPlayOutEntityTeleport) {
++                        this.broadcast((Packet) object);
++                    } else {
++                        PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(this.tracker.getId(), i, j, k, (byte) l, (byte) i1, this.tracker.onGround);
++
++                        for(EntityPlayer viewer : (Set<EntityPlayer>) this.trackedPlayers) {
++                            if(this.freshViewers.contains(viewer)) {
++                                viewer.playerConnection.sendPacket(teleportPacket);
++                            } else {
++                                viewer.playerConnection.sendPacket((Packet) object);
++                            }
++                        }
++                    }
++
++                    this.freshViewers.clear();
++                    // SportBukkit end
+                 }
+ 
+                 this.b();
+@@ -310,6 +328,7 @@ public class EntityTrackerEntry {
+                     }
+ 
+                     // entityplayer.removeQueue.remove(Integer.valueOf(this.tracker.getId())); CraftBukkit - remove destroy queue
++                    this.freshViewers.add(entityplayer); // SportBukkit
+                     // CraftBukkit end
+                     this.trackedPlayers.add(entityplayer);
+                     Packet packet = this.c();
+-- 
+1.9.0
+


### PR DESCRIPTION
Ensure that the first movement packet a player receives for an entity that has just become visible has an absolute position. This fixes entities being offset/invisible after spawning/teleporting.