### PR TITLE
Attribute API

### DIFF
--- a/Bukkit/0041-Support-unbreakable-items.patch
+++ b/Bukkit/0041-Support-unbreakable-items.patch
@@ -1,0 +1,24 @@
+From 15adb38c4ea9af8062f3918763432b014b9873e3 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Tue, 19 May 2015 01:40:20 -0400
+Subject: [PATCH] Support unbreakable items
+
+
+diff --git a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
+index 00f71ce..0c11df2 100644
+--- a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
++++ b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
+@@ -124,6 +124,10 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable {
+     */
+     boolean hasConflictingEnchant(Enchantment ench);
+ 
++    boolean isUnbreakable();
++
++    void setUnbreakable(boolean unbreakable);
++
+     @SuppressWarnings("javadoc")
+     ItemMeta clone();
+ }
+-- 
+1.9.0
+

--- a/Bukkit/0042-Attribute-API.patch
+++ b/Bukkit/0042-Attribute-API.patch
@@ -1,0 +1,408 @@
+From 9c8bcb32eeaa940d83799df96950e5d9d20df009 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Tue, 19 May 2015 06:30:47 -0400
+Subject: [PATCH] Attribute API
+
+
+diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
+index ecf29ce..2fc8e3f 100644
+--- a/src/main/java/org/bukkit/Bukkit.java
++++ b/src/main/java/org/bukkit/Bukkit.java
+@@ -13,6 +13,7 @@ import java.util.UUID;
+ import java.util.logging.Logger;
+ 
+ import org.bukkit.Warning.WarningState;
++import org.bukkit.attributes.AttributeFactory;
+ import org.bukkit.command.CommandException;
+ import org.bukkit.command.CommandMap;
+ import org.bukkit.command.CommandSender;
+@@ -1196,4 +1197,8 @@ public final class Bukkit {
+     public static void broadcast(net.md_5.bungee.api.chat.BaseComponent... components) {
+         server.broadcast(components);
+     }
++
++    public static AttributeFactory getAttributeFactory() {
++        return server.getAttributeFactory();
++    }
+ }
+diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
+index af2806b..20ed8f6 100644
+--- a/src/main/java/org/bukkit/Server.java
++++ b/src/main/java/org/bukkit/Server.java
+@@ -13,6 +13,7 @@ import java.util.UUID;
+ import java.util.logging.Logger;
+ 
+ import org.bukkit.Warning.WarningState;
++import org.bukkit.attributes.AttributeFactory;
+ import org.bukkit.command.CommandException;
+ import org.bukkit.command.CommandMap;
+ import org.bukkit.command.CommandSender;
+@@ -976,4 +977,9 @@ public interface Server extends PluginMessageRecipient {
+      * @param components the components to send
+      */
+     public void broadcast(net.md_5.bungee.api.chat.BaseComponent... components);
++
++    /**
++     * Get the {@link AttributeFactory} for this server
++     */
++    AttributeFactory getAttributeFactory();
+ }
+diff --git a/src/main/java/org/bukkit/attributes/Attribute.java b/src/main/java/org/bukkit/attributes/Attribute.java
+new file mode 100644
+index 0000000..3f83c46
+--- /dev/null
++++ b/src/main/java/org/bukkit/attributes/Attribute.java
+@@ -0,0 +1,37 @@
++package org.bukkit.attributes;
++
++/**
++ * An {@link Attribute} defines some effect on {@link org.bukkit.entity.LivingEntity}s
++ * that is controlled by a numeric parameter. Plugins can attach
++ * {@link AttributeModifier}s to entities to change this parameter. Modifiers can also
++ * be attached to {@link org.bukkit.inventory.ItemStack}s, which will then be applied
++ * to any entity "using" the item (which means different things, depending on the item).
++ *
++ * There are a few attributes built-in to the game, and these are available through the
++ * {@link AttributeFactory} returned by {@link org.bukkit.Server#getAttributeFactory}.
++ */
++public class Attribute {
++
++    private final String name;
++    private final double defaultValue;
++
++    public Attribute(String name, double defaultValue) {
++        this.name = name;
++        this.defaultValue = defaultValue;
++    }
++
++    /**
++     * This is used to identify the attribute for the purposes of attaching
++     * modifiers to entities and items. It should be globally unique.
++     */
++    public String getName() {
++        return name;
++    }
++
++    /**
++     * The initial base value of the attribute.
++     */
++    public double getDefault() {
++        return defaultValue;
++    }
++}
+diff --git a/src/main/java/org/bukkit/attributes/AttributeFactory.java b/src/main/java/org/bukkit/attributes/AttributeFactory.java
+new file mode 100644
+index 0000000..45b23c1
+--- /dev/null
++++ b/src/main/java/org/bukkit/attributes/AttributeFactory.java
+@@ -0,0 +1,30 @@
++package org.bukkit.attributes;
++
++import java.util.Map;
++import java.util.UUID;
++
++/**
++ * Provides access to built-in {@link Attribute}s and creation of {@link AttributeModifier}s.
++ */
++public interface AttributeFactory {
++
++    /**
++     * Return all known {@link Attribute}s with built-in implementations, mapped from their names.
++     */
++    Map<String, ? extends Attribute> knownAttributes();
++
++    /**
++     * Return the built-in {@link Attribute} with the given name, or null if no such attribute is known.
++     */
++    Attribute knownAttribute(String name);
++
++    /**
++     * Return a newly created {@link AttributeModifier}.
++     */
++    AttributeModifier newAttributeModifier(UUID id, String name, double value, AttributeModifier.Operation operation);
++
++    /**
++     * Return a newly created {@link AttributeModifier}, with an automatically generated UUID.
++     */
++    AttributeModifier newAttributeModifier(String name, double value, AttributeModifier.Operation operation);
++}
+diff --git a/src/main/java/org/bukkit/attributes/AttributeModifier.java b/src/main/java/org/bukkit/attributes/AttributeModifier.java
+new file mode 100644
+index 0000000..97eb157
+--- /dev/null
++++ b/src/main/java/org/bukkit/attributes/AttributeModifier.java
+@@ -0,0 +1,56 @@
++package org.bukkit.attributes;
++
++import java.util.UUID;
++
++/** <pre>
++ * A numerical transformation that can be applied to the values of {@link Attribute}s.
++ * Modifiers are identified by their UUID, and two modifiers with the same UUID will
++ * always be considered the same modifier, regardless of whether their other properties
++ * match.
++ *
++ * {@link AttributeModifier}s can be created through the {@link AttributeFactory},
++ * which is provided by {@link org.bukkit.Server#getAttributeFactory()}.
++ *
++ * An {@link AttributeModifier} has a value and an {@link Operation} used to combine
++ * that value with the prior value of the {@link Attribute}. There are three operations
++ * available:
++ *
++ *    {@link Operation#ADD} - add the modifier's value
++ *    {@link Operation#BASE} - add the current value multiplied by the modifier's value
++ *    {@link Operation#MULTIPLY} - multiply by the modifier's value
++ *
++ * The operations are applied in the above order, but for each operation, all of its
++ * modifiers are applied simultaneously. So, all modifiers are applied in three big
++ * operations, like this:
++ *
++ * X <- A1 + A2 + A3 + ...
++ * X <- (B1 * X) + (B2 * X) + (B3 * X) + ...
++ * X <- X * M1 * M2 * M3 ...
++ * </pre>
++ */
++public interface AttributeModifier {
++
++    enum Operation { ADD, BASE, MULTIPLY }
++
++    /**
++     * A human-readable name or description for this modifier. This has no
++     * functional purpose, it exists only for debugging.
++     */
++    String getName();
++
++    /**
++     * Globally unique identifier for this modifier. Two modifiers with
++     * the same UUID will be considered the same modifier in every sense.
++     */
++    UUID getId();
++
++    /**
++     * The value of this modifier
++     */
++    double getValue();
++
++    /**
++     * The numerical operation applied by this modifier
++     */
++    Operation getOperation();
++}
+diff --git a/src/main/java/org/bukkit/attributes/AttributeOwner.java b/src/main/java/org/bukkit/attributes/AttributeOwner.java
+new file mode 100644
+index 0000000..947ae38
+--- /dev/null
++++ b/src/main/java/org/bukkit/attributes/AttributeOwner.java
+@@ -0,0 +1,44 @@
++package org.bukkit.attributes;
++
++import java.util.Collection;
++import java.util.UUID;
++
++/**
++ * Something that has values for {@link Attribute}s and is affected by them.
++ */
++public interface AttributeOwner {
++
++    /**
++     * Is the given {@link Attribute} applicable to this owner?
++     */
++    boolean hasAttribute(Attribute attribute);
++
++    /**
++     * Get all {@link Attribute}s applicable to this owner
++     */
++    Collection<Attribute> getAttributes();
++
++    /**
++     * Get the value object of the given {@link Attribute}, or null
++     * if the attribute is not applicable to this owner.
++     */
++    AttributeValue getAttributeValue(Attribute attribute);
++
++    /**
++     * Get the value object of the {@link Attribute} with the given name,
++     * or null if the owner has no applicable attribute by that name.
++     */
++    AttributeValue getAttributeValue(String name);
++
++    /**
++     * Remove the given {@link AttributeModifier} from all of this owner's
++     * {@link AttributeValue}s.
++     */
++    void removeAttributeModifier(AttributeModifier modifier);
++
++    /**
++     * Remove the {@link AttributeModifier} with the given UUID from all of
++     * this owner's {@link AttributeValue}s.
++     */
++    void removeAttributeModifier(UUID id);
++}
+diff --git a/src/main/java/org/bukkit/attributes/AttributeValue.java b/src/main/java/org/bukkit/attributes/AttributeValue.java
+new file mode 100644
+index 0000000..f3a47de
+--- /dev/null
++++ b/src/main/java/org/bukkit/attributes/AttributeValue.java
+@@ -0,0 +1,61 @@
++package org.bukkit.attributes;
++
++import java.util.UUID;
++
++/**
++ * The state of a particular {@link Attribute} for a particular {@link org.bukkit.entity.LivingEntity},
++ * consisting of a base value and a set of {@link AttributeModifier}s.
++ */
++public interface AttributeValue {
++
++    /**
++     * The {@link Attribute} this value is for
++     */
++    Attribute getAttribute();
++
++    /**
++     * The value without any {@link AttributeModifier}s applied.
++     */
++    double getBase();
++
++    /**
++     * Set the base value
++     */
++    void setBase(double value);
++
++    /**
++     * The effective value of the attribute, with {@link AttributeModifier}s applied.
++     */
++    double getFinal();
++
++    /**
++     * Has the given modifier been applied to this attribute?
++     */
++    boolean hasModifier(AttributeModifier modifier);
++
++    /**
++     * Has an {@link AttributeModifier} with the given UUID been applied to this attribute?
++     */
++    boolean hasModifier(UUID id);
++
++    /**
++     * Get the {@link AttributeModifier} with the given UUID, or null if no such modifier
++     * has been applied to this attribute.
++     */
++    AttributeModifier getModifier(UUID id);
++
++    /**
++     * Add the given modifier to the set modifying this attribute.
++     */
++    void addModifier(AttributeModifier modifier);
++
++    /**
++     * Remove the given modifier from the set modifying this attribute.
++     */
++    void removeModifier(AttributeModifier modifier);
++
++    /**
++     * Remove the {@link AttributeModifier} with the given ID from the set modifying this attribute.
++     */
++    void removeModifier(UUID id);
++}
+diff --git a/src/main/java/org/bukkit/attributes/Attributes.java b/src/main/java/org/bukkit/attributes/Attributes.java
+new file mode 100644
+index 0000000..526c1bb
+--- /dev/null
++++ b/src/main/java/org/bukkit/attributes/Attributes.java
+@@ -0,0 +1,24 @@
++package org.bukkit.attributes;
++
++public class Attributes {
++    private Attributes() {}
++
++    public static class Generic {
++        private Generic() {}
++        public static final Attribute MAX_HEALTH = new Attribute("generic.maxHealth", 20d);
++        public static final Attribute FOLLOW_RANGE = new Attribute("generic.followRange", 32d);
++        public static final Attribute KNOCKBACK_RESISTANCE = new Attribute("generic.knockbackResistance", 0d);
++        public static final Attribute MOVEMENT_SPEED = new Attribute("generic.movementSpeed", 0.7d);
++        public static final Attribute ATTACK_DAMAGE = new Attribute("generic.attackDamage", 2d);
++    }
++
++    public static class Zombie {
++        private Zombie() {}
++        public static final Attribute SPAWN_REINFORCEMENTS = new Attribute("zombie.spawnReinforcements", 0d);
++    }
++
++    public static class Horse {
++        private Horse() {}
++        public static final Attribute JUMP_STRENGTH = new Attribute("horse.jumpStrength", 0.7D);
++    }
++}
+diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
+index 471bea8..621a985 100644
+--- a/src/main/java/org/bukkit/entity/LivingEntity.java
++++ b/src/main/java/org/bukkit/entity/LivingEntity.java
+@@ -5,6 +5,7 @@ import java.util.HashSet;
+ import java.util.List;
+ 
+ import org.bukkit.Location;
++import org.bukkit.attributes.AttributeOwner;
+ import org.bukkit.block.Block;
+ import org.bukkit.inventory.EntityEquipment;
+ import org.bukkit.potion.PotionEffect;
+@@ -14,7 +15,7 @@ import org.bukkit.projectiles.ProjectileSource;
+ /**
+  * Represents a living entity, such as a monster or player
+  */
+-public interface LivingEntity extends Entity, Damageable, ProjectileSource {
++public interface LivingEntity extends Entity, Damageable, ProjectileSource, AttributeOwner {
+ 
+     /**
+      * Gets the height of the living entity's eyes above its Location.
+diff --git a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
+index 0c11df2..169dc52 100644
+--- a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
++++ b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
+@@ -1,8 +1,11 @@
+ package org.bukkit.inventory.meta;
+ 
++import java.util.Collection;
+ import java.util.List;
+ import java.util.Map;
+ 
++import org.bukkit.attributes.Attribute;
++import org.bukkit.attributes.AttributeModifier;
+ import org.bukkit.configuration.serialization.ConfigurationSerializable;
+ import org.bukkit.enchantments.Enchantment;
+ 
+@@ -128,6 +131,30 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable {
+ 
+     void setUnbreakable(boolean unbreakable);
+ 
++    boolean hasAttributeModifiers();
++
++    Collection<String> getModifiedAttributes();
++
++    boolean hasModifiedAttribute(String attribute);
++
++    boolean hasModifiedAttribute(Attribute attribute);
++
++    boolean hasAttributeModifier(String attribute, AttributeModifier modifier);
++
++    boolean hasAttributeModifier(Attribute attribute, AttributeModifier modifier);
++
++    Collection<AttributeModifier> getAttributeModifiers(String attribute);
++
++    Collection<AttributeModifier> getAttributeModifiers(Attribute attribute);
++
++    void addAttributeModifier(String attribute, AttributeModifier modifier);
++
++    void addAttributeModifier(Attribute attribute, AttributeModifier modifier);
++
++    void removeAttributeModifier(String attribute, AttributeModifier modifier);
++
++    void removeAttributeModifier(Attribute attribute, AttributeModifier modifier);
++
+     @SuppressWarnings("javadoc")
+     ItemMeta clone();
+ }
+-- 
+1.9.0
+

--- a/CraftBukkit/0105-Support-unbreakable-items.patch
+++ b/CraftBukkit/0105-Support-unbreakable-items.patch
@@ -1,0 +1,125 @@
+From fc69570f0691340ce5747a0e19318abb22568adb Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Tue, 19 May 2015 01:40:42 -0400
+Subject: [PATCH] Support unbreakable items
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
+index 4681262..6e43be0 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
+@@ -201,12 +201,14 @@ class CraftMetaItem implements ItemMeta, Repairable {
+     static final ItemMetaKey ATTRIBUTES_UUID_HIGH = new ItemMetaKey("UUIDMost");
+     @Specific(Specific.To.NBT)
+     static final ItemMetaKey ATTRIBUTES_UUID_LOW = new ItemMetaKey("UUIDLeast");
++    static final ItemMetaKey UNBREAKABLE = new ItemMetaKey("Unbreakable", "unbreakable");
+ 
+     private String displayName;
+     private List<String> lore;
+     private Map<Enchantment, Integer> enchantments;
+     private int repairCost;
+     private final NBTTagList attributes;
++    private boolean unbreakable;
+ 
+     private static final Set<String> HANDLED_TAGS = Sets.newHashSet();
+ 
+@@ -230,6 +232,7 @@ class CraftMetaItem implements ItemMeta, Repairable {
+ 
+         this.repairCost = meta.repairCost;
+         this.attributes = meta.attributes;
++        this.unbreakable = meta.unbreakable;
+         this.unhandledTags.putAll(meta.unhandledTags);
+     }
+ 
+@@ -307,6 +310,8 @@ class CraftMetaItem implements ItemMeta, Repairable {
+             attributes = null;
+         }
+ 
++        unbreakable = tag.getBoolean(UNBREAKABLE.NBT);
++
+         Set<String> keys = tag.c();
+         for (String key : keys) {
+             if (!getHandledTags().contains(key)) {
+@@ -349,6 +354,7 @@ class CraftMetaItem implements ItemMeta, Repairable {
+         }
+ 
+         attributes = null;
++        unbreakable = SerializableMeta.getBoolean(map, UNBREAKABLE.BUKKIT);
+     }
+ 
+     static Map<Enchantment, Integer> buildEnchantments(Map<String, Object> map, ItemMetaKey key) {
+@@ -389,6 +395,10 @@ class CraftMetaItem implements ItemMeta, Repairable {
+             itemTag.set(ATTRIBUTES.NBT, attributes);
+         }
+ 
++        if(unbreakable) {
++            itemTag.setBoolean(UNBREAKABLE.NBT, true);
++        }
++
+         for (Map.Entry<String, NBTBase> e : unhandledTags.entrySet()) {
+             itemTag.set(e.getKey(), e.getValue());
+         }
+@@ -443,7 +453,7 @@ class CraftMetaItem implements ItemMeta, Repairable {
+ 
+     @Overridden
+     boolean isEmpty() {
+-        return !(hasDisplayName() || hasEnchants() || hasLore() || hasAttributes() || hasRepairCost() || !unhandledTags.isEmpty());
++        return !(hasDisplayName() || hasEnchants() || hasLore() || hasAttributes() || hasRepairCost() || unbreakable || !unhandledTags.isEmpty());
+     }
+ 
+     public String getDisplayName() {
+@@ -536,6 +546,16 @@ class CraftMetaItem implements ItemMeta, Repairable {
+     }
+ 
+     @Override
++    public boolean isUnbreakable() {
++        return unbreakable;
++    }
++
++    @Override
++    public void setUnbreakable(boolean unbreakable) {
++        this.unbreakable = unbreakable;
++    }
++
++    @Override
+     public final boolean equals(Object object) {
+         if (object == null) {
+             return false;
+@@ -561,6 +581,7 @@ class CraftMetaItem implements ItemMeta, Repairable {
+                 && (this.hasLore() ? that.hasLore() && this.lore.equals(that.lore) : !that.hasLore())
+                 && (this.hasAttributes() ? that.hasAttributes() && this.attributes.equals(that.attributes) : !that.hasAttributes())
+                 && (this.hasRepairCost() ? that.hasRepairCost() && this.repairCost == that.repairCost : !that.hasRepairCost())
++                && this.unbreakable == that.unbreakable
+                 && (this.unhandledTags.equals(that.unhandledTags));
+     }
+ 
+@@ -587,6 +608,7 @@ class CraftMetaItem implements ItemMeta, Repairable {
+         hash = 61 * hash + (hasEnchants() ? this.enchantments.hashCode() : 0);
+         hash = 61 * hash + (hasAttributes() ? this.attributes.hashCode() : 0);
+         hash = 61 * hash + (hasRepairCost() ? this.repairCost : 0);
++        hash = 61 * hash + (unbreakable ? 1 : 0);
+         hash = 61 * hash + unhandledTags.hashCode();
+         return hash;
+     }
+@@ -631,6 +653,10 @@ class CraftMetaItem implements ItemMeta, Repairable {
+             builder.put(REPAIR.BUKKIT, repairCost);
+         }
+ 
++        if(unbreakable) {
++            builder.put(UNBREAKABLE.BUKKIT, true);
++        }
++
+         return builder;
+     }
+ 
+@@ -698,6 +724,7 @@ class CraftMetaItem implements ItemMeta, Repairable {
+                     REPAIR.NBT,
+                     ATTRIBUTES.NBT,
+                     ENCHANTMENTS.NBT,
++                    UNBREAKABLE.NBT,
+                     CraftMetaMap.MAP_SCALING.NBT,
+                     CraftMetaPotion.POTION_EFFECTS.NBT,
+                     CraftMetaSkull.SKULL_OWNER.NBT,
+-- 
+1.9.0
+

--- a/CraftBukkit/0106-Attribute-API.patch
+++ b/CraftBukkit/0106-Attribute-API.patch
@@ -1,0 +1,757 @@
+From c5f2cbbbc0d00d2713dafed68bae63eb807f5ef1 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Tue, 19 May 2015 06:31:14 -0400
+Subject: [PATCH] Attribute API
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+index c90a0a8..0a3c4f9 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+@@ -36,6 +36,7 @@ import org.bukkit.Warning.WarningState;
+ import org.bukkit.World;
+ import org.bukkit.World.Environment;
+ import org.bukkit.WorldCreator;
++import org.bukkit.attributes.AttributeFactory;
+ import org.bukkit.command.Command;
+ import org.bukkit.command.CommandException;
+ import org.bukkit.command.CommandSender;
+@@ -46,6 +47,7 @@ import org.bukkit.configuration.ConfigurationSection;
+ import org.bukkit.configuration.file.YamlConfiguration;
+ import org.bukkit.configuration.serialization.ConfigurationSerialization;
+ import org.bukkit.conversations.Conversable;
++import org.bukkit.craftbukkit.attributes.CraftAttributeFactory;
+ import org.bukkit.craftbukkit.command.VanillaCommandWrapper;
+ import org.bukkit.craftbukkit.entity.CraftPlayer;
+ import org.bukkit.craftbukkit.help.SimpleHelpMap;
+@@ -135,6 +137,7 @@ public final class CraftServer implements Server {
+     private final SimpleHelpMap helpMap = new SimpleHelpMap(this);
+     private final StandardMessenger messenger = new StandardMessenger();
+     private final PluginManager pluginManager = new SimplePluginManager(this, commandMap);
++    private final CraftAttributeFactory attributeFactory = new CraftAttributeFactory();
+     protected final MinecraftServer console;
+     protected final DedicatedPlayerList playerList;
+     private final Map<String, World> worlds = new LinkedHashMap<String, World>();
+@@ -1711,4 +1714,9 @@ public final class CraftServer implements Server {
+             player.sendMessage(components);
+         }
+     }
++
++    @Override
++    public AttributeFactory getAttributeFactory() {
++        return attributeFactory;
++    }
+ }
+diff --git a/src/main/java/org/bukkit/craftbukkit/attributes/CraftAttributeFactory.java b/src/main/java/org/bukkit/craftbukkit/attributes/CraftAttributeFactory.java
+new file mode 100644
+index 0000000..6337c68
+--- /dev/null
++++ b/src/main/java/org/bukkit/craftbukkit/attributes/CraftAttributeFactory.java
+@@ -0,0 +1,43 @@
++package org.bukkit.craftbukkit.attributes;
++
++import java.util.Map;
++import java.util.UUID;
++
++import com.google.common.collect.ImmutableMap;
++import org.bukkit.attributes.Attribute;
++import org.bukkit.attributes.AttributeFactory;
++import org.bukkit.attributes.AttributeModifier;
++import org.bukkit.attributes.Attributes;
++
++public class CraftAttributeFactory implements AttributeFactory {
++
++    private static final ImmutableMap<String, Attribute> knownAttributes = ImmutableMap.<String, Attribute>builder()
++        .put(Attributes.Generic.MAX_HEALTH.getName(), Attributes.Generic.MAX_HEALTH)
++        .put(Attributes.Generic.FOLLOW_RANGE.getName(), Attributes.Generic.FOLLOW_RANGE)
++        .put(Attributes.Generic.KNOCKBACK_RESISTANCE.getName(), Attributes.Generic.KNOCKBACK_RESISTANCE)
++        .put(Attributes.Generic.MOVEMENT_SPEED.getName(), Attributes.Generic.MOVEMENT_SPEED)
++        .put(Attributes.Generic.ATTACK_DAMAGE.getName(), Attributes.Generic.ATTACK_DAMAGE)
++        .put(Attributes.Zombie.SPAWN_REINFORCEMENTS.getName(), Attributes.Zombie.SPAWN_REINFORCEMENTS)
++        .put(Attributes.Horse.JUMP_STRENGTH.getName(), Attributes.Horse.JUMP_STRENGTH)
++        .build();
++
++    @Override
++    public Map<String, ? extends Attribute> knownAttributes() {
++        return knownAttributes;
++    }
++
++    @Override
++    public Attribute knownAttribute(String name) {
++        return knownAttributes.get(name);
++    }
++
++    @Override
++    public AttributeModifier newAttributeModifier(UUID id, String name, double value, AttributeModifier.Operation operation) {
++        return new CraftAttributeModifier(id, name, value, operation);
++    }
++
++    @Override
++    public AttributeModifier newAttributeModifier(String name, double value, AttributeModifier.Operation operation) {
++        return new CraftAttributeModifier(name, value, operation);
++    }
++}
+diff --git a/src/main/java/org/bukkit/craftbukkit/attributes/CraftAttributeModifier.java b/src/main/java/org/bukkit/craftbukkit/attributes/CraftAttributeModifier.java
+new file mode 100644
+index 0000000..4561686
+--- /dev/null
++++ b/src/main/java/org/bukkit/craftbukkit/attributes/CraftAttributeModifier.java
+@@ -0,0 +1,86 @@
++package org.bukkit.craftbukkit.attributes;
++
++import java.util.UUID;
++
++import org.bukkit.attributes.AttributeModifier;
++
++public class CraftAttributeModifier implements AttributeModifier {
++
++    private final net.minecraft.server.AttributeModifier handle;
++
++    public CraftAttributeModifier(net.minecraft.server.AttributeModifier handle) {
++        this.handle = handle;
++    }
++
++    public CraftAttributeModifier(UUID id, String name, double value, Operation operation) {
++        this(new net.minecraft.server.AttributeModifier(id, name, value, getOpcode(operation)));
++    }
++
++    public CraftAttributeModifier(String name, double value, Operation operation) {
++        this(new net.minecraft.server.AttributeModifier(name, value, getOpcode(operation)));
++    }
++
++    public CraftAttributeModifier(AttributeModifier modifier) {
++        this(modifier.getId(), modifier.getName(), modifier.getValue(), modifier.getOperation());
++    }
++
++    public static CraftAttributeModifier coerce(AttributeModifier modifier) {
++        if(modifier instanceof CraftAttributeModifier) {
++            return (CraftAttributeModifier) modifier;
++        } else {
++            return new CraftAttributeModifier(modifier);
++        }
++    }
++
++    public net.minecraft.server.AttributeModifier getHandle() {
++        return handle;
++    }
++
++    @Override
++    public String getName() {
++        return handle.b();
++    }
++
++    @Override
++    public UUID getId() {
++        return handle.a();
++    }
++
++    @Override
++    public double getValue() {
++        return handle.d();
++    }
++
++    @Override
++    public Operation getOperation() {
++        return getOperation(handle.c());
++    }
++
++    @Override
++    public boolean equals(Object obj) {
++        return this == obj || (obj instanceof AttributeModifier && getId().equals(((AttributeModifier) obj).getId()));
++    }
++
++    @Override
++    public int hashCode() {
++        return getId().hashCode();
++    }
++
++    public static int getOpcode(Operation operation) {
++        switch(operation) {
++            case ADD: return 0;
++            case BASE: return 1;
++            case MULTIPLY: return 2;
++        }
++        throw new IllegalStateException("Unhandled attribute modifier operation: " + operation);
++    }
++
++    public static Operation getOperation(int opcode) {
++        switch(opcode) {
++            case 0: return Operation.ADD;
++            case 1: return Operation.BASE;
++            case 2: return Operation.MULTIPLY;
++        }
++        throw new IllegalStateException("Unhandled attribute modifier opcode: " + opcode);
++    }
++}
+diff --git a/src/main/java/org/bukkit/craftbukkit/attributes/CraftAttributeValue.java b/src/main/java/org/bukkit/craftbukkit/attributes/CraftAttributeValue.java
+new file mode 100644
+index 0000000..78e1d37
+--- /dev/null
++++ b/src/main/java/org/bukkit/craftbukkit/attributes/CraftAttributeValue.java
+@@ -0,0 +1,77 @@
++package org.bukkit.craftbukkit.attributes;
++
++import java.util.UUID;
++
++import net.minecraft.server.AttributeInstance;
++import net.minecraft.server.AttributeRanged;
++import org.bukkit.attributes.Attribute;
++import org.bukkit.attributes.AttributeModifier;
++import org.bukkit.attributes.AttributeValue;
++
++public class CraftAttributeValue implements AttributeValue {
++
++    private final AttributeInstance handle;
++    private final Attribute attribute;
++
++    public CraftAttributeValue(AttributeInstance handle) {
++        this.handle = handle;
++        AttributeRanged nms = (AttributeRanged) handle.getAttribute();
++        this.attribute = new Attribute(nms.getName(), nms.b());
++    }
++
++    public AttributeInstance getHandle() {
++        return handle;
++    }
++
++    @Override
++    public Attribute getAttribute() {
++        return attribute;
++    }
++
++    @Override
++    public double getBase() {
++        return handle.b();
++    }
++
++    @Override
++    public void setBase(double value) {
++        handle.setValue(value);
++    }
++
++    @Override
++    public double getFinal() {
++        return handle.getValue();
++    }
++
++    @Override
++    public boolean hasModifier(AttributeModifier modifier) {
++        return hasModifier(modifier.getId());
++    }
++
++    @Override
++    public boolean hasModifier(UUID id) {
++        return handle.a(id) != null;
++    }
++
++    @Override
++    public AttributeModifier getModifier(UUID id) {
++        net.minecraft.server.AttributeModifier nms = handle.a(id);
++        return nms == null ? null : new CraftAttributeModifier(nms);
++    }
++
++    @Override
++    public void addModifier(AttributeModifier modifier) {
++        handle.b(CraftAttributeModifier.coerce(modifier).getHandle());
++    }
++
++    @Override
++    public void removeModifier(AttributeModifier modifier) {
++        removeModifier(modifier.getId());
++    }
++
++    @Override
++    public void removeModifier(UUID id) {
++        net.minecraft.server.AttributeModifier nms = handle.a(id);
++        if(nms != null) handle.c(nms);
++    }
++}
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
+index ea2772c..a680737 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
+@@ -5,7 +5,12 @@ import java.util.Collection;
+ import java.util.HashSet;
+ import java.util.Iterator;
+ import java.util.List;
++import java.util.UUID;
++import javax.annotation.Nullable;
+ 
++import com.google.common.base.Function;
++import com.google.common.collect.Collections2;
++import net.minecraft.server.AttributeInstance;
+ import net.minecraft.server.DamageSource;
+ import net.minecraft.server.EntityArmorStand;
+ import net.minecraft.server.EntityArrow;
+@@ -32,9 +37,13 @@ import net.minecraft.server.MobEffectList;
+ import org.apache.commons.lang.Validate;
+ import org.bukkit.Location;
+ import org.bukkit.Material;
++import org.bukkit.attributes.Attribute;
++import org.bukkit.attributes.AttributeModifier;
++import org.bukkit.attributes.AttributeValue;
+ import org.bukkit.block.Block;
+ import org.bukkit.craftbukkit.CraftServer;
+ import org.bukkit.craftbukkit.CraftWorld;
++import org.bukkit.craftbukkit.attributes.CraftAttributeValue;
+ import org.bukkit.craftbukkit.inventory.CraftEntityEquipment;
+ import org.bukkit.craftbukkit.inventory.CraftItemStack;
+ import org.bukkit.entity.Arrow;
+@@ -66,12 +75,21 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+     private CraftEntityEquipment equipment;
+     private boolean potionParticles = true;
+ 
++    private final Collection<Attribute> attributes;
++
+     public CraftLivingEntity(final CraftServer server, final EntityLiving entity) {
+         super(server, entity);
+ 
+         if (entity instanceof EntityInsentient || entity instanceof EntityArmorStand) {
+             equipment = new CraftEntityEquipment(this);
+         }
++
++        attributes = Collections2.transform((Collection<AttributeInstance>) entity.getAttributeMap().a(), new Function<AttributeInstance, Attribute>() {
++            @Override
++            public @Nullable Attribute apply(AttributeInstance input) {
++                return new Attribute(input.getAttribute().getName(), input.getAttribute().b());
++            }
++        });
+     }
+ 
+     public double getHealth() {
+@@ -484,4 +502,36 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+     public void setArrowsStuck(int arrows) {
+         getHandle().o(arrows);
+     }
++
++    @Override
++    public boolean hasAttribute(Attribute attribute) {
++        return getHandle().getAttributeMap().a(attribute.getName()) != null;
++    }
++
++    @Override
++    public Collection<Attribute> getAttributes() {
++        return attributes;
++    }
++
++    @Override
++    public AttributeValue getAttributeValue(Attribute attribute) {
++        return getAttributeValue(attribute.getName());
++    }
++
++    public AttributeValue getAttributeValue(String name) {
++        return new CraftAttributeValue(getHandle().getAttributeMap().a(name));
++    }
++
++    @Override
++    public void removeAttributeModifier(AttributeModifier modifier) {
++        removeAttributeModifier(modifier.getId());
++    }
++
++    @Override
++    public void removeAttributeModifier(UUID id) {
++        for(AttributeInstance attr : (Collection<AttributeInstance>) getHandle().getAttributeMap().a()) {
++            net.minecraft.server.AttributeModifier mod = attr.a(id);
++            if(mod != null) attr.c(mod);
++        }
++    }
+ }
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
+index 0f89623..f8f8bd4 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
+@@ -14,21 +14,11 @@ import com.google.common.collect.ImmutableSet;
+ 
+ public final class CraftItemFactory implements ItemFactory {
+     static final Color DEFAULT_LEATHER_COLOR = Color.fromRGB(0xA06540);
+-    static final Collection<String> KNOWN_NBT_ATTRIBUTE_NAMES;
+     private static final CraftItemFactory instance;
+ 
+     static {
+         instance = new CraftItemFactory();
+         ConfigurationSerialization.registerClass(CraftMetaItem.SerializableMeta.class);
+-        KNOWN_NBT_ATTRIBUTE_NAMES = ImmutableSet.<String>builder()
+-            .add("generic.attackDamage")
+-            .add("generic.followRange")
+-            .add("generic.knockbackResistance")
+-            .add("generic.maxHealth")
+-            .add("generic.movementSpeed")
+-            .add("horse.jumpStrength")
+-            .add("zombie.spawnReinforcements")
+-            .build();
+     }
+ 
+     private CraftItemFactory() {
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
+index 6e43be0..0a49147 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
+@@ -8,11 +8,16 @@ import java.lang.reflect.Constructor;
+ import java.lang.reflect.InvocationTargetException;
+ import java.util.ArrayList;
+ import java.util.Collection;
++import java.util.Collections;
+ import java.util.HashMap;
+ import java.util.List;
+ import java.util.Map;
+ import java.util.NoSuchElementException;
+ 
++import com.google.common.collect.HashMultimap;
++import com.google.common.collect.ImmutableSet;
++import com.google.common.collect.SetMultimap;
++import net.minecraft.server.GenericAttributes;
+ import net.minecraft.server.NBTBase;
+ import net.minecraft.server.NBTTagCompound;
+ import net.minecraft.server.NBTTagDouble;
+@@ -23,10 +28,13 @@ import net.minecraft.server.NBTTagString;
+ 
+ import org.apache.commons.lang.Validate;
+ import org.bukkit.Material;
++import org.bukkit.attributes.Attribute;
++import org.bukkit.attributes.AttributeModifier;
+ import org.bukkit.configuration.serialization.ConfigurationSerializable;
+ import org.bukkit.configuration.serialization.DelegateDeserialization;
+ import org.bukkit.configuration.serialization.SerializableAs;
+ import org.bukkit.craftbukkit.Overridden;
++import org.bukkit.craftbukkit.attributes.CraftAttributeModifier;
+ import org.bukkit.craftbukkit.inventory.CraftMetaItem.ItemMetaKey.Specific;
+ import org.bukkit.enchantments.Enchantment;
+ import org.bukkit.inventory.meta.ItemMeta;
+@@ -207,7 +215,7 @@ class CraftMetaItem implements ItemMeta, Repairable {
+     private List<String> lore;
+     private Map<Enchantment, Integer> enchantments;
+     private int repairCost;
+-    private final NBTTagList attributes;
++    private SetMultimap<String, AttributeModifier> attributeModifiers;
+     private boolean unbreakable;
+ 
+     private static final Set<String> HANDLED_TAGS = Sets.newHashSet();
+@@ -216,7 +224,7 @@ class CraftMetaItem implements ItemMeta, Repairable {
+ 
+     CraftMetaItem(CraftMetaItem meta) {
+         if (meta == null) {
+-            attributes = null;
++            attributeModifiers = null;
+             return;
+         }
+ 
+@@ -230,8 +238,11 @@ class CraftMetaItem implements ItemMeta, Repairable {
+             this.enchantments = new HashMap<Enchantment, Integer>(meta.enchantments);
+         }
+ 
++        if(meta.hasAttributeModifiers()) {
++            this.attributeModifiers = HashMultimap.create(meta.attributeModifiers);
++        }
++
+         this.repairCost = meta.repairCost;
+-        this.attributes = meta.attributes;
+         this.unbreakable = meta.unbreakable;
+         this.unhandledTags.putAll(meta.unhandledTags);
+     }
+@@ -257,59 +268,12 @@ class CraftMetaItem implements ItemMeta, Repairable {
+ 
+         this.enchantments = buildEnchantments(tag, ENCHANTMENTS);
+ 
++        this.attributeModifiers = buildAttributeModifiers(tag);
++
+         if (tag.hasKey(REPAIR.NBT)) {
+             repairCost = tag.getInt(REPAIR.NBT);
+         }
+ 
+-
+-        if (tag.get(ATTRIBUTES.NBT) instanceof NBTTagList) {
+-            NBTTagList save = null;
+-            NBTTagList nbttaglist = tag.getList(ATTRIBUTES.NBT, 10);
+-
+-            for (int i = 0; i < nbttaglist.size(); ++i) {
+-                if (!(nbttaglist.get(i) instanceof NBTTagCompound)) {
+-                    continue;
+-                }
+-                NBTTagCompound nbttagcompound = (NBTTagCompound) nbttaglist.get(i);
+-
+-                if (!nbttagcompound.hasKeyOfType(ATTRIBUTES_UUID_HIGH.NBT, 99)) {
+-                    continue;
+-                }
+-                if (!nbttagcompound.hasKeyOfType(ATTRIBUTES_UUID_LOW.NBT, 99)) {
+-                    continue;
+-                }
+-                if (!(nbttagcompound.get(ATTRIBUTES_IDENTIFIER.NBT) instanceof NBTTagString) || !CraftItemFactory.KNOWN_NBT_ATTRIBUTE_NAMES.contains(nbttagcompound.getString(ATTRIBUTES_IDENTIFIER.NBT))) {
+-                    continue;
+-                }
+-                if (!(nbttagcompound.get(ATTRIBUTES_NAME.NBT) instanceof NBTTagString) || nbttagcompound.getString(ATTRIBUTES_NAME.NBT).isEmpty()) {
+-                    continue;
+-                }
+-                if (!nbttagcompound.hasKeyOfType(ATTRIBUTES_VALUE.NBT, 99)) {
+-                    continue;
+-                }
+-                if (!nbttagcompound.hasKeyOfType(ATTRIBUTES_TYPE.NBT, 99) || nbttagcompound.getInt(ATTRIBUTES_TYPE.NBT) < 0 || nbttagcompound.getInt(ATTRIBUTES_TYPE.NBT) > 2) {
+-                    continue;
+-                }
+-
+-                if (save == null) {
+-                    save = new NBTTagList();
+-                }
+-
+-                NBTTagCompound entry = new NBTTagCompound();
+-                entry.set(ATTRIBUTES_UUID_HIGH.NBT, nbttagcompound.get(ATTRIBUTES_UUID_HIGH.NBT));
+-                entry.set(ATTRIBUTES_UUID_LOW.NBT, nbttagcompound.get(ATTRIBUTES_UUID_LOW.NBT));
+-                entry.set(ATTRIBUTES_IDENTIFIER.NBT, nbttagcompound.get(ATTRIBUTES_IDENTIFIER.NBT));
+-                entry.set(ATTRIBUTES_NAME.NBT, nbttagcompound.get(ATTRIBUTES_NAME.NBT));
+-                entry.set(ATTRIBUTES_VALUE.NBT, nbttagcompound.get(ATTRIBUTES_VALUE.NBT));
+-                entry.set(ATTRIBUTES_TYPE.NBT, nbttagcompound.get(ATTRIBUTES_TYPE.NBT));
+-                save.add(entry);
+-            }
+-
+-            attributes = save;
+-        } else {
+-            attributes = null;
+-        }
+-
+         unbreakable = tag.getBoolean(UNBREAKABLE.NBT);
+ 
+         Set<String> keys = tag.c();
+@@ -338,6 +302,21 @@ class CraftMetaItem implements ItemMeta, Repairable {
+         return enchantments;
+     }
+ 
++    static SetMultimap<String, AttributeModifier> buildAttributeModifiers(NBTTagCompound tag) {
++        if(!tag.hasKey(ATTRIBUTES.NBT)) return null;
++
++        SetMultimap<String, AttributeModifier> attributeModifiers = HashMultimap.create();
++
++        NBTTagList mods = tag.getList(ATTRIBUTES.NBT, 10);
++        for(int i = 0; i < mods.size(); i++) {
++            NBTTagCompound mod = mods.get(i);
++            attributeModifiers.put(mod.getString(ATTRIBUTES_IDENTIFIER.NBT),
++                                   new CraftAttributeModifier(GenericAttributes.a(mod)));
++        }
++
++        return attributeModifiers;
++    }
++
+     CraftMetaItem(Map<String, Object> map) {
+         setDisplayName(SerializableMeta.getString(map, NAME.BUKKIT, true));
+ 
+@@ -353,7 +332,7 @@ class CraftMetaItem implements ItemMeta, Repairable {
+             setRepairCost(repairCost);
+         }
+ 
+-        attributes = null;
++        attributeModifiers = null; // No Bukkit serialization for attributes
+         unbreakable = SerializableMeta.getBoolean(map, UNBREAKABLE.BUKKIT);
+     }
+ 
+@@ -391,9 +370,7 @@ class CraftMetaItem implements ItemMeta, Repairable {
+             itemTag.setInt(REPAIR.NBT, repairCost);
+         }
+ 
+-        if (attributes != null) {
+-            itemTag.set(ATTRIBUTES.NBT, attributes);
+-        }
++        copyAttributeModifiers(itemTag);
+ 
+         if(unbreakable) {
+             itemTag.setBoolean(UNBREAKABLE.NBT, true);
+@@ -436,6 +413,28 @@ class CraftMetaItem implements ItemMeta, Repairable {
+         tag.set(key.NBT, list);
+     }
+ 
++    static NBTTagCompound createAttributeModifierTag(AttributeModifier modifier) {
++        NBTTagCompound tag = new NBTTagCompound();
++        tag.setString(ATTRIBUTES_NAME.NBT, modifier.getName());
++        tag.setDouble(ATTRIBUTES_VALUE.NBT, modifier.getValue());
++        tag.setInt(ATTRIBUTES_TYPE.NBT, CraftAttributeModifier.getOpcode(modifier.getOperation()));
++        tag.setLong(ATTRIBUTES_UUID_HIGH.NBT, modifier.getId().getMostSignificantBits());
++        tag.setLong(ATTRIBUTES_UUID_LOW.NBT, modifier.getId().getLeastSignificantBits());
++        return tag;
++    }
++
++    void copyAttributeModifiers(NBTTagCompound tag) {
++        if(!hasAttributeModifiers()) return;
++
++        NBTTagList list = new NBTTagList();
++        for(Map.Entry<String, AttributeModifier> entry : attributeModifiers.entries()) {
++            NBTTagCompound mod = createAttributeModifierTag(entry.getValue());
++            mod.setString(ATTRIBUTES_IDENTIFIER.NBT, entry.getKey());
++            list.add(mod);
++        }
++        tag.set(ATTRIBUTES.NBT, list);
++    }
++
+     void setDisplayTag(NBTTagCompound tag, String key, NBTBase value) {
+         final NBTTagCompound display = tag.getCompound(DISPLAY.NBT);
+ 
+@@ -453,7 +452,7 @@ class CraftMetaItem implements ItemMeta, Repairable {
+ 
+     @Overridden
+     boolean isEmpty() {
+-        return !(hasDisplayName() || hasEnchants() || hasLore() || hasAttributes() || hasRepairCost() || unbreakable || !unhandledTags.isEmpty());
++        return !(hasDisplayName() || hasEnchants() || hasLore() || hasAttributeModifiers() || hasRepairCost() || unbreakable || !unhandledTags.isEmpty());
+     }
+ 
+     public String getDisplayName() {
+@@ -472,10 +471,6 @@ class CraftMetaItem implements ItemMeta, Repairable {
+         return this.lore != null && !this.lore.isEmpty();
+     }
+ 
+-    public boolean hasAttributes() {
+-        return this.attributes != null;
+-    }
+-
+     public boolean hasRepairCost() {
+         return repairCost > 0;
+     }
+@@ -520,6 +515,69 @@ class CraftMetaItem implements ItemMeta, Repairable {
+         return checkConflictingEnchants(enchantments, ench);
+     }
+ 
++    @Override
++    public boolean hasAttributeModifiers() {
++        return attributeModifiers != null && !attributeModifiers.isEmpty();
++    }
++
++    @Override
++    public Collection<String> getModifiedAttributes() {
++        return hasAttributeModifiers() ? ImmutableSet.copyOf(attributeModifiers.keySet()) : Collections.<String>emptySet();
++    }
++
++    @Override
++    public boolean hasModifiedAttribute(String attribute) {
++        return hasAttributeModifiers() && attributeModifiers.containsKey(attribute);
++    }
++
++    @Override
++    public boolean hasModifiedAttribute(Attribute attribute) {
++        return hasModifiedAttribute(attribute.getName());
++    }
++
++    @Override
++    public Collection<AttributeModifier> getAttributeModifiers(String attribute) {
++        return hasAttributeModifiers() ? attributeModifiers.get(attribute) : Collections.<AttributeModifier>emptySet();
++    }
++
++    @Override
++    public Collection<AttributeModifier> getAttributeModifiers(Attribute attribute) {
++        return getAttributeModifiers(attribute.getName());
++    }
++
++    @Override
++    public boolean hasAttributeModifier(String attribute, AttributeModifier modifier) {
++        return hasAttributeModifiers() && attributeModifiers.containsEntry(attribute, modifier);
++    }
++
++    @Override
++    public boolean hasAttributeModifier(Attribute attribute, AttributeModifier modifier) {
++        return hasAttributeModifier(attribute.getName(), modifier);
++    }
++
++    @Override
++    public void addAttributeModifier(String attribute, AttributeModifier modifier) {
++        if(attributeModifiers == null) attributeModifiers = HashMultimap.create();
++        attributeModifiers.put(attribute, modifier);
++    }
++
++    @Override
++    public void addAttributeModifier(Attribute attribute, AttributeModifier modifier) {
++        addAttributeModifier(attribute.getName(), modifier);
++    }
++
++    @Override
++    public void removeAttributeModifier(String attribute, AttributeModifier modifier) {
++        if(attributeModifiers != null) {
++            attributeModifiers.remove(attribute, modifier);
++        }
++    }
++
++    @Override
++    public void removeAttributeModifier(Attribute attribute, AttributeModifier modifier) {
++        removeAttributeModifier(attribute.getName(), modifier);
++    }
++
+     public List<String> getLore() {
+         return this.lore == null ? null : new ArrayList<String>(this.lore);
+     }
+@@ -579,7 +637,7 @@ class CraftMetaItem implements ItemMeta, Repairable {
+         return ((this.hasDisplayName() ? that.hasDisplayName() && this.displayName.equals(that.displayName) : !that.hasDisplayName()))
+                 && (this.hasEnchants() ? that.hasEnchants() && this.enchantments.equals(that.enchantments) : !that.hasEnchants())
+                 && (this.hasLore() ? that.hasLore() && this.lore.equals(that.lore) : !that.hasLore())
+-                && (this.hasAttributes() ? that.hasAttributes() && this.attributes.equals(that.attributes) : !that.hasAttributes())
++                && (this.hasAttributeModifiers() ? that.hasAttributeModifiers() && this.attributeModifiers.equals(that.attributeModifiers) : !that.hasAttributeModifiers())
+                 && (this.hasRepairCost() ? that.hasRepairCost() && this.repairCost == that.repairCost : !that.hasRepairCost())
+                 && this.unbreakable == that.unbreakable
+                 && (this.unhandledTags.equals(that.unhandledTags));
+@@ -606,7 +664,7 @@ class CraftMetaItem implements ItemMeta, Repairable {
+         hash = 61 * hash + (hasDisplayName() ? this.displayName.hashCode() : 0);
+         hash = 61 * hash + (hasLore() ? this.lore.hashCode() : 0);
+         hash = 61 * hash + (hasEnchants() ? this.enchantments.hashCode() : 0);
+-        hash = 61 * hash + (hasAttributes() ? this.attributes.hashCode() : 0);
++        hash = 61 * hash + (hasAttributeModifiers() ? this.attributeModifiers.hashCode() : 0);
+         hash = 61 * hash + (hasRepairCost() ? this.repairCost : 0);
+         hash = 61 * hash + (unbreakable ? 1 : 0);
+         hash = 61 * hash + unhandledTags.hashCode();
+@@ -624,6 +682,9 @@ class CraftMetaItem implements ItemMeta, Repairable {
+             if (this.enchantments != null) {
+                 clone.enchantments = new HashMap<Enchantment, Integer>(this.enchantments);
+             }
++            if (this.attributeModifiers != null) {
++                clone.attributeModifiers = HashMultimap.create(this.attributeModifiers);
++            }
+             return clone;
+         } catch (CloneNotSupportedException e) {
+             throw new Error(e);
+diff --git a/src/test/java/org/bukkit/craftbukkit/inventory/ItemFactoryTest.java b/src/test/java/org/bukkit/craftbukkit/inventory/ItemFactoryTest.java
+deleted file mode 100644
+index f5bcbdb..0000000
+--- a/src/test/java/org/bukkit/craftbukkit/inventory/ItemFactoryTest.java
++++ /dev/null
+@@ -1,47 +0,0 @@
+-package org.bukkit.craftbukkit.inventory;
+-
+-import static org.junit.Assert.*;
+-import static org.hamcrest.Matchers.*;
+-
+-import java.lang.reflect.Field;
+-import java.lang.reflect.Modifier;
+-import java.util.Collection;
+-import java.util.HashSet;
+-import java.util.zip.ZipEntry;
+-import java.util.zip.ZipInputStream;
+-
+-import net.minecraft.server.CommandAbstract;
+-import net.minecraft.server.IAttribute;
+-
+-import org.bukkit.support.AbstractTestingBase;
+-import org.junit.Test;
+-
+-public class ItemFactoryTest extends AbstractTestingBase {
+-
+-    @Test
+-    public void testKnownAttributes() throws Throwable {
+-        final ZipInputStream nmsZipStream = new ZipInputStream(CommandAbstract.class/* Magic class that isn't imported! */.getProtectionDomain().getCodeSource().getLocation().openStream());
+-        final Collection<String> names = new HashSet<String>();
+-        for (ZipEntry clazzEntry; (clazzEntry = nmsZipStream.getNextEntry()) != null; ) {
+-            final String entryName = clazzEntry.getName();
+-            if (!(entryName.endsWith(".class") && entryName.startsWith("net/minecraft/server/"))) {
+-                continue;
+-            }
+-
+-            final Class<?> clazz = Class.forName(entryName.substring(0, entryName.length() - ".class".length()).replace('/', '.'));
+-            assertThat(entryName, clazz, is(not(nullValue())));
+-            for (final Field field : clazz.getDeclaredFields()) {
+-                if (IAttribute.class.isAssignableFrom(field.getType()) && Modifier.isStatic(field.getModifiers())) {
+-                    field.setAccessible(true);
+-                    final String attributeName = ((IAttribute) field.get(null)).getName();
+-                    assertThat("Logical error: duplicate name `" + attributeName + "' in " + clazz.getName(), names.add(attributeName), is(true));
+-                    assertThat(clazz.getName(), CraftItemFactory.KNOWN_NBT_ATTRIBUTE_NAMES, hasItem(attributeName));
+-                }
+-            }
+-        }
+-
+-        nmsZipStream.close();
+-
+-        assertThat("Extra values detected", CraftItemFactory.KNOWN_NBT_ATTRIBUTE_NAMES, is(names));
+-    }
+-}
+-- 
+1.9.0
+


### PR DESCRIPTION
This is a complete API for applying attribute modifiers to both `LivingEntity`s and `ItemMeta`s

As a little bonus, there is also support for the Unbreakable tag on items.

The data model mirrors the NMS one pretty closely, and wraps NMS objects, but it should work fine if you pass it alternate implementations of the interfaces.

Modifier on an item:
```
AttributeModifier mod = Bukkit.getAttributeFactory().newAttributeModifier("Attack Buff", 3.5, AttributeModifier.Operation.ADD);
stack.getItemMeta().addAttributeModifier("generic.attackDamage", mod);
stack.getItemMeta().addAttributeModifier(Bukkit.getAttributeFactory().knownAttribute("generic.attackDamage"), mod);
stack.getItemMeta().addAttributeModifier(Bukkit.getAttributeFactory().attackDamageAttribute(), mod);
```
The last three lines all do the same thing. `AttributeModifier`s on items are associated only with names, but you can pass an `Attribute` and it will just call `getName()` on it.

Modifier on an entity:
```
AttributeModifier mod = Bukkit.getAttributeFactory().newAttributeModifier("Hyperspeed", 10, AttributeModifier.Operation.MULTIPLY);
player.getAttributeValue("generic.movementSpeed").addModifier(mod);
```
Same deal, you can use the attribute name directly or get an `Attribute` instance from the factory.

It does not currently support custom attributes (as in, their effects implemented by plugins), but it would be fairly straightforward to extend it to do that.