### PR TITLE
Allow custom underwater arrow distances

### DIFF
--- a/Bukkit/0062-Allow-custom-underwater-arrow-distances.patch
+++ b/Bukkit/0062-Allow-custom-underwater-arrow-distances.patch
@@ -1,0 +1,43 @@
+From af2eddf6ef44cbce89014ecbe07387ed944c055c Mon Sep 17 00:00:00 2001
+From: ShinyDialga45 <shinydialga45@gmail.com>
+Date: Tue, 18 Aug 2015 09:40:44 -0500
+Subject: [PATCH] Allow custom underwater arrow distances
+
+
+diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
+index 37918e4..d0fae2c 100644
+--- a/src/main/java/org/bukkit/Bukkit.java
++++ b/src/main/java/org/bukkit/Bukkit.java
+@@ -339,6 +339,13 @@ public final class Bukkit {
+     }
+ 
+     /**
++     * @see Server#getArrowWaterDistance()
++     */
++    public static float getArrowWaterDistance() {
++        return server.getArrowWaterDistance();
++    }
++
++    /**
+      * Gets default ticks per animal spawns value.
+      * <p>
+      * <b>Example Usage:</b>
+diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
+index 4e64c28..d599d23 100644
+--- a/src/main/java/org/bukkit/Server.java
++++ b/src/main/java/org/bukkit/Server.java
+@@ -275,6 +275,11 @@ public interface Server extends PluginMessageRecipient {
+     public boolean getWaterPushesTNT();
+ 
+     /**
++     * How far should arrows go in water?
++     */
++    public float getArrowWaterDistance();
++
++    /**
+      * Gets default ticks per animal spawns value.
+      * <p>
+      * <b>Example Usage:</b>
+-- 
+1.9.4.msysgit.2
+

--- a/CraftBukkit/0126-Allow-custom-underwater-arrow-distances.patch
+++ b/CraftBukkit/0126-Allow-custom-underwater-arrow-distances.patch
@@ -1,0 +1,88 @@
+From 6f0adaa2d68840c619f584c20bcebddc20f8a6dd Mon Sep 17 00:00:00 2001
+From: ShinyDialga45 <shinydialga45@gmail.com>
+Date: Tue, 18 Aug 2015 09:40:21 -0500
+Subject: [PATCH] Allow custom underwater arrow distances
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityArrow.java b/src/main/java/net/minecraft/server/EntityArrow.java
+index 04863b3..a9cfac2 100644
+--- a/src/main/java/net/minecraft/server/EntityArrow.java
++++ b/src/main/java/net/minecraft/server/EntityArrow.java
+@@ -340,7 +340,7 @@ public class EntityArrow extends Entity implements IProjectile {
+                     this.world.addParticle(EnumParticle.WATER_BUBBLE, this.locX - this.motX * (double) f3, this.locY - this.motY * (double) f3, this.locZ - this.motZ * (double) f3, this.motX, this.motY, this.motZ, new int[0]);
+                 }
+ 
+-                f4 = 0.6F;
++                f4 = this.world.getServer().getArrowWaterDistance(); //SportBukkit - use a custom arrow distance value instead
+             }
+ 
+             if (this.U()) {
+@@ -474,4 +474,37 @@ public class EntityArrow extends Entity implements IProjectile {
+         return inGround;
+     }
+     // CraftBukkit end
++
++    //SportBukkit start - Send the client updates in order to display the true location of the arrow rather than show the arrow teleport back.
++    //Code used from @jedediah commit "Fix TNT physics": https://github.com/OvercastNetwork/SportBukkit/commit/3fa8e200bba73c381ccd77c31dfec3b81de2d2e5
++    @Override
++    public boolean W() {
++        if (this.world.a(this.getBoundingBox().grow(0.0D, -0.4000000059604645D, 0.0D).shrink(0.001D, 0.001D, 0.001D), Material.WATER, this)) {
++            if (!this.inWater && !this.justCreated) {
++                this.X();
++            }
++
++            this.fallDistance = 0.0F;
++            this.inWater = true;
++            this.fireTicks = 0;
++            // Send position and velocity updates to nearby players on every tick while the Arrow is in water.
++            // This does pretty well at keeping their clients in sync with the server.
++            EntityTrackerEntry ete = (EntityTrackerEntry) ((WorldServer) this.getWorld()).getTracker().trackedEntities.get(this.getId());
++            if (ete != null && this.inWater) {
++                PacketPlayOutEntityVelocity velocityPacket = new PacketPlayOutEntityVelocity(this);
++                PacketPlayOutEntityTeleport positionPacket = new PacketPlayOutEntityTeleport(this);
++                for (EntityPlayer viewer : ete.trackedPlayers) {
++                    if ((viewer.locX - this.locX) * (viewer.locY - this.locY) * (viewer.locZ - this.locZ) < 16 * 16) {
++                        viewer.playerConnection.sendPacket(velocityPacket);
++                        viewer.playerConnection.sendPacket(positionPacket);
++                    }
++                }
++            }
++        } else {
++            this.inWater = false;
++        }
++
++        return this.inWater;
++    }
++    //SportBukkit end
+ }
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+index c006200..c14a046 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+@@ -599,6 +599,11 @@ public final class CraftServer implements Server {
+     }
+ 
+     @Override
++    public float getArrowWaterDistance() {
++        return Float.parseFloat(this.configuration.getString("settings.arrow-water-distance", "0.6"));
++    }
++
++    @Override
+     public int getTicksPerAnimalSpawns() {
+         return this.configuration.getInt("ticks-per.animal-spawns");
+     }
+diff --git a/src/main/resources/configurations/bukkit.yml b/src/main/resources/configurations/bukkit.yml
+index 6867fe3..8d60321 100644
+--- a/src/main/resources/configurations/bukkit.yml
++++ b/src/main/resources/configurations/bukkit.yml
+@@ -25,6 +25,7 @@ settings:
+     shutdown-message: Server closed
+     bungeecord: false
+     fetch-skulls: true
++    arrow-water-distance: 0.6
+ spawn-limits:
+     monsters: 70
+     animals: 15
+-- 
+1.9.4.msysgit.2
+


### PR DESCRIPTION
As of 1.8, arrows have been severely nerfed underwater. They can only go about 7 blocks in water compared to 1.7 being about 20 blocks. This patch allows you to change the float that determines how far the arrow goes underwater. The default setting in the `bukkit.yml` is 0.6, as is the default in vanilla. The variable in the config appears as `arrow-water-distance: 0.6` I found 0.86 (I found the value of cos(pi/6) to be very similar (0.86602540378) but I'm not sure if there's a correlation) to be very replicative of 1.7's arrow behavior of 20 blocks maximum. There is also code (thanks to @jedediah's moving TNT patch) that sends velocity and teleport packets to the client to show the true location of the arrow, as it appears to be a little off without it.

I attempted something at this patch before, but didn't really care enough until this thread came out: https://oc.tc/forums/topics/55d1f8475f35b9034600069d

Here's a youtube video showing 1.8 arrow behavior vs actions with the patch:
https://www.youtube.com/watch?v=EhLiampr_kw