### PR TITLE
Add ExplosionPrimeByEntityEvent

### DIFF
--- a/Bukkit/0049-Add-ExplosionPrimeByEntityEvent.patch
+++ b/Bukkit/0049-Add-ExplosionPrimeByEntityEvent.patch
@@ -1,0 +1,49 @@
+From 054e5b383fb4e6b0809ee30ec6c53bc95bfb2950 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Sun, 14 Jun 2015 04:13:42 -0400
+Subject: [PATCH] Add ExplosionPrimeByEntityEvent
+
+
+diff --git a/src/main/java/org/bukkit/event/entity/ExplosionPrimeByEntityEvent.java b/src/main/java/org/bukkit/event/entity/ExplosionPrimeByEntityEvent.java
+new file mode 100644
+index 0000000..6b7d13f
+--- /dev/null
++++ b/src/main/java/org/bukkit/event/entity/ExplosionPrimeByEntityEvent.java
+@@ -0,0 +1,34 @@
++package org.bukkit.event.entity;
++
++import org.bukkit.entity.Entity;
++import org.bukkit.entity.Explosive;
++
++import static com.google.common.base.Preconditions.checkNotNull;
++
++/**
++ * Called when an entity has made another entity decide to explode, specifically when:
++ *  - a player activates a TNT block or Creeper with Flint & Steel
++ *  - an entity's explosion chains to a TNT block
++ *  - a flaming arrow activates a TNT block
++ *  - an entity damages an Ender Crystal
++ */
++public class ExplosionPrimeByEntityEvent extends ExplosionPrimeEvent {
++
++    private final Entity primer;
++
++    public ExplosionPrimeByEntityEvent(Entity what, float radius, boolean fire, Entity primer) {
++        super(what, radius, fire);
++        this.primer = checkNotNull(primer);
++    }
++
++    public ExplosionPrimeByEntityEvent(Explosive explosive, Entity primer) {
++        this(explosive, explosive.getYield(), explosive.isIncendiary(), primer);
++    }
++
++    /**
++     * @return The {@link Entity} that caused this entity to become primed
++     */
++    public Entity getPrimer() {
++        return primer;
++    }
++}
+-- 
+1.9.0
+

--- a/CraftBukkit/0111-Add-ExplosionPrimeByEntityEvent.patch
+++ b/CraftBukkit/0111-Add-ExplosionPrimeByEntityEvent.patch
@@ -1,0 +1,151 @@
+From 478eade930632296207f910ccb4d11cd637f6b8e Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Sun, 14 Jun 2015 04:13:52 -0400
+Subject: [PATCH] Add ExplosionPrimeByEntityEvent
+
+
+diff --git a/src/main/java/net/minecraft/server/BlockTNT.java b/src/main/java/net/minecraft/server/BlockTNT.java
+index 581e416..e269286 100644
+--- a/src/main/java/net/minecraft/server/BlockTNT.java
++++ b/src/main/java/net/minecraft/server/BlockTNT.java
+@@ -2,6 +2,7 @@ package net.minecraft.server;
+ 
+ public class BlockTNT extends Block {
+     boolean removeBlock = false; // CraftBukkit
++    Entity primer; // SportBukkit
+ 
+     public static final BlockStateBoolean EXPLODE = BlockStateBoolean.of("explode");
+ 
+@@ -33,7 +34,12 @@ public class BlockTNT extends Block {
+             EntityTNTPrimed entitytntprimed = new EntityTNTPrimed(world, (double) ((float) blockposition.getX() + 0.5F), (double) blockposition.getY(), (double) ((float) blockposition.getZ() + 0.5F), explosion.c());
+ 
+             // CraftBukkit start - allow exploded TNT to cancel priming
+-            org.bukkit.event.entity.ExplosionPrimeEvent event = new org.bukkit.event.entity.ExplosionPrimeEvent((org.bukkit.entity.Explosive) entitytntprimed.getBukkitEntity());
++            org.bukkit.event.entity.ExplosionPrimeEvent event;
++            if(explosion.source != null) {
++                event = new org.bukkit.event.entity.ExplosionPrimeByEntityEvent((org.bukkit.entity.Explosive) entitytntprimed.getBukkitEntity(), explosion.source.getBukkitEntity());
++            } else {
++                event = new org.bukkit.event.entity.ExplosionPrimeEvent((org.bukkit.entity.Explosive) entitytntprimed.getBukkitEntity());
++            }
+             world.getServer().getPluginManager().callEvent(event);
+ 
+             if (!event.isCancelled()) {
+@@ -57,7 +63,12 @@ public class BlockTNT extends Block {
+                 EntityTNTPrimed entitytntprimed = new EntityTNTPrimed(world, (double) ((float) blockposition.getX() + 0.5F), (double) blockposition.getY(), (double) ((float) blockposition.getZ() + 0.5F), entityliving);
+ 
+                 // CraftBukkit start - fire ExplosionPrimeEvent
+-                org.bukkit.event.entity.ExplosionPrimeEvent event = new org.bukkit.event.entity.ExplosionPrimeEvent((org.bukkit.entity.Explosive) entitytntprimed.getBukkitEntity());
++                org.bukkit.event.entity.ExplosionPrimeEvent event;
++                if(primer != null) {
++                    event = new org.bukkit.event.entity.ExplosionPrimeByEntityEvent((org.bukkit.entity.Explosive) entitytntprimed.getBukkitEntity(), primer.getBukkitEntity());
++                } else {
++                    event = new org.bukkit.event.entity.ExplosionPrimeEvent((org.bukkit.entity.Explosive) entitytntprimed.getBukkitEntity());
++                }
+                 world.getServer().getPluginManager().callEvent(event);
+ 
+                 if (event.isCancelled()) {
+@@ -77,7 +88,9 @@ public class BlockTNT extends Block {
+             Item item = entityhuman.bZ().getItem();
+ 
+             if (item == Items.FLINT_AND_STEEL || item == Items.FIRE_CHARGE) {
++                try { primer = entityhuman; // SportBukkit
+                 this.a(world, blockposition, iblockdata.set(BlockTNT.EXPLODE, Boolean.valueOf(true)), (EntityLiving) entityhuman);
++                } finally { primer = null; } // SportBukkit
+                 // CraftBukkit start - don't remove block if TNT priming is cancelled
+                 if (removeBlock) {
+                     world.setAir(blockposition);
+@@ -101,7 +114,9 @@ public class BlockTNT extends Block {
+             EntityArrow entityarrow = (EntityArrow) entity;
+ 
+             if (entityarrow.isBurning()) {
++                try { primer = entityarrow; // SportBukkit
+                 this.a(world, blockposition, world.getType(blockposition).set(BlockTNT.EXPLODE, Boolean.valueOf(true)), entityarrow.shooter instanceof EntityLiving ? (EntityLiving) entityarrow.shooter : null);
++                } finally { primer = null; } // SportBukkit
+                 world.setAir(blockposition);
+             }
+         }
+diff --git a/src/main/java/net/minecraft/server/EntityCreeper.java b/src/main/java/net/minecraft/server/EntityCreeper.java
+index 64215d5..77cae64 100644
+--- a/src/main/java/net/minecraft/server/EntityCreeper.java
++++ b/src/main/java/net/minecraft/server/EntityCreeper.java
+@@ -3,6 +3,7 @@ package net.minecraft.server;
+ // CraftBukkit start
+ import org.bukkit.craftbukkit.event.CraftEventFactory;
+ import org.bukkit.event.entity.ExplosionPrimeEvent;
++import org.bukkit.event.entity.ExplosionPrimeByEntityEvent;
+ // CraftBukkit end
+ 
+ public class EntityCreeper extends EntityMonster {
+@@ -13,6 +14,7 @@ public class EntityCreeper extends EntityMonster {
+     private int explosionRadius = 3;
+     private int bn = 0;
+     private int record = -1; // CraftBukkit
++    private Entity primer; // SportBukkit
+ 
+     public EntityCreeper(World world) {
+         super(world);
+@@ -93,7 +95,12 @@ public class EntityCreeper extends EntityMonster {
+             float radius = this.isPowered() ? 6.0F : 3.0F;
+ 
+             if (i > 0 && this.fuseTicks == 0) {
+-                ExplosionPrimeEvent event = new ExplosionPrimeEvent(this.getBukkitEntity(), radius, false);
++                ExplosionPrimeEvent event;
++                if(primer != null) {
++                    event = new ExplosionPrimeByEntityEvent(this.getBukkitEntity(), radius, false, primer.getBukkitEntity());
++                } else {
++                    event = new ExplosionPrimeEvent(this.getBukkitEntity(), radius, false);
++                }
+                 this.world.getServer().getPluginManager().callEvent(event);
+ 
+                 if (event.isCancelled()) {
+@@ -207,6 +214,7 @@ public class EntityCreeper extends EntityMonster {
+             this.world.makeSound(this.locX + 0.5D, this.locY + 0.5D, this.locZ + 0.5D, "fire.ignite", 1.0F, this.random.nextFloat() * 0.4F + 0.8F);
+             entityhuman.bw();
+             if (!this.world.isClientSide) {
++                this.primer = entityhuman; // SportBukkit
+                 this.co();
+                 itemstack.damage(1, entityhuman);
+                 return true;
+@@ -221,7 +229,12 @@ public class EntityCreeper extends EntityMonster {
+             boolean flag = this.world.getGameRules().getBoolean("mobGriefing");
+             float f = this.isPowered() ? 2.0F : 1.0F;
+ 
+-            ExplosionPrimeEvent event = new ExplosionPrimeEvent(this.getBukkitEntity(), this.explosionRadius * f, false);
++            ExplosionPrimeEvent event;
++            if(primer != null) {
++                event = new ExplosionPrimeByEntityEvent(this.getBukkitEntity(), this.explosionRadius * f, false, primer.getBukkitEntity());
++            } else {
++                event = new ExplosionPrimeEvent(this.getBukkitEntity(), this.explosionRadius * f, false);
++            }
+             this.world.getServer().getPluginManager().callEvent(event);
+             if (!event.isCancelled()) {
+                 this.world.createExplosion(this, this.locX, this.locY, this.locZ, event.getRadius(), event.getFire(), flag);
+diff --git a/src/main/java/net/minecraft/server/EntityEnderCrystal.java b/src/main/java/net/minecraft/server/EntityEnderCrystal.java
+index 07533e4..0e348cf 100644
+--- a/src/main/java/net/minecraft/server/EntityEnderCrystal.java
++++ b/src/main/java/net/minecraft/server/EntityEnderCrystal.java
+@@ -3,6 +3,7 @@ package net.minecraft.server;
+ // CraftBukkit start
+ import org.bukkit.craftbukkit.event.CraftEventFactory;
+ import org.bukkit.event.entity.ExplosionPrimeEvent;
++import org.bukkit.event.entity.ExplosionPrimeByEntityEvent;
+ // CraftBukkit end
+ 
+ public class EntityEnderCrystal extends Entity {
+@@ -69,7 +70,12 @@ public class EntityEnderCrystal extends Entity {
+                     this.die();
+                     if (!this.world.isClientSide) {
+                         // CraftBukkit start
+-                        ExplosionPrimeEvent event = new ExplosionPrimeEvent(this.getBukkitEntity(), 6.0F, false);
++                        ExplosionPrimeEvent event;
++                        if(damagesource.getEntity() != null) {
++                            event = new ExplosionPrimeByEntityEvent(this.getBukkitEntity(), 6.0F, false, ((Entity) damagesource.getEntity()).getBukkitEntity());
++                        } else {
++                            event = new ExplosionPrimeEvent(this.getBukkitEntity(), 6.0F, false);
++                        }
+                         this.world.getServer().getPluginManager().callEvent(event);
+                         if (event.isCancelled()) {
+                             this.dead = false;
+-- 
+1.9.0
+


### PR DESCRIPTION
Called when an entity has made another entity decide to explode, specifically when:
* a player activates a TNT block or Creeper with Flint & Steel
* an entity's explosion chains to a TNT block
* a flaming arrow activates a TNT block
* an entity damages an Ender Crystal