### PR TITLE
Make Location extend Vector

### DIFF
--- a/Bukkit/0060-Location-extends-Vector.patch
+++ b/Bukkit/0060-Location-extends-Vector.patch
@@ -1,0 +1,314 @@
+From 616b456bbed152929f4906c63d497281017ae2c7 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Tue, 14 Jul 2015 09:57:16 -0400
+Subject: [PATCH] Location extends Vector
+
+
+diff --git a/src/main/java/org/bukkit/Location.java b/src/main/java/org/bukkit/Location.java
+index cd7ac2f..89f25d9 100644
+--- a/src/main/java/org/bukkit/Location.java
++++ b/src/main/java/org/bukkit/Location.java
+@@ -1,22 +1,17 @@
+ package org.bukkit;
+ 
+-import java.util.HashMap;
+ import java.util.Map;
+ 
+ import org.bukkit.block.Block;
+ import org.bukkit.configuration.serialization.ConfigurationSerializable;
+ import org.bukkit.util.NumberConversions;
+-import static org.bukkit.util.NumberConversions.checkFinite;
+ import org.bukkit.util.Vector;
+ 
+ /**
+  * Represents a 3-dimensional position in a world
+  */
+-public class Location implements Cloneable, ConfigurationSerializable, Physical {
++public class Location extends Vector implements Cloneable, ConfigurationSerializable, Physical {
+     private World world;
+-    private double x;
+-    private double y;
+-    private double z;
+     private float pitch;
+     private float yaw;
+ 
+@@ -43,10 +38,8 @@ public class Location implements Cloneable, ConfigurationSerializable, Physical
+      * @param pitch The absolute rotation on the y-plane, in degrees
+      */
+     public Location(final World world, final double x, final double y, final double z, final float yaw, final float pitch) {
++        super(x, y, z);
+         this.world = world;
+-        this.x = x;
+-        this.y = y;
+-        this.z = z;
+         this.pitch = pitch;
+         this.yaw = yaw;
+     }
+@@ -92,8 +85,18 @@ public class Location implements Cloneable, ConfigurationSerializable, Physical
+      *
+      * @param x X-coordinate
+      */
+-    public void setX(double x) {
++    public Location setX(double x) {
+         this.x = x;
++        return this;
++    }
++
++    /**
++     * Do not use this method, it's here for legacy compatibility only.
++     * It is renamed after compilation.
++     * @deprecated
++     */
++    public void _INVALID_setX(double x) {
++        setX(x);
+     }
+ 
+     /**
+@@ -120,8 +123,18 @@ public class Location implements Cloneable, ConfigurationSerializable, Physical
+      *
+      * @param y y-coordinate
+      */
+-    public void setY(double y) {
++    public Location setY(double y) {
+         this.y = y;
++        return this;
++    }
++
++    /**
++     * Do not use this method, it's here for legacy compatibility only.
++     * It is renamed after compilation.
++     * @deprecated
++     */
++    public void _INVALID_setY(double y) {
++        setY(y);
+     }
+ 
+     /**
+@@ -148,7 +161,17 @@ public class Location implements Cloneable, ConfigurationSerializable, Physical
+      *
+      * @param z z-coordinate
+      */
+-    public void setZ(double z) {
++    public Location setZ(double z) {
++        this.z = z;
++        return this;
++    }
++
++    /**
++     * Do not use this method, it's here for legacy compatibility only.
++     * It is renamed after compilation.
++     * @deprecated
++     */
++    public void _INVALID_setZ(double z) {
+         this.z = z;
+     }
+ 
+@@ -307,14 +330,7 @@ public class Location implements Cloneable, ConfigurationSerializable, Physical
+      * @throws IllegalArgumentException for differing worlds
+      */
+     public Location add(Location vec) {
+-        if (vec == null || vec.getWorld() != getWorld()) {
+-            throw new IllegalArgumentException("Cannot add Locations of differing worlds");
+-        }
+-
+-        x += vec.x;
+-        y += vec.y;
+-        z += vec.z;
+-        return this;
++        return add((Vector) vec);
+     }
+ 
+     /**
+@@ -325,9 +341,10 @@ public class Location implements Cloneable, ConfigurationSerializable, Physical
+      * @return the same location
+      */
+     public Location add(Vector vec) {
+-        this.x += vec.getX();
+-        this.y += vec.getY();
+-        this.z += vec.getZ();
++        if (vec == null || (vec instanceof Location && ((Location) vec).getWorld() != getWorld())) {
++            throw new IllegalArgumentException("Cannot add Locations of differing worlds");
++        }
++        super.add(vec);
+         return this;
+     }
+ 
+@@ -341,9 +358,7 @@ public class Location implements Cloneable, ConfigurationSerializable, Physical
+      * @return the same location
+      */
+     public Location add(double x, double y, double z) {
+-        this.x += x;
+-        this.y += y;
+-        this.z += z;
++        super.add(x, y, z);
+         return this;
+     }
+ 
+@@ -356,14 +371,7 @@ public class Location implements Cloneable, ConfigurationSerializable, Physical
+      * @throws IllegalArgumentException for differing worlds
+      */
+     public Location subtract(Location vec) {
+-        if (vec == null || vec.getWorld() != getWorld()) {
+-            throw new IllegalArgumentException("Cannot add Locations of differing worlds");
+-        }
+-
+-        x -= vec.x;
+-        y -= vec.y;
+-        z -= vec.z;
+-        return this;
++        return subtract((Vector) vec);
+     }
+ 
+     /**
+@@ -374,9 +382,10 @@ public class Location implements Cloneable, ConfigurationSerializable, Physical
+      * @return the same location
+      */
+     public Location subtract(Vector vec) {
+-        this.x -= vec.getX();
+-        this.y -= vec.getY();
+-        this.z -= vec.getZ();
++        if (vec == null || (vec instanceof Location && ((Location) vec).getWorld() != getWorld())) {
++            throw new IllegalArgumentException("Cannot subtract Locations of differing worlds");
++        }
++        super.subtract(vec);
+         return this;
+     }
+ 
+@@ -391,9 +400,7 @@ public class Location implements Cloneable, ConfigurationSerializable, Physical
+      * @return the same location
+      */
+     public Location subtract(double x, double y, double z) {
+-        this.x -= x;
+-        this.y -= y;
+-        this.z -= z;
++        super.subtract(x, y, z);
+         return this;
+     }
+ 
+@@ -409,7 +416,7 @@ public class Location implements Cloneable, ConfigurationSerializable, Physical
+      * @return the magnitude
+      */
+     public double length() {
+-        return Math.sqrt(NumberConversions.square(x) + NumberConversions.square(y) + NumberConversions.square(z));
++        return super.length();
+     }
+ 
+     /**
+@@ -420,7 +427,7 @@ public class Location implements Cloneable, ConfigurationSerializable, Physical
+      * @return the magnitude
+      */
+     public double lengthSquared() {
+-        return NumberConversions.square(x) + NumberConversions.square(y) + NumberConversions.square(z);
++        return super.lengthSquared();
+     }
+ 
+     /**
+@@ -436,7 +443,7 @@ public class Location implements Cloneable, ConfigurationSerializable, Physical
+      * @throws IllegalArgumentException for differing worlds
+      */
+     public double distance(Location o) {
+-        return Math.sqrt(distanceSquared(o));
++        return super.distance(o);
+     }
+ 
+     /**
+@@ -455,8 +462,7 @@ public class Location implements Cloneable, ConfigurationSerializable, Physical
+         } else if (o.getWorld() != getWorld()) {
+             throw new IllegalArgumentException("Cannot measure distance between " + getWorld().getName() + " and " + o.getWorld().getName());
+         }
+-
+-        return NumberConversions.square(x - o.x) + NumberConversions.square(y - o.y) + NumberConversions.square(z - o.z);
++        return super.distanceSquared(o);
+     }
+ 
+     /**
+@@ -481,9 +487,7 @@ public class Location implements Cloneable, ConfigurationSerializable, Physical
+      * @return the same location
+      */
+     public Location zero() {
+-        x = 0;
+-        y = 0;
+-        z = 0;
++        super.zero();
+         return this;
+     }
+ 
+@@ -548,11 +552,7 @@ public class Location implements Cloneable, ConfigurationSerializable, Physical
+ 
+     @Override
+     public Location clone() {
+-        try {
+-            return (Location) super.clone();
+-        } catch (CloneNotSupportedException e) {
+-            throw new Error(e);
+-        }
++        return (Location) super.clone();
+     }
+ 
+     /**
+@@ -568,13 +568,9 @@ public class Location implements Cloneable, ConfigurationSerializable, Physical
+ 
+ 	@Utility
+ 	public Map<String, Object> serialize() {
+-		Map<String, Object> data = new HashMap<String, Object>();
++		Map<String, Object> data = super.serialize();
+ 		data.put("world", this.world.getName());
+ 
+-		data.put("x", this.x);
+-		data.put("y", this.y);
+-		data.put("z", this.z);
+-
+ 		data.put("yaw", this.yaw);
+ 		data.put("pitch", this.pitch);
+ 
+diff --git a/src/main/java/org/bukkit/util/Vector.java b/src/main/java/org/bukkit/util/Vector.java
+index 03d9601..147a3b9 100644
+--- a/src/main/java/org/bukkit/util/Vector.java
++++ b/src/main/java/org/bukkit/util/Vector.java
+@@ -105,6 +105,21 @@ public class Vector implements Cloneable, ConfigurationSerializable, BlockPositi
+     }
+ 
+     /**
++     * Adds a vector to this one
++     *
++     * @param x X coordinate
++     * @param y Y coordinate
++     * @param z Z coordinate
++     * @return the same vector
++     */
++    public Vector add(double x, double y, double z) {
++        this.x += x;
++        this.y += y;
++        this.z += z;
++        return this;
++    }
++
++    /**
+      * Subtracts a vector from this one.
+      *
+      * @param vec The other vector
+@@ -118,6 +133,21 @@ public class Vector implements Cloneable, ConfigurationSerializable, BlockPositi
+     }
+ 
+     /**
++     * Subtracts a vector from this one.
++     *
++     * @param x X coordinate
++     * @param y Y coordinate
++     * @param z Z coordinate
++     * @return the same vector
++     */
++    public Vector subtract(double x, double y, double z) {
++        this.x -= x;
++        this.y -= y;
++        this.z -= z;
++        return this;
++    }
++
++    /**
+      * Multiplies the vector by another.
+      *
+      * @param vec The other vector
+-- 
+1.9.0
+

--- a/CraftBukkit/0123-Location-extends-Vector.patch
+++ b/CraftBukkit/0123-Location-extends-Vector.patch
@@ -1,0 +1,36 @@
+From b8fca4fe160952610df40de9fb3bbf629cabaf8e Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Tue, 14 Jul 2015 09:57:51 -0400
+Subject: [PATCH] Location extends Vector
+
+
+diff --git a/deprecation-mappings.at b/deprecation-mappings.at
+index 5858b48..08a79de 100644
+--- a/deprecation-mappings.at
++++ b/deprecation-mappings.at
+@@ -26,6 +26,10 @@ public+synthetic org/bukkit/event/entity/EntityRegainHealthEvent/setAmount(I)V
+ public+synthetic org/bukkit/event/vehicle/VehicleDamageEvent/getDamage()I
+ public+synthetic org/bukkit/event/vehicle/VehicleDamageEvent/setDamage(I)V
+ 
++public+synthetic org/bukkit/Location/setX(D)V
++public+synthetic org/bukkit/Location/setY(D)V
++public+synthetic org/bukkit/Location/setZ(D)V
++
+ # CraftBukkit
+ public+synthetic org/bukkit/craftbukkit/v1_8_R3/CraftServer/getOnlinePlayers()[Lorg/bukkit/entity/Player;
+ 
+diff --git a/deprecation-mappings.csrg b/deprecation-mappings.csrg
+index 48bc504..69e1708 100644
+--- a/deprecation-mappings.csrg
++++ b/deprecation-mappings.csrg
+@@ -25,3 +25,7 @@ org/bukkit/event/entity/EntityRegainHealthEvent _INVALID_setAmount (I)V setAmoun
+ 
+ org/bukkit/event/vehicle/VehicleDamageEvent _INVALID_getDamage ()I getDamage
+ org/bukkit/event/vehicle/VehicleDamageEvent _INVALID_setDamage (I)V setDamage
++
++org/bukkit/Location _INVALID_setX (D)V setX
++org/bukkit/Location _INVALID_setY (D)V setY
++org/bukkit/Location _INVALID_setZ (D)V setZ
+-- 
+1.9.0
+


### PR DESCRIPTION
Never understood why `Location` was not a `Vector`, since it duplicated a lot of the code. Well, now it is. This should be entirely backward compatible.