### PR TITLE
Support dynamic port allocation

### DIFF
--- a/Bukkit/0062-Dynamic-port-allocation.patch
+++ b/Bukkit/0062-Dynamic-port-allocation.patch
@@ -1,0 +1,95 @@
+From df5a908c050f4924d28a5b984deeba0e83111365 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Tue, 25 Aug 2015 05:22:19 -0400
+Subject: [PATCH] Dynamic port allocation
+
+
+diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
+index 37918e4..77c07e3 100644
+--- a/src/main/java/org/bukkit/Bukkit.java
++++ b/src/main/java/org/bukkit/Bukkit.java
+@@ -160,13 +160,39 @@ public final class Bukkit {
+      */
+     public static int getMaxPlayers() {
+         return server.getMaxPlayers();
++
++    }
++    /**
++     * Get the port number specified in the server configuration.
++     * If this is 0, the port is dynamically allocated, and can be
++     * retrieved with {@link #getPort()}.
++     *
++     * @return the configured listening port
++     */
++    public static int getConfiguredPort() {
++        return server.getConfiguredPort();
+     }
+ 
+     /**
+-     * Get the game port that the server runs on.
++     * Get the port that the server is currently listening on.
++     * If the port is dynamic, this method can be used to detect the
++     * ephemeral port that was allocated. If the server is not bound
++     * to a port, this will return 0, which should only happen if
++     * binding failed for some reason.
++     *
++     * @return the currently bound listening port
++     */
++    public static int getBoundPort() {
++        return server.getBoundPort();
++    }
++
++    /**
++     * Get the port that the server is currently listening on,
++     * or the configured port if the server is not currently listening.
+      *
+      * @return the port number of this server
+      */
++    @Deprecated
+     public static int getPort() {
+         return server.getPort();
+     }
+diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
+index 4e64c28..dc758a2 100644
+--- a/src/main/java/org/bukkit/Server.java
++++ b/src/main/java/org/bukkit/Server.java
+@@ -137,10 +137,35 @@ public interface Server extends PluginMessageRecipient {
+     public int getMaxPlayers();
+ 
+     /**
+-     * Get the game port that the server runs on.
++     * Get the port number specified in the server configuration.
++     * If this is 0, the port is dynamically allocated, and can be
++     * retrieved with {@link #getBoundPort()}.
++     *
++     * @return the configured listening port
++     */
++    int getConfiguredPort();
++
++    /**
++     * Get the port that the server is currently listening on.
++     * If the port is dynamic, this method can be used to detect the
++     * ephemeral port that was allocated. If the server is not bound
++     * to a port, this will return 0, which should only happen if
++     * binding failed for some reason.
++     *
++     * @return the currently bound listening port
++     */
++    int getBoundPort();
++
++    /**
++     * Get the port that the server is currently listening on,
++     * or the configured port if the server is not currently listening.
++     *
++     * Deprecated: use either {@link #getConfiguredPort()} or {@link #getBoundPort()},
++     * depending on what, exactly, you want to know.
+      *
+      * @return the port number of this server
+      */
++    @Deprecated
+     public int getPort();
+ 
+     /**
+-- 
+1.9.0
+

--- a/CraftBukkit/0126-Dynamic-port-allocation.patch
+++ b/CraftBukkit/0126-Dynamic-port-allocation.patch
@@ -1,0 +1,102 @@
+From 40441cb4a00faaed35a98ade7b1cc5ecd3148d49 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Tue, 25 Aug 2015 05:30:20 -0400
+Subject: [PATCH] Dynamic port allocation
+
+
+diff --git a/src/main/java/net/minecraft/server/DedicatedServer.java b/src/main/java/net/minecraft/server/DedicatedServer.java
+index 00a6e83..756bdbb 100644
+--- a/src/main/java/net/minecraft/server/DedicatedServer.java
++++ b/src/main/java/net/minecraft/server/DedicatedServer.java
+@@ -169,6 +169,11 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
+ 
+             try {
+                 this.aq().a(inetaddress, this.R());
++                // SportBukkit start
++                if(this.aq().getPort() != this.R()) {
++                    DedicatedServer.LOGGER.info("Bound to port " + this.aq().getPort());
++                }
++                // SportBukkit end
+             } catch (IOException ioexception) {
+                 DedicatedServer.LOGGER.warn("**** FAILED TO BIND TO PORT!");
+                 DedicatedServer.LOGGER.warn("The exception was: {}", new Object[] { ioexception.toString()});
+@@ -273,6 +278,17 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
+         }
+     }
+ 
++    // SportBukkit start
++    @Override
++    public int F() {
++        if(this.aq().getPort() != 0) {
++            return this.aq().getPort();
++        } else {
++            return super.F();
++        }
++    }
++    // SportBukkit end
++
+     // CraftBukkit start
+     public PropertyManager getPropertyManager() {
+         return this.propertyManager;
+diff --git a/src/main/java/net/minecraft/server/ServerConnection.java b/src/main/java/net/minecraft/server/ServerConnection.java
+index 8e5eeff..26438ab 100644
+--- a/src/main/java/net/minecraft/server/ServerConnection.java
++++ b/src/main/java/net/minecraft/server/ServerConnection.java
+@@ -63,6 +63,11 @@ public class ServerConnection {
+     private final List<ChannelFuture> g = Collections.synchronizedList(Lists.<ChannelFuture>newArrayList());
+     private final List<NetworkManager> h = Collections.synchronizedList(Lists.<NetworkManager>newArrayList());
+ 
++    // SportBukkit start
++    private int port;
++    public int getPort() { return port; }
++    // SportBukkit end
++
+     public ServerConnection(MinecraftServer minecraftserver) {
+         this.f = minecraftserver;
+         this.d = true;
+@@ -101,6 +106,8 @@ public class ServerConnection {
+                     networkmanager.a((PacketListener) (new HandshakeListener(ServerConnection.this.f, networkmanager)));
+                 }
+             }).group((EventLoopGroup) lazyinitvar.c()).localAddress(inetaddress, i)).bind().syncUninterruptibly());
++
++            this.port = ((java.net.InetSocketAddress) this.g.get(0).channel().localAddress()).getPort(); // SportBukkit
+         }
+     }
+ 
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+index c006200..0858455 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+@@ -496,12 +496,28 @@ public final class CraftServer implements Server {
+ 
+     // NOTE: These are dependent on the corrisponding call in MinecraftServer
+     // so if that changes this will need to as well
++
+     @Override
+-    public int getPort() {
++    public int getConfiguredPort() {
+         return this.getConfigInt("server-port", 25565);
+     }
+ 
+     @Override
++    public int getBoundPort() {
++        return getHandle().getServer().aq().getPort();
++    }
++
++    @Override
++    public int getPort() {
++        int port = getBoundPort();
++        if(port > 0) {
++            return port;
++        } else {
++            return getConfiguredPort();
++        }
++    }
++
++    @Override
+     public int getViewDistance() {
+         return this.getConfigInt("view-distance", 10);
+     }
+-- 
+1.9.0
+


### PR DESCRIPTION
You can already set the port to 0 in server.properties to make the server allocate an ephemeral port. This patch adds a Bukkit API to get the port.