### PR TITLE
Support reverted potions

### DIFF
--- a/Bukkit/0040-Support-reverted-potions.patch
+++ b/Bukkit/0040-Support-reverted-potions.patch
@@ -1,0 +1,229 @@
+From bcd3f9ab6b3f5f7ecdb505deea19c78e9625dbc9 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Sat, 16 May 2015 22:58:26 -0400
+Subject: [PATCH] Support reverted potions
+
+
+diff --git a/src/main/java/org/bukkit/potion/Potion.java b/src/main/java/org/bukkit/potion/Potion.java
+index edc9175..8a3bce9 100644
+--- a/src/main/java/org/bukkit/potion/Potion.java
++++ b/src/main/java/org/bukkit/potion/Potion.java
+@@ -15,6 +15,7 @@ import com.google.common.collect.ImmutableList;
+ public class Potion {
+     private boolean extended = false;
+     private boolean splash = false;
++    private boolean reverted = false;
+     private int level = 1;
+     private int name = -1;
+     private PotionType type;
+@@ -154,6 +155,16 @@ public class Potion {
+     }
+ 
+     /**
++     * Chain this to the constructor to revert the potion.
++     *
++     * @return The potion.
++     */
++    public Potion revert() {
++        setReverted(true);
++        return this;
++    }
++
++    /**
+      * Applies the effects of this potion to the given {@link ItemStack}. The
+      * ItemStack must be a potion.
+      *
+@@ -186,7 +197,7 @@ public class Potion {
+             return false;
+         }
+         Potion other = (Potion) obj;
+-        return extended == other.extended && splash == other.splash && level == other.level && type == other.type;
++        return extended == other.extended && splash == other.splash && reverted == other.reverted && level == other.level && type == other.type;
+     }
+ 
+     /**
+@@ -245,6 +256,7 @@ public class Potion {
+         int result = prime + level;
+         result = prime * result + (extended ? 1231 : 1237);
+         result = prime * result + (splash ? 1231 : 1237);
++        result = prime * result + (reverted ? 1231 : 1237);
+         result = prime * result + ((type == null) ? 0 : type.hashCode());
+         return result;
+     }
+@@ -259,6 +271,17 @@ public class Potion {
+     }
+ 
+     /**
++     * Returns whether this potion is reverted, which is what happens to
++     * tier 2 instant potions when they are brewed with redstone, or to
++     * extended non-tiered potions when they are brewed with glowstone.
++     * Potions obtained from the creative mode inventory are reverted,
++     * when they can be.
++     */
++    public boolean isReverted() {
++        return reverted;
++    }
++
++    /**
+      * Set whether this potion has extended duration. This will cause the
+      * potion to have roughly 8/3 more duration than a regular potion.
+      *
+@@ -280,6 +303,15 @@ public class Potion {
+     }
+ 
+     /**
++     * Sets whether this potion is reverted. See {@link #isReverted} for an explanation.
++     *
++     * @param isReverted Whether this potion is reverted
++     */
++    public void setReverted(boolean isReverted) {
++        reverted = isReverted;
++    }
++
++    /**
+      * Sets the {@link Tier} of this potion.
+      *
+      * @param tier The new tier of this potion
+@@ -328,14 +360,16 @@ public class Potion {
+             // Without this, mundanePotion.toDamageValue() would return 0
+             damage = (short) (name == 0 ? 8192 : name);
+         } else {
+-            damage = (short) (level - 1);
+-            damage <<= TIER_SHIFT;
+-            damage |= (short) type.getDamageValue();
++            damage = (short) type.getDamageValue();
++        }
++        if(level > 1 || (type != null && !type.isTiered() && reverted)) {
++            // Levels above 2 are lost
++            damage |= TIER_BIT;
+         }
+         if (splash) {
+             damage |= SPLASH_BIT;
+         }
+-        if (extended) {
++        if (extended || (type != null && type.isInstant() && reverted)) {
+             damage |= EXTENDED_BIT;
+         }
+         return damage;
+@@ -382,7 +416,6 @@ public class Potion {
+     private static final int POTION_BIT = 0xF;
+     private static final int SPLASH_BIT = 0x4000;
+     private static final int TIER_BIT = 0x20;
+-    private static final int TIER_SHIFT = 5;
+     private static final int NAME_BIT = 0x3F;
+ 
+     /**
+@@ -398,15 +431,24 @@ public class Potion {
+         if (type == null || type == PotionType.WATER) {
+             potion = new Potion(damage & NAME_BIT);
+         } else {
+-            int level = (damage & TIER_BIT) >> TIER_SHIFT;
+-            level++;
+-            potion = new Potion(type, level);
++            potion = new Potion(type);
++        }
++        if((damage & TIER_BIT) > 0) {
++            if(potion.getType().isTiered()) {
++                potion.setLevel(2);
++            } else {
++                potion.setReverted(true);
++            }
+         }
+         if ((damage & SPLASH_BIT) > 0) {
+             potion = potion.splash();
+         }
+         if ((damage & EXTENDED_BIT) > 0) {
+-            potion = potion.extend();
++            if(potion.getType().isInstant()) {
++                potion = potion.revert();
++            } else {
++                potion = potion.extend();
++            }
+         }
+         return potion;
+     }
+diff --git a/src/main/java/org/bukkit/potion/PotionType.java b/src/main/java/org/bukkit/potion/PotionType.java
+index 6ad9a91..8beaf4a 100644
+--- a/src/main/java/org/bukkit/potion/PotionType.java
++++ b/src/main/java/org/bukkit/potion/PotionType.java
+@@ -44,6 +44,10 @@ public enum PotionType {
+         return maxLevel;
+     }
+ 
++    public boolean isTiered() {
++        return maxLevel > 1;
++    }
++
+     public boolean isInstant() {
+         return effect == null ? true : effect.isInstant();
+     }
+diff --git a/src/test/java/org/bukkit/potion/PotionTest.java b/src/test/java/org/bukkit/potion/PotionTest.java
+index 58252ae..3d45255 100644
+--- a/src/test/java/org/bukkit/potion/PotionTest.java
++++ b/src/test/java/org/bukkit/potion/PotionTest.java
+@@ -9,8 +9,30 @@ import org.bukkit.inventory.ItemStack;
+ import org.junit.Test;
+ 
+ public class PotionTest {
++    private void registerPoisonEffect() {
++        if(PotionEffectType.getById(19) == null) {
++            PotionEffectType.registerPotionEffectType(new PotionEffectType(19) {
++                @Override
++                public double getDurationModifier() {
++                    return 1;
++                }
++
++                @Override
++                public String getName() {
++                    return "Poison";
++                }
++
++                @Override
++                public boolean isInstant() {
++                    return false;
++                }
++            });
++        }
++    }
++
+     @Test
+     public void applyToItemStack() {
++        registerPoisonEffect();
+         Potion potion = new Potion(PotionType.POISON);
+         ItemStack stack = new ItemStack(Material.POTION, 1);
+         potion.apply(stack);
+@@ -35,6 +57,7 @@ public class PotionTest {
+ 
+     @Test
+     public void ItemStackConversion() {
++        registerPoisonEffect();
+         Potion potion = new Potion(PotionType.POISON);
+         ItemStack itemstack = potion.toItemStack(1);
+         assertThat(itemstack.getType(), is(Material.POTION));
+@@ -44,22 +67,7 @@ public class PotionTest {
+ 
+     @Test
+     public void setExtended() {
+-        PotionEffectType.registerPotionEffectType(new PotionEffectType(19){
+-            @Override
+-            public double getDurationModifier() {
+-                return 1;
+-            }
+-
+-            @Override
+-            public String getName() {
+-                return "Poison";
+-            }
+-
+-            @Override
+-            public boolean isInstant() {
+-                return false;
+-            }
+-        });
++        registerPoisonEffect();
+         Potion potion = new Potion(PotionType.POISON);
+         assertFalse(potion.hasExtendedDuration());
+         potion.setHasExtendedDuration(true);
+-- 
+1.9.0
+


### PR DESCRIPTION
Extend the Bukkit API to support "reverted" potion types (and fix "instant potion cannot be extended" exceptions)

http://minecraft.gamepedia.com/Potion#Data_values