### PR TITLE
Fire events for potion effect changes

### DIFF
--- a/Bukkit/0054-Potion-effect-events.patch
+++ b/Bukkit/0054-Potion-effect-events.patch
@@ -1,0 +1,198 @@
+From d075f786a049288c35b969312e57270d1e1b9d6a Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Mon, 29 Jun 2015 04:38:33 -0400
+Subject: [PATCH] Potion effect events
+
+
+diff --git a/src/main/java/org/bukkit/event/entity/PotionEffectAddEvent.java b/src/main/java/org/bukkit/event/entity/PotionEffectAddEvent.java
+new file mode 100644
+index 0000000..a0e0634
+--- /dev/null
++++ b/src/main/java/org/bukkit/event/entity/PotionEffectAddEvent.java
+@@ -0,0 +1,32 @@
++package org.bukkit.event.entity;
++
++import org.bukkit.entity.LivingEntity;
++import org.bukkit.event.Cancellable;
++import org.bukkit.event.HandlerList;
++import org.bukkit.potion.PotionEffect;
++
++/**
++ * Called when a potion effect is applied to an entity, or an existing effect is extended or upgraded
++ */
++public class PotionEffectAddEvent extends PotionEffectEvent implements Cancellable {
++
++    private boolean cancelled;
++
++    public PotionEffectAddEvent(LivingEntity entity, PotionEffect effect) {
++        super(entity, effect);
++    }
++
++    @Override
++    public boolean isCancelled() {
++        return cancelled;
++    }
++
++    @Override
++    public void setCancelled(boolean cancel) {
++        this.cancelled = cancel;
++    }
++
++    private static final HandlerList handlers = new HandlerList();
++    @Override public HandlerList getHandlers() { return handlers; }
++    public static HandlerList getHandlerList() { return handlers; }
++}
+diff --git a/src/main/java/org/bukkit/event/entity/PotionEffectEvent.java b/src/main/java/org/bukkit/event/entity/PotionEffectEvent.java
+new file mode 100644
+index 0000000..b0571a6
+--- /dev/null
++++ b/src/main/java/org/bukkit/event/entity/PotionEffectEvent.java
+@@ -0,0 +1,23 @@
++package org.bukkit.event.entity;
++
++import org.bukkit.entity.LivingEntity;
++import org.bukkit.potion.PotionEffect;
++
++public abstract class PotionEffectEvent extends EntityEvent {
++
++    private final PotionEffect effect;
++
++    public PotionEffectEvent(LivingEntity what, PotionEffect effect) {
++        super(what);
++        this.effect = effect;
++    }
++
++    @Override
++    public LivingEntity getEntity() {
++        return (LivingEntity) super.getEntity();
++    }
++
++    public PotionEffect getEffect() {
++        return effect;
++    }
++}
+diff --git a/src/main/java/org/bukkit/event/entity/PotionEffectExpireEvent.java b/src/main/java/org/bukkit/event/entity/PotionEffectExpireEvent.java
+new file mode 100644
+index 0000000..0fc2840
+--- /dev/null
++++ b/src/main/java/org/bukkit/event/entity/PotionEffectExpireEvent.java
+@@ -0,0 +1,45 @@
++package org.bukkit.event.entity;
++
++import org.bukkit.entity.LivingEntity;
++import org.bukkit.potion.PotionEffect;
++
++/**
++ * Called when a potion effect on an entity runs out. Cancelling the event extends
++ * the effect with a practically infinite duration. The new duration can also be set
++ * explicitly by calling {@link #setDuration}.
++ *
++ * Handlers of {@link PotionEffectRemoveEvent} will also receive this event.
++ */
++public class PotionEffectExpireEvent extends PotionEffectRemoveEvent {
++
++    private int duration = 0;
++
++    public PotionEffectExpireEvent(LivingEntity entity, PotionEffect effect) {
++        super(entity, effect);
++    }
++
++    /**
++     * Get the new duration for the potion effect. This is initially 0.
++     */
++    public int getDuration() {
++        return duration;
++    }
++
++    /**
++     * Set a new duration for the potion effect. Passing 0 to this method un-cancels
++     * the event, and passing anything above 0 cancels it.
++     */
++    public void setDuration(int duration) {
++        this.duration = Math.max(0, duration);
++    }
++
++    @Override
++    public boolean isCancelled() {
++        return duration > 0;
++    }
++
++    @Override
++    public void setCancelled(boolean cancel) {
++        this.duration = cancel ? Integer.MAX_VALUE : 0;
++    }
++}
+diff --git a/src/main/java/org/bukkit/event/entity/PotionEffectExtendEvent.java b/src/main/java/org/bukkit/event/entity/PotionEffectExtendEvent.java
+new file mode 100644
+index 0000000..02164cf
+--- /dev/null
++++ b/src/main/java/org/bukkit/event/entity/PotionEffectExtendEvent.java
+@@ -0,0 +1,26 @@
++package org.bukkit.event.entity;
++
++import org.bukkit.entity.LivingEntity;
++import org.bukkit.potion.PotionEffect;
++
++/**
++ * Called when an entity's active potion effect is extended or upgraded.
++ *
++ * Handlers of {@link PotionEffectAddEvent} will also receive this event.
++ */
++public class PotionEffectExtendEvent extends PotionEffectAddEvent {
++
++    private final PotionEffect oldEffect;
++
++    public PotionEffectExtendEvent(LivingEntity entity, PotionEffect effect, PotionEffect oldEffect) {
++        super(entity, effect);
++        this.oldEffect = oldEffect;
++    }
++
++    /**
++     * Get the state of the potion effect prior to the change
++     */
++    public PotionEffect getOldEffect() {
++        return oldEffect;
++    }
++}
+diff --git a/src/main/java/org/bukkit/event/entity/PotionEffectRemoveEvent.java b/src/main/java/org/bukkit/event/entity/PotionEffectRemoveEvent.java
+new file mode 100644
+index 0000000..c95af16
+--- /dev/null
++++ b/src/main/java/org/bukkit/event/entity/PotionEffectRemoveEvent.java
+@@ -0,0 +1,33 @@
++package org.bukkit.event.entity;
++
++import org.bukkit.entity.LivingEntity;
++import org.bukkit.event.Cancellable;
++import org.bukkit.event.HandlerList;
++import org.bukkit.potion.PotionEffect;
++
++/**
++ * Called when a potion effect is removed from an entity for whatever reason
++ */
++public class PotionEffectRemoveEvent extends PotionEffectEvent implements Cancellable {
++
++    private boolean cancelled;
++
++    public PotionEffectRemoveEvent(LivingEntity entity, PotionEffect effect) {
++        super(entity, effect);
++    }
++
++    @Override
++    public boolean isCancelled() {
++        return cancelled;
++    }
++
++    @Override
++    public void setCancelled(boolean cancel) {
++        this.cancelled = cancel;
++    }
++
++    private static final HandlerList handlers = new HandlerList();
++    @Override public HandlerList getHandlers() { return handlers; }
++    public static HandlerList getHandlerList() { return handlers; }
++
++}
+-- 
+1.9.0
+

--- a/CraftBukkit/0117-Potion-effect-events.patch
+++ b/CraftBukkit/0117-Potion-effect-events.patch
@@ -1,0 +1,160 @@
+From 4074c0eb990e97652b3bf8e1f098684e3d4519e2 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Mon, 29 Jun 2015 04:47:28 -0400
+Subject: [PATCH] Potion effect events
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
+index 27b6d82..b17c72f 100644
+--- a/src/main/java/net/minecraft/server/EntityLiving.java
++++ b/src/main/java/net/minecraft/server/EntityLiving.java
+@@ -15,11 +15,16 @@ import java.util.ArrayList;
+ import com.google.common.base.Function;
+ import com.google.common.collect.Lists;
+ import org.bukkit.craftbukkit.event.CraftEventFactory;
++import org.bukkit.craftbukkit.potion.CraftPotionUtils;
+ import org.bukkit.entity.LivingEntity;
+ import org.bukkit.entity.Vehicle;
+ import org.bukkit.event.entity.EntityDamageEvent;
+ import org.bukkit.event.entity.EntityDamageEvent.DamageModifier;
+ import org.bukkit.event.entity.EntityRegainHealthEvent;
++import org.bukkit.event.entity.PotionEffectAddEvent;
++import org.bukkit.event.entity.PotionEffectExpireEvent;
++import org.bukkit.event.entity.PotionEffectExtendEvent;
++import org.bukkit.event.entity.PotionEffectRemoveEvent;
+ import org.bukkit.event.vehicle.VehicleExitEvent;
+ import org.bukkit.craftbukkit.entity.CraftLivingEntity;
+ // CraftBukkit end
+@@ -459,13 +464,24 @@ public abstract class EntityLiving extends Entity {
+     protected void bi() {
+         Iterator iterator = this.effects.keySet().iterator();
+ 
+-        isTickingEffects = true; // CraftBukkit
++        try { isTickingEffects = true; // CraftBukkit
+         while (iterator.hasNext()) {
+             Integer integer = (Integer) iterator.next();
+             MobEffect mobeffect = (MobEffect) this.effects.get(integer);
+ 
+             if (!mobeffect.tick(this)) {
+                 if (!this.world.isClientSide) {
++                    // SportBukkit start - fire event
++                    PotionEffectExpireEvent event = new PotionEffectExpireEvent((LivingEntity) this.getBukkitEntity(),
++                                                                                CraftPotionUtils.toBukkit(mobeffect));
++                    this.world.getServer().getPluginManager().callEvent(event);
++                    if(event.isCancelled()) {
++                        // Duration must be extended if event is cancelled
++                        CraftPotionUtils.extendDuration(mobeffect, event.getDuration());
++                        continue;
++                    }
++                    // SportBukkit end
++
+                     iterator.remove();
+                     this.b(mobeffect);
+                 }
+@@ -474,7 +490,7 @@ public abstract class EntityLiving extends Entity {
+             }
+         }
+         // CraftBukkit start
+-        isTickingEffects = false;
++        } finally { isTickingEffects = false; }
+         for (Object e : effectsToProcess) {
+             if (e instanceof MobEffect) {
+                 addEffect((MobEffect) e);
+@@ -553,8 +569,11 @@ public abstract class EntityLiving extends Entity {
+             MobEffect mobeffect = (MobEffect) this.effects.get(integer);
+ 
+             if (!this.world.isClientSide) {
+-                iterator.remove();
+-                this.b(mobeffect);
++                // SportBukkit start - go through method that fires event
++                this.removeEffect(integer);
++                //iterator.remove();
++                //this.b(mobeffect);
++                // SportBukkit end
+             }
+         }
+ 
+@@ -586,9 +605,24 @@ public abstract class EntityLiving extends Entity {
+         // CraftBukkit end
+         if (this.d(mobeffect)) {
+             if (this.effects.containsKey(Integer.valueOf(mobeffect.getEffectId()))) {
++                // SportBukkit start - fire event
++                PotionEffectExtendEvent event = new PotionEffectExtendEvent((LivingEntity) this.getBukkitEntity(),
++                                                                            CraftPotionUtils.toBukkit(mobeffect),
++                                                                            CraftPotionUtils.toBukkit(this.effects.get(mobeffect.getEffectId())));
++                this.world.getServer().getPluginManager().callEvent(event);
++                if(event.isCancelled()) return;
++                // SportBukkit end
++
+                 ((MobEffect) this.effects.get(Integer.valueOf(mobeffect.getEffectId()))).a(mobeffect);
+                 this.a((MobEffect) this.effects.get(Integer.valueOf(mobeffect.getEffectId())), true);
+             } else {
++                // SportBukkit start - fire event
++                PotionEffectAddEvent event = new PotionEffectAddEvent((LivingEntity) this.getBukkitEntity(),
++                                                                      CraftPotionUtils.toBukkit(mobeffect));
++                this.world.getServer().getPluginManager().callEvent(event);
++                if(event.isCancelled()) return;
++                // SportBukkit end
++
+                 this.effects.put(Integer.valueOf(mobeffect.getEffectId()), mobeffect);
+                 this.a(mobeffect);
+             }
+@@ -622,6 +656,16 @@ public abstract class EntityLiving extends Entity {
+         MobEffect mobeffect = (MobEffect) this.effects.remove(Integer.valueOf(i));
+ 
+         if (mobeffect != null) {
++            // SportBukkit start
++            PotionEffectRemoveEvent event = new PotionEffectRemoveEvent((LivingEntity) this.getBukkitEntity(),
++                                                                        CraftPotionUtils.toBukkit(mobeffect));
++            this.world.getServer().getPluginManager().callEvent(event);
++            if(event.isCancelled()) {
++                this.effects.put(i, mobeffect);
++                return;
++            }
++            // SportBukkit end
++
+             this.b(mobeffect);
+         }
+ 
+diff --git a/src/main/java/org/bukkit/craftbukkit/potion/CraftPotionUtils.java b/src/main/java/org/bukkit/craftbukkit/potion/CraftPotionUtils.java
+new file mode 100644
+index 0000000..1374199
+--- /dev/null
++++ b/src/main/java/org/bukkit/craftbukkit/potion/CraftPotionUtils.java
+@@ -0,0 +1,33 @@
++package org.bukkit.craftbukkit.potion;
++
++import net.minecraft.server.MobEffect;
++import org.bukkit.potion.PotionEffect;
++import org.bukkit.potion.PotionEffectType;
++
++public class CraftPotionUtils {
++    private CraftPotionUtils() {}
++
++    public static PotionEffect toBukkit(MobEffect effect) {
++        return new PotionEffect(PotionEffectType.getById(effect.getEffectId()),
++                                effect.getDuration(),
++                                effect.getAmplifier(),
++                                effect.isAmbient(),
++                                effect.isShowParticles());
++    }
++
++    public static MobEffect toNMS(PotionEffect effect) {
++        return new MobEffect(effect.getType().getId(),
++                             effect.getDuration(),
++                             effect.getAmplifier(),
++                             effect.isAmbient(),
++                             effect.hasParticles());
++    }
++
++    public static MobEffect cloneWithDuration(MobEffect effect, int duration) {
++        return new MobEffect(effect.getEffectId(), duration, effect.getAmplifier(), effect.isAmbient(), effect.isShowParticles());
++    }
++
++    public static void extendDuration(MobEffect effect, int duration) {
++        effect.a(cloneWithDuration(effect, duration));
++    }
++}
+-- 
+1.9.0
+


### PR DESCRIPTION
Adds four new events:
`PotionEffectAddEvent` - Effect added to an entity
`PotionEffectExtendEvent` - Existing effect extended (subclass of above)
`PotionEffectRemoveEvent` - Effect removed
`PotionEffectExpireEvent` - Effect removed due to timer running out (subclass of above)