### PR TITLE
Tweaked a bit shell scripts

### DIFF
--- a/apply-cb-patches.sh
+++ b/apply-cb-patches.sh
@@ -14,7 +14,7 @@ if [ ! -d work/CraftBukkit ]; then
     git clone base/CraftBukkit work/CraftBukkit
 fi
 
-pushd work/CraftBukkit
+pushd work/CraftBukkit >/dev/null
 git checkout upstream
 git reset --hard origin/upstream
 
@@ -23,8 +23,8 @@ log_info "Applying CraftBukkit patches"
 
 log_info "Committing branch"
 git add src/main/java/net/minecraft/server/*
-git commit -m "CraftBukkit \$$(date +%s)"
+git commit -m "CraftBukkit \$ $(date +%s)"
 
-popd
+popd >/dev/null
 log_info "Done. Now you should run ./apply-sb-patches.sh to proceed."
 

--- a/apply-sb-patches.sh
+++ b/apply-sb-patches.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
-ORIG_PWD="$(pwd)"
-cd "$(dirname "$0")"
-
+pushd "$(dirname "$0")" >/dev/null
 . util.sh
 
 function requireCleanWorkTree {
@@ -13,7 +11,7 @@ function requireCleanWorkTree {
     # Disallow unstaged changes in the working tree
     if ! git diff-files --quiet --ignore-submodules --
     then
-        echo >&2 "cannot apply patches to $1: you have unstaged changes."
+        log_error "cannot apply patches to $1: you have unstaged changes."
         git diff-files --name-status -r --ignore-submodules -- >&2
         err=1
     fi
@@ -21,14 +19,14 @@ function requireCleanWorkTree {
     # Disallow uncommitted changes in the index
     if ! git diff-index --cached --quiet HEAD --ignore-submodules --
     then
-        echo >&2 "cannot apply patches to $1: your index contains uncommitted changes."
+        log_error "cannot apply patches to $1: your index contains uncommitted changes."
         git diff-index --cached --name-status -r --ignore-submodules HEAD -- >&2
         err=1
     fi
 
     if [ $err = 1 ]
     then
-        echo >&2 "Please commit or stash them."
+        log_error "Please commit or stash them."
         exit 1
     fi
 }
@@ -39,34 +37,35 @@ function applyPatches {
     target=build/$2
     patches=$2
 
-    pushd $what
+    pushd $what >/dev/null
     git branch -f upstream >/dev/null
-    popd
+    popd >/dev/null
     if [ ! -d $target ]; then
         git clone $what $target
     fi
 
-    cd $target
+    pushd $target >/dev/null
 
     requireCleanWorkTree $target
 
-    echo "  Resetting $target to $what..."
+    log_info "Resetting $target to $what..."
     git remote rm upstream 2>/dev/null 2>&1
     git remote add upstream ../../$what >/dev/null 2>&1
     git fetch upstream >/dev/null 2>&1
     git reset --hard upstream/upstream
 
-    echo "  Applying patches to $target..."
+    log_info "Applying patches to $target..."
     git am --abort
 
     if !(git am --3way ../../$patches/*.patch); then
-        echo "  Something did not apply cleanly to $target."
-        echo "  Please review above details and finish the apply then"
-        echo "  save the changes with rebuildPatches.sh"
-        cd "$ORIG_PWD"
+        log_error "Something did not apply cleanly to $target."
+        log_error "Please review above details and finish the apply then"
+        log_error "save the changes with rebuildPatches.sh"
+        popd >/dev/null
+        popd >/dev/null
         exit 1
     else
-        echo "  Patches applied cleanly to $target"
+        log_info "  Patches applied cleanly to $target"
     fi
 
     cd ../..
@@ -77,6 +76,6 @@ log_info "Applying SportBukkit patches"
 applyPatches base Bukkit
 applyPatches work CraftBukkit
 
+popd >/dev/null
 log_info "Done. Now you should run ./compile.sh to proceed."
 
-cd "$ORIG_PWD"

--- a/clean.sh
+++ b/clean.sh
@@ -1,19 +1,31 @@
 #!/bin/bash
 
+. util.sh
+
 function clean {
-    if [ -d $1 ]; then
-        rm -rf $1
-        if [ -d $1 ]; then
-            echo "Unable to remove $1 directory"
+    if [ -d "$1" ]; then
+        log_info "Removing directory $1"
+        if ! rm -rf "$1"; then
+            log_error "Unable to remove $1 directory"
+            return 1
         fi
     fi
+    return 0
 }
 
-pushd "$(dirname "$0")"
+log_info "Cleaning work directories"
+pushd "$(dirname "$0")" >/dev/null
 
 clean temp
-clean cache
-clean build
-clean work
+FAILED=$?
 
-popd
+clean build
+FAILED=$(($FAILED+$?))
+
+clean work
+FAILED=$(($FAILED+$?))
+
+popd >/dev/null
+log_info "Done"
+exit $FAILED
+

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,26 +1,27 @@
 #!/bin/bash
 
-ORIG_PWD="$(pwd)"
-cd "$(dirname "$0")"
+pushd "$(dirname "$0")" >/dev/null
+. util.sh
 
 function deploy {
     target=build/$1
 
-    echo "  $1 deploying..."
-    cd $target
+    log_info "$1 deploying..."
+    pushd $target >/dev/null
 
     if !(MAVEN_OPTS="$MAVEN_OPTS -Xmx1G" mvn deploy); then
-        echo "  $1 failed to deploy"
-        cd "$ORIG_PWD"
+        log_error "$1 failed to deploy"
+        popd >/dev/null
+        popd >/dev/null
         exit 1
     else
-        echo "  $1 deployed"
+        log_info "$1 deployed"
     fi
 
-    cd ../..
+    popd >/dev/null
 }
 
 deploy Bukkit
 deploy CraftBukkit
 
-cd "$ORIG_PWD"
+popd >/dev/null

--- a/init.sh
+++ b/init.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-pushd "$(dirname "$0")"
-
+pushd "$(dirname "$0")" >/dev/null
 . util.sh
 
 log_info "Preparing folder layout"
@@ -18,12 +17,13 @@ git init
 git submodule update --init
 
 log_info "Resetting upstream repositories"
-pushd base/Bukkit
+pushd base/Bukkit >/dev/null
 git branch -f upstream
-popd
-pushd base/CraftBukkit
+popd >/dev/null
+pushd base/CraftBukkit >/dev/null
 git branch -f upstream
-popd
+popd >/dev/null
 
+popd >/dev/null
 log_info "Done. Now you should run ./remap-nms.sh to proceed."
-popd
+

--- a/util.sh
+++ b/util.sh
@@ -24,11 +24,11 @@ log_info() {
 }
 
 log_warning() {
-	echo -e "\033[33m!!!\033[0m $1"
+	echo -e "\033[33m!!!\033[0m $1" >&2
 }
 
 log_error() {
-	echo -e "\033[31m###\033[0m $1"
+	echo -e "\033[31m###\033[0m $1" >&2
 }
 
 if hash md5sum 2> /dev/null; then
@@ -58,7 +58,11 @@ downloadfile() {
 	fi
 
 	log_info "Downloading ${FILE}"
-	curl -o "${FILE}" "${URL}"
+	if which curl; then
+		curl -o "${FILE}" "${URL}"
+	else
+		wget -O "${FILE}" "${URL}"
+	fi
 
 	CALCMD5=$(filemd5 "${FILE}")
 	if [ $CALCMD5 == $NMS_MD5 ]; then


### PR DESCRIPTION
This PR makes pushd and popd silent, uses log_* everywhere for improved visibility of errors, and uses wget if curl is not available.

Also I made clean.sh so that it returns the number of failed directory removals (so it's possible to chain commands like "./clean.sh && ./build.sh" so the second does not execute if the first fails)

I also removed cache directory from clean.sh. Cache is used solely for 1:1 copies of binaries from CDN. These files are never modified, and its MD5 is checked so corrupted files or modified are automatically removed and redownloaded when needed. Therefore there's no need to wait or waste bandwidth redownloading them once fetched.