### PR TITLE
Common interface for all things associated with a World

### DIFF
--- a/Bukkit/0056-Physical-interface.patch
+++ b/Bukkit/0056-Physical-interface.patch
@@ -1,0 +1,610 @@
+From 1c19d5e411124a27ae7a72606e96b2357a833709 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Fri, 3 Jul 2015 01:08:40 -0400
+Subject: [PATCH] Physical interface
+
+
+diff --git a/src/main/java/org/bukkit/Chunk.java b/src/main/java/org/bukkit/Chunk.java
+index d931109..fce2c50 100644
+--- a/src/main/java/org/bukkit/Chunk.java
++++ b/src/main/java/org/bukkit/Chunk.java
+@@ -10,7 +10,7 @@ import java.util.Set;
+ /**
+  * Represents a chunk of blocks
+  */
+-public interface Chunk {
++public interface Chunk extends Physical {
+ 
+     /**
+      * Gets the X-coordinate of this chunk
+diff --git a/src/main/java/org/bukkit/Location.java b/src/main/java/org/bukkit/Location.java
+index e7af316..cd7ac2f 100644
+--- a/src/main/java/org/bukkit/Location.java
++++ b/src/main/java/org/bukkit/Location.java
+@@ -12,7 +12,7 @@ import org.bukkit.util.Vector;
+ /**
+  * Represents a 3-dimensional position in a world
+  */
+-public class Location implements Cloneable, ConfigurationSerializable {
++public class Location implements Cloneable, ConfigurationSerializable, Physical {
+     private World world;
+     private double x;
+     private double y;
+diff --git a/src/main/java/org/bukkit/Physical.java b/src/main/java/org/bukkit/Physical.java
+new file mode 100644
+index 0000000..24a58ff
+--- /dev/null
++++ b/src/main/java/org/bukkit/Physical.java
+@@ -0,0 +1,14 @@
++package org.bukkit;
++
++/**
++ * Common interface for any type of object that can be associated with a specific world.
++ * This interface makes no guarantees about the mutability or nullability of the world.
++ */
++public interface Physical {
++
++    /**
++     * Return the world this object is associated with. May return null if the world
++     * is not available (i.e. not loaded), or this object does not have a world.
++     */
++    World getWorld();
++}
+diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
+index c6cbac5..5532a04 100644
+--- a/src/main/java/org/bukkit/World.java
++++ b/src/main/java/org/bukkit/World.java
+@@ -17,7 +17,6 @@ import org.bukkit.block.Block;
+ import org.bukkit.entity.*;
+ import org.bukkit.generator.BlockPopulator;
+ import org.bukkit.inventory.ItemStack;
+-import org.bukkit.material.MaterialData;
+ import org.bukkit.metadata.Metadatable;
+ import org.bukkit.plugin.messaging.PluginMessageRecipient;
+ import org.bukkit.util.RayBlockIntersection;
+@@ -26,7 +25,7 @@ import org.bukkit.util.Vector;
+ /**
+  * Represents a world, which may contain entities, chunks and blocks
+  */
+-public interface World extends PluginMessageRecipient, Metadatable {
++public interface World extends PluginMessageRecipient, Metadatable, Physical {
+ 
+     /**
+      * Gets the {@link Block} at the given coordinates
+diff --git a/src/main/java/org/bukkit/block/Block.java b/src/main/java/org/bukkit/block/Block.java
+index fe32537..158bd8f 100644
+--- a/src/main/java/org/bukkit/block/Block.java
++++ b/src/main/java/org/bukkit/block/Block.java
+@@ -6,6 +6,7 @@ import org.bukkit.Chunk;
+ import org.bukkit.Material;
+ import org.bukkit.World;
+ import org.bukkit.Location;
++import org.bukkit.Physical;
+ import org.bukkit.inventory.ItemStack;
+ import org.bukkit.metadata.Metadatable;
+ import org.bukkit.util.RayBlockIntersection;
+@@ -17,7 +18,7 @@ import org.bukkit.util.Vector;
+  * concurrently to your own handling of it; use block.getState() to get a
+  * snapshot state of a block which will not be modified.
+  */
+-public interface Block extends Metadatable {
++public interface Block extends Metadatable, Physical {
+ 
+     /**
+      * Gets the metadata for this block
+diff --git a/src/main/java/org/bukkit/block/BlockImage.java b/src/main/java/org/bukkit/block/BlockImage.java
+index c7ed2ad..1ec0d45 100644
+--- a/src/main/java/org/bukkit/block/BlockImage.java
++++ b/src/main/java/org/bukkit/block/BlockImage.java
+@@ -3,12 +3,13 @@ package org.bukkit.block;
+ import java.util.UUID;
+ 
+ import org.bukkit.World;
++import org.bukkit.Physical;
+ 
+ /**
+  * A set of saved block states.
+  * TODO: Provide a way to actually get {@link BlockState}s from one of these.
+  */
+-public interface BlockImage {
++public interface BlockImage extends Physical {
+     /**
+      * Unique ID of the {@link World} this image was created from.
+      * This world may or may not still exist. This object does not hold any
+diff --git a/src/main/java/org/bukkit/block/BlockState.java b/src/main/java/org/bukkit/block/BlockState.java
+index 911a4d1..7899117 100644
+--- a/src/main/java/org/bukkit/block/BlockState.java
++++ b/src/main/java/org/bukkit/block/BlockState.java
+@@ -4,6 +4,7 @@ import org.bukkit.Chunk;
+ import org.bukkit.Location;
+ import org.bukkit.Material;
+ import org.bukkit.World;
++import org.bukkit.Physical;
+ import org.bukkit.material.MaterialData;
+ import org.bukkit.metadata.Metadatable;
+ 
+@@ -16,7 +17,7 @@ import org.bukkit.metadata.Metadatable;
+  * change the state of the block and you will not know, or they may change the
+  * block to another type entirely, causing your BlockState to become invalid.
+  */
+-public interface BlockState extends Metadatable {
++public interface BlockState extends Metadatable, Physical {
+ 
+     /**
+      * Gets the block represented by this BlockState
+diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
+index 521c50a..73c4fa2 100644
+--- a/src/main/java/org/bukkit/entity/Entity.java
++++ b/src/main/java/org/bukkit/entity/Entity.java
+@@ -4,6 +4,7 @@ import org.bukkit.Location;
+ import org.bukkit.EntityEffect;
+ import org.bukkit.Server;
+ import org.bukkit.World;
++import org.bukkit.Physical;
+ import org.bukkit.event.entity.EntityDamageEvent;
+ import org.bukkit.metadata.Metadatable;
+ import org.bukkit.util.Vector;
+@@ -16,7 +17,7 @@ import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
+ /**
+  * Represents a base entity in the world
+  */
+-public interface Entity extends Metadatable, CommandSender {
++public interface Entity extends Metadatable, CommandSender, Physical {
+ 
+     /**
+      * Gets the entity's current position
+diff --git a/src/main/java/org/bukkit/event/block/BlockEvent.java b/src/main/java/org/bukkit/event/block/BlockEvent.java
+index 2405205..4fdf37e 100644
+--- a/src/main/java/org/bukkit/event/block/BlockEvent.java
++++ b/src/main/java/org/bukkit/event/block/BlockEvent.java
+@@ -1,12 +1,14 @@
+ package org.bukkit.event.block;
+ 
++import org.bukkit.World;
++import org.bukkit.Physical;
+ import org.bukkit.block.Block;
+ import org.bukkit.event.Event;
+ 
+ /**
+  * Represents a block related event.
+  */
+-public abstract class BlockEvent extends Event {
++public abstract class BlockEvent extends Event implements Physical {
+     protected Block block;
+ 
+     public BlockEvent(final Block theBlock) {
+@@ -21,4 +23,9 @@ public abstract class BlockEvent extends Event {
+     public final Block getBlock() {
+         return block;
+     }
++
++    @Override
++    public World getWorld() {
++        return getBlock().getWorld();
++    }
+ }
+diff --git a/src/main/java/org/bukkit/event/entity/EntityEvent.java b/src/main/java/org/bukkit/event/entity/EntityEvent.java
+index c9a4ab3..0cebd9f 100644
+--- a/src/main/java/org/bukkit/event/entity/EntityEvent.java
++++ b/src/main/java/org/bukkit/event/entity/EntityEvent.java
+@@ -1,5 +1,7 @@
+ package org.bukkit.event.entity;
+ 
++import org.bukkit.World;
++import org.bukkit.Physical;
+ import org.bukkit.entity.Entity;
+ import org.bukkit.entity.EntityType;
+ import org.bukkit.event.Event;
+@@ -7,7 +9,7 @@ import org.bukkit.event.Event;
+ /**
+  * Represents an Entity-related event
+  */
+-public abstract class EntityEvent extends Event {
++public abstract class EntityEvent extends Event implements Physical {
+     protected Entity entity;
+ 
+     public EntityEvent(final Entity what) {
+@@ -31,4 +33,9 @@ public abstract class EntityEvent extends Event {
+     public EntityType getEntityType() {
+         return entity.getType();
+     }
++
++    @Override
++    public World getWorld() {
++        return getEntity().getWorld();
++    }
+ }
+diff --git a/src/main/java/org/bukkit/event/entity/PlayerLeashEntityEvent.java b/src/main/java/org/bukkit/event/entity/PlayerLeashEntityEvent.java
+index 74d458a..b4d0f3c 100644
+--- a/src/main/java/org/bukkit/event/entity/PlayerLeashEntityEvent.java
++++ b/src/main/java/org/bukkit/event/entity/PlayerLeashEntityEvent.java
+@@ -1,5 +1,7 @@
+ package org.bukkit.event.entity;
+ 
++import org.bukkit.World;
++import org.bukkit.Physical;
+ import org.bukkit.entity.Entity;
+ import org.bukkit.entity.Player;
+ import org.bukkit.event.Cancellable;
+@@ -9,7 +11,7 @@ import org.bukkit.event.HandlerList;
+ /**
+  * Called immediately prior to a creature being leashed by a player.
+  */
+-public class PlayerLeashEntityEvent extends Event implements Cancellable {
++public class PlayerLeashEntityEvent extends Event implements Cancellable, Physical {
+     private static final HandlerList handlers = new HandlerList();
+     private final Entity leashHolder;
+     private final Entity entity;
+@@ -50,6 +52,11 @@ public class PlayerLeashEntityEvent extends Event implements Cancellable {
+     }
+ 
+     @Override
++    public World getWorld() {
++        return getEntity().getWorld();
++    }
++
++    @Override
+     public HandlerList getHandlers() {
+         return handlers;
+     }
+diff --git a/src/main/java/org/bukkit/event/hanging/HangingEvent.java b/src/main/java/org/bukkit/event/hanging/HangingEvent.java
+index b370afe..a680c80 100644
+--- a/src/main/java/org/bukkit/event/hanging/HangingEvent.java
++++ b/src/main/java/org/bukkit/event/hanging/HangingEvent.java
+@@ -1,15 +1,16 @@
+ package org.bukkit.event.hanging;
+ 
+ import org.bukkit.entity.Hanging;
+-import org.bukkit.event.Event;
++import org.bukkit.event.entity.EntityEvent;
+ 
+ /**
+  * Represents a hanging entity-related event.
+  */
+-public abstract class HangingEvent extends Event {
++public abstract class HangingEvent extends EntityEvent {
+     protected Hanging hanging;
+ 
+     protected HangingEvent(final Hanging painting) {
++        super(painting);
+         this.hanging = painting;
+     }
+ 
+diff --git a/src/main/java/org/bukkit/event/inventory/InventoryEvent.java b/src/main/java/org/bukkit/event/inventory/InventoryEvent.java
+index 973c392..fd0fc2f 100644
+--- a/src/main/java/org/bukkit/event/inventory/InventoryEvent.java
++++ b/src/main/java/org/bukkit/event/inventory/InventoryEvent.java
+@@ -3,6 +3,8 @@ package org.bukkit.event.inventory;
+ 
+ import java.util.List;
+ 
++import org.bukkit.World;
++import org.bukkit.Physical;
+ import org.bukkit.event.HandlerList;
+ import org.bukkit.entity.HumanEntity;
+ import org.bukkit.event.Event;
+@@ -12,7 +14,7 @@ import org.bukkit.inventory.InventoryView;
+ /**
+  * Represents a player related inventory event
+  */
+-public class InventoryEvent extends Event {
++public class InventoryEvent extends Event implements Physical {
+     private static final HandlerList handlers = new HandlerList();
+     protected InventoryView transaction;
+ 
+@@ -49,6 +51,11 @@ public class InventoryEvent extends Event {
+     }
+ 
+     @Override
++    public World getWorld() {
++        return getInventory().getWorld();
++    }
++
++    @Override
+     public HandlerList getHandlers() {
+         return handlers;
+     }
+diff --git a/src/main/java/org/bukkit/event/inventory/InventoryMoveItemEvent.java b/src/main/java/org/bukkit/event/inventory/InventoryMoveItemEvent.java
+index 06ec99a..05ef7ec 100644
+--- a/src/main/java/org/bukkit/event/inventory/InventoryMoveItemEvent.java
++++ b/src/main/java/org/bukkit/event/inventory/InventoryMoveItemEvent.java
+@@ -1,6 +1,8 @@
+ package org.bukkit.event.inventory;
+ 
+ import org.apache.commons.lang.Validate;
++import org.bukkit.World;
++import org.bukkit.Physical;
+ import org.bukkit.event.Cancellable;
+ import org.bukkit.event.Event;
+ import org.bukkit.event.HandlerList;
+@@ -23,7 +25,7 @@ import org.bukkit.inventory.ItemStack;
+  * has not been modified, the source inventory slot will be restored to its
+  * former state. Otherwise any additional items will be discarded.
+  */
+-public class InventoryMoveItemEvent extends Event implements Cancellable {
++public class InventoryMoveItemEvent extends Event implements Cancellable, Physical {
+     private static final HandlerList handlers = new HandlerList();
+     private boolean cancelled;
+     private final Inventory sourceInventory;
+@@ -89,6 +91,11 @@ public class InventoryMoveItemEvent extends Event implements Cancellable {
+         return didSourceInitiate ? sourceInventory : destinationInventory;
+     }
+ 
++    @Override
++    public World getWorld() {
++        return getInitiator().getWorld();
++    }
++
+     public boolean isCancelled() {
+         return cancelled;
+     }
+diff --git a/src/main/java/org/bukkit/event/inventory/InventoryPickupItemEvent.java b/src/main/java/org/bukkit/event/inventory/InventoryPickupItemEvent.java
+index af6ad5b..9958e63 100644
+--- a/src/main/java/org/bukkit/event/inventory/InventoryPickupItemEvent.java
++++ b/src/main/java/org/bukkit/event/inventory/InventoryPickupItemEvent.java
+@@ -1,5 +1,7 @@
+ package org.bukkit.event.inventory;
+ 
++import org.bukkit.World;
++import org.bukkit.Physical;
+ import org.bukkit.entity.Item;
+ import org.bukkit.event.Cancellable;
+ import org.bukkit.event.Event;
+@@ -9,7 +11,7 @@ import org.bukkit.inventory.Inventory;
+ /**
+  * Called when a hopper or hopper minecart picks up a dropped item.
+  */
+-public class InventoryPickupItemEvent extends Event implements Cancellable {
++public class InventoryPickupItemEvent extends Event implements Cancellable, Physical {
+     private static final HandlerList handlers = new HandlerList();
+     private boolean cancelled;
+     private final Inventory inventory;
+@@ -39,6 +41,11 @@ public class InventoryPickupItemEvent extends Event implements Cancellable {
+         return item;
+     }
+ 
++    @Override
++    public World getWorld() {
++        return getInventory().getHolder().getWorld();
++    }
++
+     public boolean isCancelled() {
+         return cancelled;
+     }
+diff --git a/src/main/java/org/bukkit/event/painting/PaintingEvent.java b/src/main/java/org/bukkit/event/painting/PaintingEvent.java
+index 3a51348..29871fb 100644
+--- a/src/main/java/org/bukkit/event/painting/PaintingEvent.java
++++ b/src/main/java/org/bukkit/event/painting/PaintingEvent.java
+@@ -1,6 +1,8 @@
+ package org.bukkit.event.painting;
+ 
+ import org.bukkit.Warning;
++import org.bukkit.World;
++import org.bukkit.Physical;
+ import org.bukkit.entity.Painting;
+ import org.bukkit.event.Event;
+ 
+@@ -11,7 +13,7 @@ import org.bukkit.event.Event;
+  */
+ @Deprecated
+ @Warning(reason="This event has been replaced by HangingEvent")
+-public abstract class PaintingEvent extends Event {
++public abstract class PaintingEvent extends Event implements Physical {
+     protected Painting painting;
+ 
+     protected PaintingEvent(final Painting painting) {
+@@ -26,4 +28,9 @@ public abstract class PaintingEvent extends Event {
+     public Painting getPainting() {
+         return painting;
+     }
++
++    @Override
++    public World getWorld() {
++        return getPainting().getWorld();
++    }
+ }
+diff --git a/src/main/java/org/bukkit/event/player/PlayerEvent.java b/src/main/java/org/bukkit/event/player/PlayerEvent.java
+index 0d4833f..8e0ddfc 100644
+--- a/src/main/java/org/bukkit/event/player/PlayerEvent.java
++++ b/src/main/java/org/bukkit/event/player/PlayerEvent.java
+@@ -1,12 +1,14 @@
+ package org.bukkit.event.player;
+ 
++import org.bukkit.World;
++import org.bukkit.Physical;
+ import org.bukkit.entity.Player;
+ import org.bukkit.event.Event;
+ 
+ /**
+  * Represents a player related event
+  */
+-public abstract class PlayerEvent extends Event {
++public abstract class PlayerEvent extends Event implements Physical {
+     protected Player player;
+ 
+     public PlayerEvent(final Player who) {
+@@ -27,4 +29,9 @@ public abstract class PlayerEvent extends Event {
+     public final Player getPlayer() {
+         return player;
+     }
++
++    @Override
++    public World getWorld() {
++        return getPlayer().getWorld();
++    }
+ }
+diff --git a/src/main/java/org/bukkit/event/server/MapInitializeEvent.java b/src/main/java/org/bukkit/event/server/MapInitializeEvent.java
+index 8834489..f0e1672 100644
+--- a/src/main/java/org/bukkit/event/server/MapInitializeEvent.java
++++ b/src/main/java/org/bukkit/event/server/MapInitializeEvent.java
+@@ -1,12 +1,14 @@
+ package org.bukkit.event.server;
+ 
++import org.bukkit.World;
++import org.bukkit.Physical;
+ import org.bukkit.event.HandlerList;
+ import org.bukkit.map.MapView;
+ 
+ /**
+  * Called when a map is initialized.
+  */
+-public class MapInitializeEvent extends ServerEvent {
++public class MapInitializeEvent extends ServerEvent implements Physical {
+     private static final HandlerList handlers = new HandlerList();
+     private final MapView mapView;
+ 
+@@ -24,6 +26,11 @@ public class MapInitializeEvent extends ServerEvent {
+     }
+ 
+     @Override
++    public World getWorld() {
++        return getMap().getWorld();
++    }
++
++    @Override
+     public HandlerList getHandlers() {
+         return handlers;
+     }
+diff --git a/src/main/java/org/bukkit/event/vehicle/VehicleEvent.java b/src/main/java/org/bukkit/event/vehicle/VehicleEvent.java
+index b8255c0..3a00b5b 100644
+--- a/src/main/java/org/bukkit/event/vehicle/VehicleEvent.java
++++ b/src/main/java/org/bukkit/event/vehicle/VehicleEvent.java
+@@ -1,12 +1,14 @@
+ package org.bukkit.event.vehicle;
+ 
++import org.bukkit.World;
++import org.bukkit.Physical;
+ import org.bukkit.entity.Vehicle;
+ import org.bukkit.event.Event;
+ 
+ /**
+  * Represents a vehicle-related event.
+  */
+-public abstract class VehicleEvent extends Event {
++public abstract class VehicleEvent extends Event implements Physical {
+     protected Vehicle vehicle;
+ 
+     public VehicleEvent(final Vehicle vehicle) {
+@@ -21,4 +23,9 @@ public abstract class VehicleEvent extends Event {
+     public final Vehicle getVehicle() {
+         return vehicle;
+     }
++
++    @Override
++    public World getWorld() {
++        return getVehicle().getWorld();
++    }
+ }
+diff --git a/src/main/java/org/bukkit/event/weather/WeatherEvent.java b/src/main/java/org/bukkit/event/weather/WeatherEvent.java
+index 0cae9bc..2f41ab4 100644
+--- a/src/main/java/org/bukkit/event/weather/WeatherEvent.java
++++ b/src/main/java/org/bukkit/event/weather/WeatherEvent.java
+@@ -1,12 +1,13 @@
+ package org.bukkit.event.weather;
+ 
+ import org.bukkit.World;
++import org.bukkit.Physical;
+ import org.bukkit.event.Event;
+ 
+ /**
+  * Represents a Weather-related event
+  */
+-public abstract class WeatherEvent extends Event {
++public abstract class WeatherEvent extends Event implements Physical {
+     protected World world;
+ 
+     public WeatherEvent(final World where) {
+diff --git a/src/main/java/org/bukkit/event/world/WorldEvent.java b/src/main/java/org/bukkit/event/world/WorldEvent.java
+index bd89b81..10845d1 100644
+--- a/src/main/java/org/bukkit/event/world/WorldEvent.java
++++ b/src/main/java/org/bukkit/event/world/WorldEvent.java
+@@ -1,12 +1,13 @@
+ package org.bukkit.event.world;
+ 
+ import org.bukkit.World;
++import org.bukkit.Physical;
+ import org.bukkit.event.Event;
+ 
+ /**
+  * Represents events within a world
+  */
+-public abstract class WorldEvent extends Event {
++public abstract class WorldEvent extends Event implements Physical {
+     private final World world;
+ 
+     public WorldEvent(final World world) {
+diff --git a/src/main/java/org/bukkit/inventory/Inventory.java b/src/main/java/org/bukkit/inventory/Inventory.java
+index da5d83e..873824e 100644
+--- a/src/main/java/org/bukkit/inventory/Inventory.java
++++ b/src/main/java/org/bukkit/inventory/Inventory.java
+@@ -5,6 +5,7 @@ import java.util.List;
+ import java.util.ListIterator;
+ 
+ import org.bukkit.Material;
++import org.bukkit.Physical;
+ import org.bukkit.entity.HumanEntity;
+ import org.bukkit.event.inventory.InventoryType;
+ 
+@@ -12,7 +13,7 @@ import org.bukkit.event.inventory.InventoryType;
+  * Interface to the various inventories. Behavior relating to {@link
+  * Material#AIR} is unspecified.
+  */
+-public interface Inventory extends Iterable<ItemStack> {
++public interface Inventory extends Iterable<ItemStack>, Physical {
+ 
+     /**
+      * Returns the size of the inventory
+diff --git a/src/main/java/org/bukkit/inventory/InventoryHolder.java b/src/main/java/org/bukkit/inventory/InventoryHolder.java
+index 9c06a3d..6e128ba 100644
+--- a/src/main/java/org/bukkit/inventory/InventoryHolder.java
++++ b/src/main/java/org/bukkit/inventory/InventoryHolder.java
+@@ -1,6 +1,8 @@
+ package org.bukkit.inventory;
+ 
+-public interface InventoryHolder {
++import org.bukkit.Physical;
++
++public interface InventoryHolder extends Physical {
+ 
+     /**
+      * Get the object's inventory.
+diff --git a/src/main/java/org/bukkit/map/MapView.java b/src/main/java/org/bukkit/map/MapView.java
+index 65c4159..e0bb2a6 100644
+--- a/src/main/java/org/bukkit/map/MapView.java
++++ b/src/main/java/org/bukkit/map/MapView.java
+@@ -2,11 +2,12 @@ package org.bukkit.map;
+ 
+ import java.util.List;
+ import org.bukkit.World;
++import org.bukkit.Physical;
+ 
+ /**
+  * Represents a map item.
+  */
+-public interface MapView {
++public interface MapView extends Physical {
+ 
+     /**
+      * An enum representing all possible scales a map can be set to.
+diff --git a/src/main/java/org/bukkit/projectiles/ProjectileSource.java b/src/main/java/org/bukkit/projectiles/ProjectileSource.java
+index cf90946..bd2d3a1 100644
+--- a/src/main/java/org/bukkit/projectiles/ProjectileSource.java
++++ b/src/main/java/org/bukkit/projectiles/ProjectileSource.java
+@@ -1,12 +1,13 @@
+ package org.bukkit.projectiles;
+ 
++import org.bukkit.Physical;
+ import org.bukkit.entity.Projectile;
+ import org.bukkit.util.Vector;
+ 
+ /**
+  * Represents a valid source of a projectile.
+  */
+-public interface ProjectileSource {
++public interface ProjectileSource extends Physical {
+ 
+     /**
+      * Launches a {@link Projectile} from the ProjectileSource.
+-- 
+1.9.0
+

--- a/CraftBukkit/0119-Physical-interface.patch
+++ b/CraftBukkit/0119-Physical-interface.patch
@@ -1,0 +1,73 @@
+From 7cabfd301bab0dc1748ce6e2a6f61dfea6f01ba3 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Fri, 3 Jul 2015 01:08:46 -0400
+Subject: [PATCH] Physical interface
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+index fb02b58..16066b0 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+@@ -91,6 +91,11 @@ public class CraftWorld implements World {
+         }
+     }
+ 
++    @Override
++    public World getWorld() {
++        return this;
++    }
++
+     public Block getBlockAt(int x, int y, int z) {
+         return getChunkAt(x >> 4, z >> 4).getBlock(x & 0xF, y, z & 0xF);
+     }
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventory.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventory.java
+index e9a3c50..694da65 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventory.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventory.java
+@@ -17,6 +17,7 @@ import net.minecraft.server.TileEntityDropper;
+ import net.minecraft.server.TileEntityFurnace;
+ 
+ import org.apache.commons.lang.Validate;
++import org.bukkit.World;
+ import org.bukkit.entity.HumanEntity;
+ import org.bukkit.event.inventory.InventoryType;
+ import org.bukkit.inventory.Inventory;
+@@ -462,6 +463,11 @@ public class CraftInventory implements Inventory {
+         return inventory.getOwner();
+     }
+ 
++    @Override
++    public World getWorld() {
++        return getHolder().getWorld();
++    }
++
+     public int getMaxStackSize() {
+         return inventory.getMaxStackSize();
+     }
+diff --git a/src/main/java/org/bukkit/craftbukkit/projectiles/CraftBlockProjectileSource.java b/src/main/java/org/bukkit/craftbukkit/projectiles/CraftBlockProjectileSource.java
+index b8bf754..70a1023 100644
+--- a/src/main/java/org/bukkit/craftbukkit/projectiles/CraftBlockProjectileSource.java
++++ b/src/main/java/org/bukkit/craftbukkit/projectiles/CraftBlockProjectileSource.java
+@@ -4,6 +4,7 @@ import java.util.Random;
+ 
+ import org.apache.commons.lang.Validate;
+ import org.bukkit.Material;
++import org.bukkit.World;
+ import org.bukkit.block.Block;
+ import org.bukkit.craftbukkit.inventory.CraftItemStack;
+ import org.bukkit.entity.Arrow;
+@@ -52,6 +53,11 @@ public class CraftBlockProjectileSource implements BlockProjectileSource {
+     }
+ 
+     @Override
++    public World getWorld() {
++        return getBlock().getWorld();
++    }
++
++    @Override
+     public <T extends Projectile> T launchProjectile(Class<? extends T> projectile) {
+         return launchProjectile(projectile, null);
+     }
+-- 
+1.9.0
+


### PR DESCRIPTION
Add an interface called `WorldThing` (better suggestion?) with a single method `getWorld()`. The interface is implemented by pretty much everything that already has that method, plus a few more. It's also implemented by every `Event` subclass that is world-specific. Events are where this is particularly useful, since it was previously quite complex to get an event's world in a general way.

Complete list of `WorldThing` inheritors (anything missing?):
* `World`
* `Chunk`
* `Location`
* `Entity`
* `Block`
* `BlockState`
* `BlockImage`
* `Inventory`
* `InventoryHolder`
* `ProjectileSource`
* `MapView`
* `WorldEvent`, `EntityEvent`, `BlockEvent`, `VehicleEvent`, `HangingEvent`, `PaintingEvent`, `PlayerEvent`, `PlayerLeashEntityEvent`, `InventoryEvent`, `InventoryMoveItemEvent`, `InventoryPickupItemEvent`, `MapInitializeEvent`, `WeatherEvent`
