### PR TITLE
Bulk read/write of cuboid block volumes

### DIFF
--- a/Bukkit/0055-Block-images.patch
+++ b/Bukkit/0055-Block-images.patch
@@ -1,0 +1,286 @@
+From 6302985623480e93f0a7342a7eef2c0549ee3fea Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Wed, 1 Jul 2015 12:40:49 -0400
+Subject: [PATCH] Block images
+
+
+diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
+index 89d5a41..37918e4 100644
+--- a/src/main/java/org/bukkit/Bukkit.java
++++ b/src/main/java/org/bukkit/Bukkit.java
+@@ -14,6 +14,7 @@ import java.util.logging.Logger;
+ 
+ import org.bukkit.Warning.WarningState;
+ import org.bukkit.attributes.AttributeFactory;
++import org.bukkit.block.RegionFactory;
+ import org.bukkit.command.CommandException;
+ import org.bukkit.command.CommandMap;
+ import org.bukkit.command.CommandSender;
+@@ -1091,6 +1092,13 @@ public final class Bukkit {
+     }
+ 
+     /**
++     * Get the region factory.
++     */
++    public static RegionFactory getRegionFactory() {
++        return server.getRegionFactory();
++    }
++
++    /**
+      * Gets the instance of the scoreboard manager.
+      * <p>
+      * This will only exist after the first world has loaded.
+diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
+index 6eca79c..4e64c28 100644
+--- a/src/main/java/org/bukkit/Server.java
++++ b/src/main/java/org/bukkit/Server.java
+@@ -14,6 +14,7 @@ import java.util.logging.Logger;
+ 
+ import org.bukkit.Warning.WarningState;
+ import org.bukkit.attributes.AttributeFactory;
++import org.bukkit.block.RegionFactory;
+ import org.bukkit.command.CommandException;
+ import org.bukkit.command.CommandMap;
+ import org.bukkit.command.CommandSender;
+@@ -904,6 +905,11 @@ public interface Server extends PluginMessageRecipient {
+     ItemFactory getItemFactory();
+ 
+     /**
++     * Get the region factory.
++     */
++    RegionFactory getRegionFactory();
++
++    /**
+      * Gets the instance of the scoreboard manager.
+      * <p>
+      * This will only exist after the first world has loaded.
+diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
+index 3511f7d..c6cbac5 100644
+--- a/src/main/java/org/bukkit/World.java
++++ b/src/main/java/org/bukkit/World.java
+@@ -1,6 +1,10 @@
+ package org.bukkit;
+ 
+ import java.io.File;
++
++import org.bukkit.block.BlockImage;
++import org.bukkit.block.BlockPosition;
++import org.bukkit.block.BlockRegion;
+ import org.bukkit.generator.ChunkGenerator;
+ import java.util.Collection;
+ import java.util.HashMap;
+@@ -1244,6 +1248,28 @@ public interface World extends PluginMessageRecipient, Metadatable {
+     public WorldBorder getWorldBorder();
+ 
+     /**
++     * Copy block states in the specified region to a saved image.
++     * @return A copy of the specified block states
++     */
++    BlockImage copyBlocks(BlockRegion region, boolean includeAir, boolean clearSource);
++
++    /**
++     * Copy block states in the given saved image to the given position
++     * in this world.
++     * @param image Block image to copy
++     * @param offset Offset of copied blocks from their original position in the image.
++     * @return The number of blocks in this world affected by the operation.
++     */
++    int pasteBlocks(BlockImage image, BlockPosition offset);
++
++    /**
++     * Copy block states in the given saved image to their original position.
++     * @param image Block image to copy
++     * @return The number of blocks in this world affected by the operation.
++     */
++    int pasteBlocks(BlockImage image);
++
++    /**
+      * Represents various map environment types that a world may be
+      */
+     public enum Environment {
+diff --git a/src/main/java/org/bukkit/block/BlockImage.java b/src/main/java/org/bukkit/block/BlockImage.java
+new file mode 100644
+index 0000000..c7ed2ad
+--- /dev/null
++++ b/src/main/java/org/bukkit/block/BlockImage.java
+@@ -0,0 +1,30 @@
++package org.bukkit.block;
++
++import java.util.UUID;
++
++import org.bukkit.World;
++
++/**
++ * A set of saved block states.
++ * TODO: Provide a way to actually get {@link BlockState}s from one of these.
++ */
++public interface BlockImage {
++    /**
++     * Unique ID of the {@link World} this image was created from.
++     * This world may or may not still exist. This object does not hold any
++     * reference to the world it came from.
++     */
++    UUID getWorldId();
++
++    /**
++     * The {@link World} this image was created from, or null if
++     * that world is not currently loaded.
++     */
++    World getWorld();
++
++    /**
++     * The set of blocks included in this image. Any blocks excluded from the image
++     * (e.g. air blocks) will also be exlcuded from this region.
++     */
++    BlockRegion getRegion();
++}
+diff --git a/src/main/java/org/bukkit/block/BlockPosition.java b/src/main/java/org/bukkit/block/BlockPosition.java
+new file mode 100644
+index 0000000..4e5cf1b
+--- /dev/null
++++ b/src/main/java/org/bukkit/block/BlockPosition.java
+@@ -0,0 +1,37 @@
++package org.bukkit.block;
++
++/**
++ * Represents the coordinates of a block. Though this interface has no mutating methods,
++ * implementations are not necessarily immutable.
++ *
++ * TODO: More transforms, support for this in other parts of the Bukkit API
++ */
++public interface BlockPosition extends Cloneable {
++
++    int getBlockX();
++
++    int getBlockY();
++
++    int getBlockZ();
++
++    /**
++     * Are the block coordinates of this object all zero?
++     */
++    boolean isBlockZero();
++
++    /**
++     * Return a block position equal to this one translated by the given
++     * offset. The translation is performed in block space, in other words,
++     * the block coordinates of the returned object will be the sum of
++     * the block coordinates of this object and the given offset.
++     *
++     * This method is guaranteed not to modify this object. If the offset
++     * is zero, it may return this object.
++     */
++    BlockPosition translate(BlockPosition offset);
++
++    /**
++     * Return a new position object that is equal to this one.
++     */
++    BlockPosition clone();
++}
+diff --git a/src/main/java/org/bukkit/block/BlockPositionIterator.java b/src/main/java/org/bukkit/block/BlockPositionIterator.java
+new file mode 100644
+index 0000000..4ccef6b
+--- /dev/null
++++ b/src/main/java/org/bukkit/block/BlockPositionIterator.java
+@@ -0,0 +1,17 @@
++package org.bukkit.block;
++
++import java.util.Iterator;
++
++/**
++ * A mutable {@link BlockPosition} used to iterate over some sequence of values.
++ * The iterator itself takes on the values it is iterating over, and returns itself
++ * from the {@link #next()} method, thus avoiding creating a new object for each iteration.
++ *
++ * The {@link #next()} method must be called at least once before reading the
++ * value of the iterator i.e. before calling any of the methods in {@link BlockPosition}.
++ * The result of calling these methods before the first iteration is undefined.
++ * If iterating over an empty sequence, the iterator cannot be advanced and thus
++ * never has a defined value.
++ */
++public interface BlockPositionIterator extends BlockPosition, Iterator<BlockPosition> {
++}
+diff --git a/src/main/java/org/bukkit/block/BlockRegion.java b/src/main/java/org/bukkit/block/BlockRegion.java
+new file mode 100644
+index 0000000..32a3caf
+--- /dev/null
++++ b/src/main/java/org/bukkit/block/BlockRegion.java
+@@ -0,0 +1,12 @@
++package org.bukkit.block;
++
++/**
++ * Represents a set of block coordinates, and supports iteration over them and tests for inclusion.
++ */
++public interface BlockRegion extends Iterable<BlockPosition> {
++
++    boolean contains(BlockPosition position);
++
++    @Override
++    BlockPositionIterator iterator();
++}
+diff --git a/src/main/java/org/bukkit/block/RegionFactory.java b/src/main/java/org/bukkit/block/RegionFactory.java
+new file mode 100644
+index 0000000..87cc429
+--- /dev/null
++++ b/src/main/java/org/bukkit/block/RegionFactory.java
+@@ -0,0 +1,17 @@
++package org.bukkit.block;
++
++/**
++ * It makes regions.
++ */
++public interface RegionFactory {
++
++    /**
++     * @return a cuboid shaped region with the given minimum-valued corner and size
++     */
++    BlockRegion cuboid(BlockPosition origin, BlockPosition size);
++
++    /**
++     * @return the given region translated by the given offset. If the offset is zero, it may return the same region given.
++     */
++    BlockRegion translate(BlockRegion region, BlockPosition offset);
++}
+diff --git a/src/main/java/org/bukkit/util/Vector.java b/src/main/java/org/bukkit/util/Vector.java
+index 685148e..03d9601 100644
+--- a/src/main/java/org/bukkit/util/Vector.java
++++ b/src/main/java/org/bukkit/util/Vector.java
+@@ -5,6 +5,7 @@ import java.util.Map;
+ import java.util.Random;
+ import org.bukkit.Location;
+ import org.bukkit.World;
++import org.bukkit.block.BlockPosition;
+ import org.bukkit.configuration.serialization.ConfigurationSerializable;
+ import org.bukkit.configuration.serialization.SerializableAs;
+ import static org.bukkit.util.NumberConversions.checkFinite;
+@@ -16,7 +17,7 @@ import static org.bukkit.util.NumberConversions.checkFinite;
+  * <code>clone()</code> in order to get a copy.
+  */
+ @SerializableAs("Vector")
+-public class Vector implements Cloneable, ConfigurationSerializable {
++public class Vector implements Cloneable, ConfigurationSerializable, BlockPosition {
+     private static final long serialVersionUID = -2657651106777219169L;
+ 
+     private static Random random = new Random();
+@@ -78,6 +79,18 @@ public class Vector implements Cloneable, ConfigurationSerializable {
+         this.z = z;
+     }
+ 
++    @Override
++    public boolean isBlockZero() {
++        return x == 0d && y == 0d && z == 0d;
++    }
++
++    @Override
++    public Vector translate(BlockPosition offset) {
++        return new Vector(x + offset.getBlockX(),
++                          y + offset.getBlockY(),
++                          z + offset.getBlockZ());
++    }
++
+     /**
+      * Adds a vector to this one
+      *
+-- 
+1.9.0
+

--- a/CraftBukkit/0118-Block-images.patch
+++ b/CraftBukkit/0118-Block-images.patch
@@ -1,0 +1,628 @@
+From 950f1a1a7b642b1239941c90a32da1e4366180f3 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Wed, 1 Jul 2015 12:42:37 -0400
+Subject: [PATCH] Block images
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+index 067fda2..c006200 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+@@ -37,6 +37,7 @@ import org.bukkit.World;
+ import org.bukkit.World.Environment;
+ import org.bukkit.WorldCreator;
+ import org.bukkit.attributes.AttributeFactory;
++import org.bukkit.block.RegionFactory;
+ import org.bukkit.command.Command;
+ import org.bukkit.command.CommandException;
+ import org.bukkit.command.CommandSender;
+@@ -48,6 +49,7 @@ import org.bukkit.configuration.file.YamlConfiguration;
+ import org.bukkit.configuration.serialization.ConfigurationSerialization;
+ import org.bukkit.conversations.Conversable;
+ import org.bukkit.craftbukkit.attributes.CraftAttributeFactory;
++import org.bukkit.craftbukkit.block.CraftRegionFactory;
+ import org.bukkit.craftbukkit.command.VanillaCommandWrapper;
+ import org.bukkit.craftbukkit.entity.CraftPlayer;
+ import org.bukkit.craftbukkit.help.SimpleHelpMap;
+@@ -1661,6 +1663,11 @@ public final class CraftServer implements Server {
+     }
+ 
+     @Override
++    public RegionFactory getRegionFactory() {
++        return CraftRegionFactory.instance();
++    }
++
++    @Override
+     public CraftScoreboardManager getScoreboardManager() {
+         return scoreboardManager;
+     }
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+index d0a579b..fb02b58 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+@@ -28,8 +28,12 @@ import org.bukkit.WorldBorder;
+ import org.bukkit.block.Biome;
+ import org.bukkit.block.Block;
+ import org.bukkit.block.BlockFace;
++import org.bukkit.block.BlockImage;
++import org.bukkit.block.BlockRegion;
+ import org.bukkit.block.BlockState;
+ import org.bukkit.craftbukkit.block.CraftBlock;
++import org.bukkit.craftbukkit.block.CraftBlockPosition;
++import org.bukkit.craftbukkit.block.CraftBlockImage;
+ import org.bukkit.craftbukkit.block.CraftBlockState;
+ import org.bukkit.craftbukkit.entity.*;
+ import org.bukkit.craftbukkit.inventory.CraftItemStack;
+@@ -1431,4 +1435,19 @@ public class CraftWorld implements World {
+             cps.queueUnload(chunk.locX, chunk.locZ);
+         }
+     }
++
++    @Override
++    public BlockImage copyBlocks(BlockRegion region, boolean includeAir, boolean clearSource) {
++        return new CraftBlockImage(this, region, includeAir, clearSource);
++    }
++
++    @Override
++    public int pasteBlocks(BlockImage image, org.bukkit.block.BlockPosition offset) {
++        return ((CraftBlockImage) image).write(this, offset);
++    }
++
++    @Override
++    public int pasteBlocks(BlockImage image) {
++        return pasteBlocks(image, CraftBlockPosition.zero());
++    }
+ }
+diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlockImage.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlockImage.java
+new file mode 100644
+index 0000000..665ea5b
+--- /dev/null
++++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlockImage.java
+@@ -0,0 +1,242 @@
++package org.bukkit.craftbukkit.block;
++
++import java.util.ArrayList;
++import java.util.HashSet;
++import java.util.List;
++import java.util.Set;
++import java.util.UUID;
++
++import com.google.common.collect.Iterables;
++import net.minecraft.server.BlockPosition;
++import net.minecraft.server.Blocks;
++import net.minecraft.server.IBlockData;
++import net.minecraft.server.IInventory;
++import net.minecraft.server.NBTTagCompound;
++import net.minecraft.server.NextTickListEntry;
++import net.minecraft.server.StructureBoundingBox;
++import net.minecraft.server.TileEntity;
++import org.bukkit.Bukkit;
++import org.bukkit.World;
++import org.bukkit.block.BlockImage;
++import org.bukkit.block.BlockPositionIterator;
++import org.bukkit.block.BlockRegion;
++import org.bukkit.craftbukkit.CraftWorld;
++
++/**
++ * Read/write algorithms are derived from the code for the /clone command,
++ * which can be found in {@link net.minecraft.server.CommandClone}.
++ */
++public class CraftBlockImage implements BlockImage {
++
++    static class BlockRecord extends CraftBlockPosition {
++        final IBlockData blockData;
++        final NBTTagCompound tileEntityData;
++
++        public BlockRecord(org.bukkit.block.BlockPosition pos, IBlockData blockData, NBTTagCompound tileEntityData) {
++            super(pos.getBlockX(), pos.getBlockY(), pos.getBlockZ());
++            this.blockData = blockData;
++            this.tileEntityData = tileEntityData;
++        }
++    }
++
++    private final UUID worldId;
++
++    private final Set<BlockPosition> blockSet = new HashSet<BlockPosition>();
++    private final List<BlockRecord> earlyBlocks = new ArrayList<BlockRecord>();
++    private final List<BlockRecord> tileEntities = new ArrayList<BlockRecord>();
++    private final List<BlockRecord> lateBlocks = new ArrayList<BlockRecord>();
++
++    private long tickTime;
++    private final List<NextTickListEntry> tickListEntries = new ArrayList<NextTickListEntry>();
++
++    public CraftBlockImage(CraftWorld world, BlockRegion region, boolean includeAir, boolean clearSource) {
++        this.worldId = world.getUID();
++        read(world, region, includeAir, clearSource);
++    }
++
++    private void read(CraftWorld craftWorld, BlockRegion region, boolean includeAir, boolean clearSource) {
++        net.minecraft.server.WorldServer world = craftWorld.getHandle();
++        boolean oldForceChunkLoad = world.chunkProviderServer.forceChunkLoad;
++
++        try {
++            world.chunkProviderServer.forceChunkLoad = true;
++
++            for(org.bukkit.block.BlockPosition position : region) {
++                // Avoid creating any objects for air blocks, as long as the region
++                // iterator is spitting out NMS BlockPositions.
++                BlockPosition nmsPosition = CraftBlockPosition.nms(position);
++                IBlockData blockData = world.getType(nmsPosition);
++
++                if(includeAir || blockData.getBlock() != Blocks.AIR) {
++                    BlockRecord block;
++
++                    TileEntity tileEntity = world.getTileEntity(nmsPosition);
++                    if(tileEntity != null) {
++                        block = new BlockRecord(position, blockData, new NBTTagCompound());
++                        tileEntity.b(block.tileEntityData);
++                        tileEntities.add(block);
++
++                        if(clearSource && tileEntity instanceof IInventory) {
++                            ((IInventory) tileEntity).l(); // Clear inventory
++                        }
++                    } else {
++                        block = new BlockRecord(position, blockData, null);
++                        if (!block.blockData.getBlock().o() && // flammable
++                            !block.blockData.getBlock().d()) { // full-sized
++                            lateBlocks.add(block);
++                        } else {
++                            earlyBlocks.add(block);
++                        }
++                    }
++
++                    blockSet.add(block);
++                }
++            }
++
++            if(clearSource) {
++                Iterable<BlockRecord> clearPositions = Iterables.concat(lateBlocks, tileEntities, earlyBlocks);
++
++                for(BlockRecord block : clearPositions) {
++                    if(block.tileEntityData != null) {
++                        TileEntity tileEntity = world.getTileEntity(block);
++                        if(tileEntity instanceof IInventory) {
++                            ((IInventory) tileEntity).l();
++                        }
++                    }
++                    world.setTypeAndData(block, Blocks.BARRIER.getBlockData(), 2);
++                }
++
++                for(BlockRecord block : clearPositions) {
++                    world.setTypeAndData(block, Blocks.AIR.getBlockData(), 3);
++                }
++            }
++
++            this.tickTime = world.getWorldData().getTime();
++
++            List<NextTickListEntry> ticks = world.a(new StructureBoundingBox(Integer.MIN_VALUE, Integer.MIN_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE), false);
++            if(ticks != null) {
++                for(NextTickListEntry tick : ticks) {
++                    if(blockSet.contains(tick.a)) {
++                        tickListEntries.add(tick);
++                    }
++                }
++            }
++        } finally {
++            world.chunkProviderServer.forceChunkLoad = oldForceChunkLoad;
++        }
++    }
++
++    public int write(CraftWorld craftWorld, org.bukkit.block.BlockPosition offset) {
++        net.minecraft.server.WorldServer world = craftWorld.getHandle();
++        boolean oldForceChunkLoad = world.chunkProviderServer.forceChunkLoad;
++
++        try {
++            world.chunkProviderServer.forceChunkLoad = true;
++            BlockPosition delta = CraftBlockPosition.nms(offset);
++
++            Iterable<BlockRecord> allBlocks = Iterables.concat(earlyBlocks, tileEntities, lateBlocks);
++            Iterable<BlockRecord> reversedBlocks = Iterables.concat(lateBlocks, tileEntities, earlyBlocks);
++
++            for(BlockRecord block : reversedBlocks) {
++                BlockPosition destPos = block.a(delta);
++                TileEntity tileEntity = world.getTileEntity(destPos);
++                if (tileEntity instanceof IInventory) {
++                    ((IInventory) tileEntity).l(); // Clear inventory
++                }
++                world.setTypeAndData(destPos, Blocks.BARRIER.getBlockData(), 2);
++            }
++
++            int affectedBlocks = 0;
++
++            for(BlockRecord block : allBlocks) {
++                if(world.setTypeAndData(block.a(delta), block.blockData, 2)) {
++                    ++affectedBlocks;
++                }
++            }
++
++            for(BlockRecord block : tileEntities) {
++                BlockPosition destPos = block.a(delta);
++                TileEntity tileEntity = world.getTileEntity(destPos);
++
++                if(block.tileEntityData != null && tileEntity != null) {
++                    block.tileEntityData.setInt("x", destPos.getX());
++                    block.tileEntityData.setInt("y", destPos.getY());
++                    block.tileEntityData.setInt("z", destPos.getZ());
++
++                    tileEntity.a(block.tileEntityData);
++                    tileEntity.update();
++                }
++
++                world.setTypeAndData(destPos, block.blockData, 2);
++            }
++
++            for(BlockRecord block : reversedBlocks) {
++                world.update(block.a(delta), block.blockData.getBlock());
++            }
++
++            if(tickListEntries != null) {
++                for(NextTickListEntry entry : tickListEntries) {
++                    world.b(entry.a.a(delta), entry.a(), (int) (entry.b - tickTime), entry.c);
++                }
++            }
++
++            return affectedBlocks;
++        } finally {
++            world.chunkProviderServer.forceChunkLoad = oldForceChunkLoad;
++        }
++    }
++
++    @Override
++    public UUID getWorldId() {
++        return worldId;
++    }
++
++    @Override
++    public World getWorld() {
++        return Bukkit.getWorld(getWorldId());
++    }
++
++    @Override
++    public BlockRegion getRegion() {
++        return new Region();
++    }
++
++    class Region implements BlockRegion {
++        @Override
++        public boolean contains(org.bukkit.block.BlockPosition position) {
++            if(position instanceof BlockPosition) {
++                return blockSet.contains(position);
++            } else {
++                return blockSet.contains(new BlockPosition(position.getBlockX(), position.getBlockY(), position.getBlockZ()));
++            }
++        }
++
++        @Override
++        public BlockPositionIterator iterator() {
++            return new Iterator();
++        }
++
++        class Iterator extends CraftMutableBlockPosition implements BlockPositionIterator {
++            private final java.util.Iterator<BlockPosition> iter = blockSet.iterator();
++
++            @Override
++            public boolean hasNext() {
++                return iter.hasNext();
++            }
++
++            @Override
++            public org.bukkit.block.BlockPosition next() {
++                BlockPosition position = iter.next();
++                set(position.getX(),
++                    position.getY(),
++                    position.getZ());
++                return this;
++            }
++
++            @Override
++            public void remove() {
++                throw new UnsupportedOperationException();
++            }
++        }
++    }
++}
+diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlockPosition.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlockPosition.java
+new file mode 100644
+index 0000000..8e9dac3
+--- /dev/null
++++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlockPosition.java
+@@ -0,0 +1,71 @@
++package org.bukkit.craftbukkit.block;
++
++import net.minecraft.server.BaseBlockPosition;
++import org.bukkit.block.BlockPosition;
++
++public class CraftBlockPosition extends net.minecraft.server.BlockPosition implements org.bukkit.block.BlockPosition {
++
++    public CraftBlockPosition(int x, int y, int z) {
++        super(x, y, z);
++    }
++
++    public CraftBlockPosition(BlockPosition that) {
++        this(that.getBlockX(), that.getBlockY(), that.getBlockZ());
++    }
++
++    public CraftBlockPosition(BlockPosition base, BlockPosition offset) {
++        this(base.getBlockX() + offset.getBlockX(),
++             base.getBlockY() + offset.getBlockY(),
++             base.getBlockZ() + offset.getBlockZ());
++    }
++
++    @Override
++    public int getBlockX() {
++        return getX();
++    }
++
++    @Override
++    public int getBlockY() {
++        return getY();
++    }
++
++    @Override
++    public int getBlockZ() {
++        return getZ();
++    }
++
++    @Override
++    public boolean isBlockZero() {
++        return getX() == 0 && getY() == 0 && getZ() == 0;
++    }
++
++    @Override
++    public int compareTo(BaseBlockPosition that) {
++        return g(that);
++    }
++
++    @Override
++    public BlockPosition clone() {
++        return new CraftBlockPosition(this);
++    }
++
++    @Override
++    public BlockPosition translate(BlockPosition offset) {
++        if(isBlockZero()) {
++            return this;
++        } else {
++            return new CraftBlockPosition(this, offset);
++        }
++    }
++
++    private static final CraftBlockPosition ZERO = new CraftBlockPosition(0, 0, 0);
++    public static CraftBlockPosition zero() { return ZERO; }
++
++    public static net.minecraft.server.BlockPosition nms(BlockPosition position) {
++        if(position instanceof net.minecraft.server.BlockPosition) {
++            return (net.minecraft.server.BlockPosition) position;
++        } else {
++            return new CraftBlockPosition(position);
++        }
++    }
++}
+diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftCuboidRegion.java b/src/main/java/org/bukkit/craftbukkit/block/CraftCuboidRegion.java
+new file mode 100644
+index 0000000..5b2a509
+--- /dev/null
++++ b/src/main/java/org/bukkit/craftbukkit/block/CraftCuboidRegion.java
+@@ -0,0 +1,78 @@
++package org.bukkit.craftbukkit.block;
++
++import java.util.NoSuchElementException;
++
++import org.bukkit.block.BlockPosition;
++import org.bukkit.block.BlockPositionIterator;
++import org.bukkit.block.BlockRegion;
++
++public class CraftCuboidRegion implements BlockRegion {
++
++    private final BlockPosition min;
++    private final BlockPosition max; // Upper bound is exclusive
++
++    public CraftCuboidRegion(BlockPosition min, BlockPosition max) {
++        this.min = new CraftBlockPosition(min);
++        this.max = new CraftBlockPosition(max);
++    }
++
++    @Override
++    public boolean contains(BlockPosition position) {
++        return min.getBlockX() < position.getBlockX() && position.getBlockX() < max.getBlockX() &&
++               min.getBlockY() < position.getBlockY() && position.getBlockY() < max.getBlockY() &&
++               min.getBlockZ() < position.getBlockZ() && position.getBlockZ() < max.getBlockZ();
++    }
++
++    @Override
++    public BlockPositionIterator iterator() {
++        return new Iterator();
++    }
++
++    class Iterator extends CraftMutableBlockPosition implements BlockPositionIterator {
++        private final int xMin, yMin;
++        private final int xMax, yMax, zMax;
++        private int xNext, yNext, zNext;
++        private boolean hasNext;
++
++        public Iterator() {
++            this.x = this.xNext = this.xMin = min.getBlockX();
++            this.y = this.yNext = this.yMin = min.getBlockY();
++            this.z = this.zNext = min.getBlockZ();
++            this.xMax = max.getBlockX();
++            this.yMax = max.getBlockY();
++            this.zMax = max.getBlockZ();
++            this.hasNext = x < xMax && y < yMax && z < zMax;
++        }
++
++        @Override
++        public boolean hasNext() {
++            return hasNext;
++        }
++
++        @Override
++        public BlockPosition next() {
++            if(!hasNext) {
++                throw new NoSuchElementException();
++            }
++
++            set(xNext, yNext, zNext);
++
++            if(++xNext >= xMax) {
++                xNext = xMin;
++                if(++yNext >= yMax) {
++                    yNext = yMin;
++                    if(++zNext >= zMax) {
++                        hasNext = false;
++                    }
++                }
++            }
++
++            return this;
++        }
++
++        @Override
++        public void remove() {
++            throw new UnsupportedOperationException();
++        }
++    }
++}
+diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftMutableBlockPosition.java b/src/main/java/org/bukkit/craftbukkit/block/CraftMutableBlockPosition.java
+new file mode 100644
+index 0000000..a927caa
+--- /dev/null
++++ b/src/main/java/org/bukkit/craftbukkit/block/CraftMutableBlockPosition.java
+@@ -0,0 +1,45 @@
++package org.bukkit.craftbukkit.block;
++
++import org.bukkit.block.BlockPosition;
++
++/**
++ * We know this will work because the NMS code does it too
++ * (see {@link net.minecraft.server.BlockPosition.MutableBlockPosition}).
++ * All other methods apparently go through the getX/Y/Z methods.
++ * However, we can't use their version because it's final.
++ */
++public class CraftMutableBlockPosition extends CraftBlockPosition {
++
++    protected int x, y, z;
++
++    public CraftMutableBlockPosition() {
++        super(0, 0, 0);
++    }
++
++    @Override
++    public int getX() {
++        return x;
++    }
++
++    @Override
++    public int getY() {
++        return y;
++    }
++
++    @Override
++    public int getZ() {
++        return z;
++    }
++
++    protected void set(int x, int y, int z) {
++        this.x = x;
++        this.y = y;
++        this.z = z;
++    }
++
++    @Override
++    public BlockPosition translate(BlockPosition offset) {
++        // Always make a copy
++        return new CraftBlockPosition(this, offset);
++    }
++}
+diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftRegionFactory.java b/src/main/java/org/bukkit/craftbukkit/block/CraftRegionFactory.java
+new file mode 100644
+index 0000000..ec36c59
+--- /dev/null
++++ b/src/main/java/org/bukkit/craftbukkit/block/CraftRegionFactory.java
+@@ -0,0 +1,27 @@
++package org.bukkit.craftbukkit.block;
++
++import org.bukkit.block.BlockPosition;
++import org.bukkit.block.BlockRegion;
++import org.bukkit.block.RegionFactory;
++
++public class CraftRegionFactory implements RegionFactory {
++
++    private static final CraftRegionFactory INSTANCE = new CraftRegionFactory();
++    public static CraftRegionFactory instance() { return INSTANCE; }
++
++    private CraftRegionFactory() {}
++
++    @Override
++    public BlockRegion cuboid(BlockPosition origin, BlockPosition size) {
++        return new CraftCuboidRegion(origin, origin.translate(size));
++    }
++
++    @Override
++    public BlockRegion translate(BlockRegion region, BlockPosition offset) {
++        if(offset.isBlockZero()) {
++            return region;
++        } else {
++            return new CraftTranslatedRegion(region, offset);
++        }
++    }
++}
+diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftTranslatedRegion.java b/src/main/java/org/bukkit/craftbukkit/block/CraftTranslatedRegion.java
+new file mode 100644
+index 0000000..5b27c56
+--- /dev/null
++++ b/src/main/java/org/bukkit/craftbukkit/block/CraftTranslatedRegion.java
+@@ -0,0 +1,51 @@
++package org.bukkit.craftbukkit.block;
++
++import org.bukkit.block.BlockPosition;
++import org.bukkit.block.BlockPositionIterator;
++import org.bukkit.block.BlockRegion;
++
++public class CraftTranslatedRegion implements BlockRegion {
++
++    private final BlockRegion region;
++    private final BlockPosition offset;
++
++    public CraftTranslatedRegion(BlockRegion region, BlockPosition offset) {
++        this.region = region;
++        this.offset = offset;
++    }
++
++    @Override
++    public boolean contains(BlockPosition position) {
++        return region.contains(new CraftBlockPosition(position.getBlockX() - offset.getBlockX(),
++                                                      position.getBlockY() - offset.getBlockY(),
++                                                      position.getBlockZ() - offset.getBlockZ()));
++    }
++
++    @Override
++    public BlockPositionIterator iterator() {
++        return new Iterator();
++    }
++
++    class Iterator extends CraftMutableBlockPosition implements BlockPositionIterator {
++        private final BlockPositionIterator iter = region.iterator();
++
++        @Override
++        public boolean hasNext() {
++            return iter.hasNext();
++        }
++
++        @Override
++        public BlockPosition next() {
++            BlockPosition p = iter.next();
++            set(p.getBlockX() + offset.getBlockX(),
++                p.getBlockY() + offset.getBlockY(),
++                p.getBlockZ() + offset.getBlockZ());
++            return this;
++        }
++
++        @Override
++        public void remove() {
++            throw new UnsupportedOperationException();
++        }
++    }
++}
+-- 
+1.9.0
+


### PR DESCRIPTION
Adds a new type `BlockImage` which is effectively a cuboid volume of `BlockState`s (though it is not implemented that way). These can be copied to and from `World`s fairly efficiently, much more so than copying each block individually through the Bukkit API.

Currently, there are three operations: copy, cut, and paste. Masking is limited to choosing whether or not to include air. This could be expanded in the future, but this will do for now.

The block copying code is derived from the code for the `/clone` command, so it should already be fairly robust. It properly handles tile entities, attached blocks, and physics updates.