### PR TITLE
Allow TNT to push players even when not dealing damage, fixes #149

### DIFF
--- a/CraftBukkit/0113-Allow-TNT-to-push-players-even-when-not-dealing-dama.patch
+++ b/CraftBukkit/0113-Allow-TNT-to-push-players-even-when-not-dealing-dama.patch
@@ -1,0 +1,26 @@
+From f5181272f7c2b9230c11a967f45ec9271023f7d7 Mon Sep 17 00:00:00 2001
+From: Kevin Phoenix <twizmwazin@gmail.com>
+Date: Sun, 7 Jun 2015 12:03:19 -0400
+Subject: [PATCH] Allow TNT to push players even when not dealing damage
+
+
+diff --git a/src/main/java/net/minecraft/server/Explosion.java b/src/main/java/net/minecraft/server/Explosion.java
+index 279af54..df77506 100644
+--- a/src/main/java/net/minecraft/server/Explosion.java
++++ b/src/main/java/net/minecraft/server/Explosion.java
+@@ -131,9 +131,12 @@ public class Explosion {
+                         CraftEventFactory.entityDamage = source;
+                         boolean wasDamaged = entity.damageEntity(DamageSource.explosion(this), (float) ((int) ((d13 * d13 + d13) / 2.0D * 8.0D * (double) f3 + 1.0D)));
+                         CraftEventFactory.entityDamage = null;
++                        /*
+                         if (!wasDamaged && entity instanceof EntityLiving) {
+                             continue;
+                         }
++                        */
++                        // This allows players to be pushed by TNT even if it did not damage them
+                         // CraftBukkit end
+ 
+                         double d14 = EnchantmentProtection.a(entity, d13);
+-- 
+2.4.2
+


### PR DESCRIPTION
This small patch reverts CraftBukkit commit [c8f17232cf6](https://hub.spigotmc.org/stash/projects/SPIGOT/repos/craftbukkit/commits/c8f17232cf6eacbebf9b7feb4763d22fedc6daec), and reintroduces [SPIGOT-161](https://hub.spigotmc.org/jira/browse/SPIGOT-161). The trade-off is that this fixes SportBukkit-149, which is arguably more important to OCN.

What the issue in CraftBukkit appears to be is that TNT deals 0 damage to a player, and then CraftBukkit doesn't apply velocity to the player as a result. It does not differentiate between TNT not dealing significant damage and a plugin intentionally cancelling the damage.