### PR TITLE
Add MotionFlag and EntityLocation

### DIFF
--- a/Bukkit/0084-Add-PoseFlag-and-EntityLocation.patch
+++ b/Bukkit/0084-Add-PoseFlag-and-EntityLocation.patch
@@ -1,0 +1,377 @@
+From 3342deec039633541f1873d28b8c8cf71fe52ae7 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Fri, 1 Jul 2016 03:36:15 -0400
+Subject: [PATCH] Add PoseFlag and EntityLocation
+
+
+diff --git a/src/main/java/org/bukkit/EntityLocation.java b/src/main/java/org/bukkit/EntityLocation.java
+new file mode 100644
+index 0000000..f19f281
+--- /dev/null
++++ b/src/main/java/org/bukkit/EntityLocation.java
+@@ -0,0 +1,122 @@
++package org.bukkit;
++
++import java.util.Arrays;
++import java.util.EnumSet;
++import java.util.Set;
++
++import org.bukkit.util.EnumUtils;
++import org.bukkit.util.Vector;
++
++public class EntityLocation extends Location {
++
++    private final Vector velocity;
++    private final Set<PoseFlag> poseFlags;
++
++    /**
++     * Create a new EntityLocation from the given values.
++     *
++     * Note that velocity and poseFlags are NOT copied.
++     */
++    public EntityLocation(World world, double x, double y, double z, float yaw, float pitch, Vector velocity, Set<PoseFlag> poseFlags) {
++        super(world, x, y, z, yaw, pitch);
++        this.velocity = velocity;
++        this.poseFlags = poseFlags;
++
++    }
++
++    public EntityLocation(World world, Vector position, float yaw, float pitch, Vector velocity, Set<PoseFlag> poseFlags) {
++        this(world, position.getX(), position.getY(), position.getZ(), yaw, pitch, velocity, poseFlags);
++    }
++
++    /**
++     * Create a new EntityLocation from the given values.
++     *
++     * Only the position and angles are copied from the location argument,
++     * even if it is another EntityLocation.
++     *
++     * Note that velocity and poseFlags are NOT copied.
++     */
++    public EntityLocation(Location location, Vector velocity, Set<PoseFlag> poseFlags) {
++        this(location.getWorld(), location.getX(), location.getY(), location.getZ(), location.getYaw(), location.getPitch(), velocity, poseFlags);
++    }
++
++    /**
++     * Create a new EntityLocation from the given values, with zero velocity and no {@link PoseFlag}s.
++     */
++    public EntityLocation(World world, double x, double y, double z, float yaw, float pitch) {
++        this(world, x, y, z, yaw, pitch, new Vector(), EnumSet.noneOf(PoseFlag.class));
++    }
++
++    public static EntityLocation coerce(Vector value, EntityLocation defaults) {
++        if(value instanceof EntityLocation) {
++            return (EntityLocation) value;
++        } else if(value instanceof Location) {
++            return new EntityLocation((Location) value, defaults.velocity(), defaults.poseFlags());
++        } else {
++            return new EntityLocation(defaults.getWorld(), value, defaults.getYaw(), defaults.getPitch(), defaults.velocity(), defaults.poseFlags());
++        }
++    }
++
++    public static EntityLocation copyOf(Location location, Vector velocity, Set<PoseFlag> poseFlags) {
++        return new EntityLocation(location, Vector.copyOf(velocity), EnumUtils.copySet(PoseFlag.class, poseFlags));
++    }
++
++    public static EntityLocation copyOf(EntityLocation that) {
++        return copyOf(that, that.velocity(), that.poseFlags());
++    }
++
++    /**
++     * Mutable velocity vector.
++     *
++     * Changes to the returned object are reflected in this {@link EntityLocation},
++     * and vice-versa.
++     */
++    public Vector velocity() {
++        return velocity;
++    }
++
++    /**
++     * A mutable set of {@link PoseFlag}s.
++     *
++     * Changes to the returned object are reflected in this {@link EntityLocation},
++     * and vice-versa.
++     */
++    public Set<PoseFlag> poseFlags() {
++        return poseFlags;
++    }
++
++    @Override
++    public String toString() {
++        return getClass().getSimpleName() +
++               "{world=" + getWorld() +
++               " x=" + getX() +
++               " y=" + getY() +
++               " z=" + getZ() +
++               " pitch=" + getPitch() +
++               " yaw=" + getYaw() +
++               " velocity=" + velocity() +
++               " poseFlags=" + poseFlags() +
++               '}';
++    }
++
++    @Override
++    public boolean equals(Object that) {
++        return this == that || (
++            super.equals(that) &&
++            that instanceof EntityLocation &&
++            this.velocity.equals(((EntityLocation) that).velocity()) &&
++            this.poseFlags.equals(((EntityLocation) that).poseFlags())
++        );
++    }
++
++    @Override
++    public int hashCode() {
++        return Arrays.hashCode(new Object[] {super.hashCode(), velocity, poseFlags});
++    }
++
++    @Override
++    public EntityLocation clone() {
++        // Can't call super.clone(), because we have final fields
++        return copyOf(this);
++    }
++}
+diff --git a/src/main/java/org/bukkit/Location.java b/src/main/java/org/bukkit/Location.java
+index 89f25d9..91a981d 100644
+--- a/src/main/java/org/bukkit/Location.java
++++ b/src/main/java/org/bukkit/Location.java
+@@ -481,6 +481,25 @@ public class Location extends Vector implements Cloneable, ConfigurationSerializ
+     }
+ 
+     /**
++     * Copy yaw and pitch from the given {@link Location} to this one.
++     * @return this object
++     */
++    public Location copyAngles(Location loc) {
++        this.yaw = loc.getYaw();
++        this.pitch = loc.getPitch();
++        return this;
++    }
++
++    /**
++     * Copy position and angles from the given {@link Location} to this one.
++     * @return this object
++     */
++    public Location copyLocation(Location loc) {
++        super.copy(loc);
++        return copyAngles(loc);
++    }
++
++    /**
+      * Zero this location's components. Not world-aware.
+      *
+      * @see Vector
+diff --git a/src/main/java/org/bukkit/PoseFlag.java b/src/main/java/org/bukkit/PoseFlag.java
+new file mode 100644
+index 0000000..4d8fbee
+--- /dev/null
++++ b/src/main/java/org/bukkit/PoseFlag.java
+@@ -0,0 +1,41 @@
++package org.bukkit;
++
++import org.bukkit.entity.Entity;
++import org.bukkit.entity.HumanEntity;
++import org.bukkit.entity.LivingEntity;
++import org.bukkit.entity.Player;
++
++public enum PoseFlag {
++    /** @see Entity#isOnGround() */
++    GROUNDED,
++
++    /** @see Entity#isDead() */
++    DEAD,
++
++    /** @see HumanEntity#isSleeping() */
++    SLEEPING,
++
++    /** @see Player#isSneaking() */
++    SNEAKING,
++
++    /** @see Player#isSprinting() */
++    SPRINTING,
++
++    /** @see HumanEntity#isBlocking() */
++    BLOCKING,
++
++    /** @see Player#isDigging() */
++    DIGGING,
++
++    /** @see LivingEntity#isGliding() */
++    GLIDING,
++
++    /** @see Player#isFlying() */
++    FLYING,
++
++    /** @see LivingEntity#isLeashed() */
++    LEASHED,
++
++    /** @see Entity#isInsideVehicle() */
++    RIDING;
++}
+diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
+index 1fa3059..fa44c2f 100644
+--- a/src/main/java/org/bukkit/entity/Entity.java
++++ b/src/main/java/org/bukkit/entity/Entity.java
+@@ -1,7 +1,9 @@
+ package org.bukkit.entity;
+ 
++import org.bukkit.EntityLocation;
+ import org.bukkit.Location;
+ import org.bukkit.EntityEffect;
++import org.bukkit.PoseFlag;
+ import org.bukkit.Server;
+ import org.bukkit.World;
+ import org.bukkit.Physical;
+@@ -11,6 +13,7 @@ import org.bukkit.util.Cuboid;
+ import org.bukkit.util.Vector;
+ 
+ import java.util.List;
++import java.util.Set;
+ import java.util.UUID;
+ import org.bukkit.command.CommandSender;
+ import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
+@@ -27,6 +30,8 @@ public interface Entity extends Metadatable, CommandSender, Physical {
+      */
+     public Location getLocation();
+ 
++    EntityLocation getEntityLocation();
++
+     /**
+      * Stores the entity's current position in the provided Location object.
+      * <p>
+@@ -39,6 +44,11 @@ public interface Entity extends Metadatable, CommandSender, Physical {
+     public Location getLocation(Location loc);
+ 
+     /**
++     * The set of {@link PoseFlag}s describing this entity's current state
++     */
++    Set<PoseFlag> getPoseFlags();
++
++    /**
+      * Sets this entity's velocity
+      *
+      * @param velocity New velocity to travel with
+diff --git a/src/main/java/org/bukkit/event/player/PlayerMoveEvent.java b/src/main/java/org/bukkit/event/player/PlayerMoveEvent.java
+index 7687667..9445a7c 100644
+--- a/src/main/java/org/bukkit/event/player/PlayerMoveEvent.java
++++ b/src/main/java/org/bukkit/event/player/PlayerMoveEvent.java
+@@ -1,6 +1,7 @@
+ package org.bukkit.event.player;
+ 
+ import com.google.common.base.Preconditions;
++import org.bukkit.EntityLocation;
+ import org.bukkit.Location;
+ import org.bukkit.entity.Player;
+ import org.bukkit.event.Cancellable;
+@@ -12,15 +13,21 @@ import org.bukkit.event.HandlerList;
+ public class PlayerMoveEvent extends PlayerActionBase implements Cancellable {
+     private static final HandlerList handlers = new HandlerList();
+     private boolean cancel = false;
+-    private Location from;
+-    private Location to;
++    private EntityLocation from;
++    private EntityLocation to;
+ 
+-    public PlayerMoveEvent(final Player player, final Location from, final Location to) {
++    public PlayerMoveEvent(final Player player, final EntityLocation from, final EntityLocation to) {
+         super(player);
+         this.from = from;
+         this.to = to;
+     }
+ 
++    public PlayerMoveEvent(final Player player, final Location from, final Location to) {
++        this(player,
++             EntityLocation.coerce(from, player.getEntityLocation()),
++             EntityLocation.coerce(to, player.getEntityLocation()));
++    }
++
+     /**
+      * Gets the cancellation state of this event. A cancelled event will not
+      * be executed in the server, but will still pass to other plugins
+@@ -58,6 +65,10 @@ public class PlayerMoveEvent extends PlayerActionBase implements Cancellable {
+         return from;
+     }
+ 
++    public EntityLocation getEntityFrom() {
++        return from;
++    }
++
+     /**
+      * Sets the location to mark as where the player moved from
+      *
+@@ -65,7 +76,7 @@ public class PlayerMoveEvent extends PlayerActionBase implements Cancellable {
+      */
+     public void setFrom(Location from) {
+         validateLocation(from);
+-        this.from = from;
++        this.from = EntityLocation.coerce(from, this.from);
+     }
+ 
+     /**
+@@ -77,6 +88,10 @@ public class PlayerMoveEvent extends PlayerActionBase implements Cancellable {
+         return to;
+     }
+ 
++    public EntityLocation getEntityTo() {
++        return to;
++    }
++
+     /**
+      * Sets the location that this player will move to
+      *
+@@ -84,7 +99,7 @@ public class PlayerMoveEvent extends PlayerActionBase implements Cancellable {
+      */
+     public void setTo(Location to) {
+         validateLocation(to);
+-        this.to = to;
++        this.to = EntityLocation.coerce(to, this.to);
+     }
+ 
+     private void validateLocation(Location loc) {
+diff --git a/src/main/java/org/bukkit/util/EnumUtils.java b/src/main/java/org/bukkit/util/EnumUtils.java
+new file mode 100644
+index 0000000..d064568
+--- /dev/null
++++ b/src/main/java/org/bukkit/util/EnumUtils.java
+@@ -0,0 +1,22 @@
++package org.bukkit.util;
++
++import java.util.Collection;
++import java.util.EnumSet;
++import java.util.Set;
++
++public final class EnumUtils {
++    private EnumUtils() {}
++
++    /**
++     * Create a new {@link EnumSet} of the given type, copying the initial
++     * contents from the given set.
++     *
++     * Unlike {@link EnumSet#copyOf(Collection)}, this method always works,
++     * even if the given set is empty, and is not another {@link EnumSet}.
++     */
++    public static <E extends Enum<E>> EnumSet<E> copySet(Class<E> type, Set<E> set) {
++        final EnumSet<E> copy = EnumSet.noneOf(type);
++        copy.addAll(set);
++        return copy;
++    }
++}
+diff --git a/src/main/java/org/bukkit/util/Vector.java b/src/main/java/org/bukkit/util/Vector.java
+index 2864442..dc7525f 100644
+--- a/src/main/java/org/bukkit/util/Vector.java
++++ b/src/main/java/org/bukkit/util/Vector.java
+@@ -754,6 +754,10 @@ public class Vector implements Cloneable, ConfigurationSerializable, BlockPositi
+ 
+     // Construction
+ 
++    public static Vector copyOf(Vector that) {
++        return new Vector(that.getX(), that.getY(), that.getZ());
++    }
++
+     public static Vector interpolate(Vector a, Vector b, double n) {
+         return new Vector(NumberConversions.interpolate(a.getX(), b.getX(), n),
+                           NumberConversions.interpolate(a.getY(), b.getY(), n),
+-- 
+1.9.0
+

--- a/CraftBukkit/0156-Add-PoseFlag-and-EntityLocation.patch
+++ b/CraftBukkit/0156-Add-PoseFlag-and-EntityLocation.patch
@@ -1,0 +1,442 @@
+From e8063d9c9f61b7f2ddb9d3bad1f7d7c1c61b14c5 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Fri, 1 Jul 2016 03:36:25 -0400
+Subject: [PATCH] Add PoseFlag and EntityLocation
+
+
+diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
+index 22da30e..84a728f 100644
+--- a/src/main/java/net/minecraft/server/Entity.java
++++ b/src/main/java/net/minecraft/server/Entity.java
+@@ -17,12 +17,15 @@ import org.apache.logging.log4j.Logger;
+ 
+ // CraftBukkit start
+ import org.bukkit.Bukkit;
++import org.bukkit.EntityLocation;
+ import org.bukkit.Location;
++import org.bukkit.PoseFlag;
+ import org.bukkit.Server;
+ import org.bukkit.TravelAgent;
+ import org.bukkit.block.BlockFace;
+ import org.bukkit.entity.Hanging;
+ import org.bukkit.entity.LivingEntity;
++import org.bukkit.entity.Player;
+ import org.bukkit.entity.Vehicle;
+ import org.bukkit.event.entity.EntityExtinguishEvent;
+ import org.bukkit.event.entity.EntityCombustByBlockEvent;
+@@ -1717,6 +1720,12 @@ public abstract class Entity implements ICommandListener {
+                          getBukkitEntity()
+                 );
+                 Bukkit.getPluginManager().callEvent(event);
++                if(getBukkitEntity() instanceof Player) {
++                    final Player player = (Player) getBukkitEntity();
++                    final EntityLocation newLocation = player.getEntityLocation();
++                    newLocation.copy(entity.getBukkitEntity().getLocation());
++                    CraftEventFactory.callPlayerPoseFlagEvent(player, PoseFlag.RIDING, true, newLocation, event);
++                }
+                 CraftEntity craftn = (CraftEntity) getBukkitEntity().getVehicle();
+                 Entity n = craftn == null ? null : craftn.getHandle();
+                 if (event.isCancelled() || n != orig) {
+@@ -1757,6 +1766,9 @@ public abstract class Entity implements ICommandListener {
+                         (LivingEntity) getBukkitEntity()
+                 );
+                 Bukkit.getPluginManager().callEvent(event);
++                if(getBukkitEntity() instanceof Player) {
++                    CraftEventFactory.callPlayerPoseFlagEvent((Player) getBukkitEntity(), PoseFlag.RIDING, false, event);
++                }
+                 CraftEntity craftn = (CraftEntity) getBukkitEntity().getVehicle();
+                 Entity n = craftn == null ? null : craftn.getHandle();
+                 if (event.isCancelled() || n != orig) {
+diff --git a/src/main/java/net/minecraft/server/EntityHuman.java b/src/main/java/net/minecraft/server/EntityHuman.java
+index 8c1f9a4..4d92cc8 100644
+--- a/src/main/java/net/minecraft/server/EntityHuman.java
++++ b/src/main/java/net/minecraft/server/EntityHuman.java
+@@ -12,6 +12,7 @@ import java.util.UUID;
+ import javax.annotation.Nullable;
+ 
+ // CraftBukkit start
++import org.bukkit.PoseFlag;
+ import org.bukkit.craftbukkit.entity.CraftHumanEntity;
+ import org.bukkit.craftbukkit.entity.CraftItem;
+ import org.bukkit.craftbukkit.event.CraftEventFactory;
+@@ -20,6 +21,7 @@ import org.bukkit.event.entity.EntityCombustByEntityEvent;
+ import org.bukkit.event.player.PlayerBedEnterEvent;
+ import org.bukkit.event.player.PlayerBedLeaveEvent;
+ import org.bukkit.event.player.PlayerDropItemEvent;
++import org.bukkit.event.player.PlayerMoveEvent;
+ import org.bukkit.event.player.PlayerVelocityEvent;
+ import org.bukkit.util.Vector;
+ // CraftBukkit end
+@@ -1268,6 +1270,7 @@ public abstract class EntityHuman extends EntityLiving {
+ 
+             PlayerBedEnterEvent event = new PlayerBedEnterEvent(player, bed);
+             this.world.getServer().getPluginManager().callEvent(event);
++            CraftEventFactory.callPlayerPoseFlagEvent(player, PoseFlag.SLEEPING, true, event);
+ 
+             if (event.isCancelled()) {
+                 return EnumBedResult.OTHER_PROBLEM;
+@@ -1373,6 +1376,7 @@ public abstract class EntityHuman extends EntityLiving {
+ 
+             PlayerBedLeaveEvent event = new PlayerBedLeaveEvent(player, bed);
+             this.world.getServer().getPluginManager().callEvent(event);
++            CraftEventFactory.callPlayerPoseFlagEvent(player, PoseFlag.SLEEPING, false, null);
+         }
+         // CraftBukkit end
+ 
+diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
+index 336882c..61cdba3 100644
+--- a/src/main/java/net/minecraft/server/PlayerConnection.java
++++ b/src/main/java/net/minecraft/server/PlayerConnection.java
+@@ -25,7 +25,9 @@ import java.util.concurrent.ExecutionException;
+ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+ import java.util.Arrays;
+ 
++import org.bukkit.EntityLocation;
+ import org.bukkit.Location;
++import org.bukkit.PoseFlag;
+ import org.bukkit.craftbukkit.entity.CraftPlayer;
+ import org.bukkit.craftbukkit.event.CraftEventFactory;
+ import org.bukkit.craftbukkit.inventory.CraftInventoryView;
+@@ -425,8 +427,8 @@ public class PlayerConnection implements PacketListenerPlayIn, ITickable {
+                     hasMoved = true;
+                 }
+                 // Spigot End
+-                Location from = new Location(player.getWorld(), lastPosX, lastPosY, lastPosZ, lastYaw, lastPitch); // Get the Players previous Event location.
+-                Location to = player.getLocation().clone(); // Start off the To location as the Players current location.
++                EntityLocation from = new EntityLocation(player.getWorld(), lastPosX, lastPosY, lastPosZ, lastYaw, lastPitch, player.getVelocity(), player.getPoseFlags()); // Get the Player's previous Event location.
++                EntityLocation to = player.getEntityLocation(); // Start off the To location as the Players current location.
+ 
+                 // If the packet contains movement information then we update the To location with the correct XYZ.
+                 to.setX(packetplayinvehiclemove.getX());
+@@ -645,8 +647,14 @@ public class PlayerConnection implements PacketListenerPlayIn, ITickable {
+                         this.player.setLocation(prevX, prevY, prevZ, prevYaw, prevPitch);
+ 
+                         Player player = this.getPlayer();
+-                        Location from = new Location(player.getWorld(), lastPosX, lastPosY, lastPosZ, lastYaw, lastPitch); // Get the Players previous Event location.
+-                        Location to = player.getLocation().clone(); // Start off the To location as the Players current location.
++                        EntityLocation from = new EntityLocation(player.getWorld(), lastPosX, lastPosY, lastPosZ, lastYaw, lastPitch, player.getVelocity(), player.getPoseFlags()); // Get the Players previous Event location.
++                        EntityLocation to = player.getEntityLocation(); // Start off the To location as the Players current location.
++
++                        if(packetplayinflying.a()) {
++                            to.poseFlags().add(PoseFlag.GROUNDED);
++                        } else {
++                            to.poseFlags().remove(PoseFlag.GROUNDED);
++                        }
+ 
+                         // If the packet contains movement information then we update the To location with the correct XYZ.
+                         if (packetplayinflying.hasPos) {
+@@ -1555,6 +1563,7 @@ public class PlayerConnection implements PacketListenerPlayIn, ITickable {
+             case STOP_SNEAKING:
+                 PlayerToggleSneakEvent event = new PlayerToggleSneakEvent(this.getPlayer(), packetplayinentityaction.b() == PacketPlayInEntityAction.EnumPlayerAction.START_SNEAKING);
+                 this.server.getPluginManager().callEvent(event);
++                CraftEventFactory.callPlayerPoseFlagEvent(this.getPlayer(), PoseFlag.SNEAKING, event.isSneaking(), event);
+ 
+                 if (event.isCancelled()) {
+                     return;
+@@ -1564,6 +1573,7 @@ public class PlayerConnection implements PacketListenerPlayIn, ITickable {
+             case STOP_SPRINTING:
+                 PlayerToggleSprintEvent e2 = new PlayerToggleSprintEvent(this.getPlayer(), packetplayinentityaction.b() == PacketPlayInEntityAction.EnumPlayerAction.START_SPRINTING);
+                 this.server.getPluginManager().callEvent(e2);
++                CraftEventFactory.callPlayerPoseFlagEvent(this.getPlayer(), PoseFlag.SPRINTING, e2.isSprinting(), e2);
+ 
+                 if (e2.isCancelled()) {
+                     return;
+@@ -2287,6 +2297,7 @@ public class PlayerConnection implements PacketListenerPlayIn, ITickable {
+         if (this.player.abilities.canFly && this.player.abilities.isFlying != packetplayinabilities.isFlying()) {
+             PlayerToggleFlightEvent event = new PlayerToggleFlightEvent(this.server.getPlayer(this.player), packetplayinabilities.isFlying());
+             this.server.getPluginManager().callEvent(event);
++            CraftEventFactory.callPlayerPoseFlagEvent(this.getPlayer(), PoseFlag.FLYING, event.isFlying(), event);
+             if (!event.isCancelled()) {
+                 this.player.abilities.isFlying = packetplayinabilities.isFlying(); // Actually set the player's flying status
+             } else {
+diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
+index ca80a08..38f2222 100644
+--- a/src/main/java/net/minecraft/server/PlayerList.java
++++ b/src/main/java/net/minecraft/server/PlayerList.java
+@@ -20,6 +20,7 @@ import org.apache.logging.log4j.LogManager;
+ import org.apache.logging.log4j.Logger;
+ 
+ // CraftBukkit start
++import org.bukkit.PoseFlag;
+ import org.bukkit.craftbukkit.CraftServer;
+ import org.bukkit.craftbukkit.CraftWorld;
+ import org.bukkit.craftbukkit.chunkio.ChunkIOExecutor;
+@@ -28,6 +29,7 @@ import org.bukkit.Bukkit;
+ import org.bukkit.Location;
+ import org.bukkit.TravelAgent;
+ import org.bukkit.craftbukkit.entity.CraftPlayer;
++import org.bukkit.craftbukkit.event.CraftEventFactory;
+ import org.bukkit.craftbukkit.util.CraftChatMessage;
+ import org.bukkit.entity.Player;
+ import org.bukkit.event.player.PlayerChangedWorldEvent;
+@@ -704,6 +706,7 @@ public abstract class PlayerList {
+             this.savePlayerFile(entityplayer);
+         }
+         // CraftBukkit end
++        CraftEventFactory.callPlayerPoseFlagEvent(entityplayer1.getBukkitEntity(), PoseFlag.DEAD, false, null); // SportBukkit
+         return entityplayer1;
+     }
+ 
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
+index 556020d..78480c5 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
+@@ -6,6 +6,7 @@ import com.google.common.base.Preconditions;
+ import java.util.ArrayList;
+ import java.util.Collection;
+ import java.util.Collections;
++import java.util.EnumSet;
+ import java.util.List;
+ import java.util.Set;
+ import java.util.UUID;
+@@ -16,7 +17,9 @@ import net.md_5.bungee.api.chat.BaseComponent;
+ import net.minecraft.server.*;
+ 
+ import org.bukkit.EntityEffect;
++import org.bukkit.EntityLocation;
+ import org.bukkit.Location;
++import org.bukkit.PoseFlag;
+ import org.bukkit.Server;
+ import org.bukkit.World;
+ import org.bukkit.command.CommandSender;
+@@ -196,7 +199,12 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+     }
+ 
+     public Location getLocation() {
+-        return new Location(getWorld(), entity.locX, entity.locY, entity.locZ, entity.yaw, entity.pitch);
++        return getEntityLocation();
++    }
++
++    @Override
++    public EntityLocation getEntityLocation() {
++        return new EntityLocation(getWorld(), entity.locX, entity.locY, entity.locZ, entity.yaw, entity.pitch, getVelocity(), getPoseFlags());
+     }
+ 
+     public Location getLocation(Location loc) {
+@@ -207,11 +215,26 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+             loc.setZ(entity.locZ);
+             loc.setYaw(entity.yaw);
+             loc.setPitch(entity.pitch);
++
++            if(loc instanceof EntityLocation) {
++                final Set<PoseFlag> flags = ((EntityLocation) loc).poseFlags();
++                flags.clear();
++                flags.addAll(getPoseFlags());
++            }
+         }
+ 
+         return loc;
+     }
+ 
++    @Override
++    public EnumSet<PoseFlag> getPoseFlags() {
++        final EnumSet<PoseFlag> flags = EnumSet.noneOf(PoseFlag.class);
++        if(isOnGround()) flags.add(PoseFlag.GROUNDED);
++        if(isDead()) flags.add(PoseFlag.DEAD);
++        if(isInsideVehicle()) flags.add(PoseFlag.RIDING);
++        return flags;
++    }
++
+     public Vector getVelocity() {
+         return new Vector(entity.motX, entity.motY, entity.motZ);
+     }
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
+index 9dd6cbf..de7587f 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
+@@ -2,12 +2,14 @@ package org.bukkit.craftbukkit.entity;
+ 
+ import com.google.common.base.Preconditions;
+ import java.util.Collection;
++import java.util.EnumSet;
+ import java.util.Set;
+ 
+ import net.minecraft.server.*;
+ 
+ import org.bukkit.GameMode;
+ import org.bukkit.Location;
++import org.bukkit.PoseFlag;
+ import org.bukkit.inventory.MainHand;
+ import org.bukkit.Material;
+ import org.bukkit.entity.HumanEntity;
+@@ -492,4 +494,12 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
+         final float f = getHandle().o(0.5f);
+         return 0.2f + f * f * 0.8f;
+     }
++
++    @Override
++    public EnumSet<PoseFlag> getPoseFlags() {
++        final EnumSet<PoseFlag> flags = super.getPoseFlags();
++        if(isSleeping()) flags.add(PoseFlag.SLEEPING);
++        if(isBlocking()) flags.add(PoseFlag.BLOCKING);
++        return flags;
++    }
+ }
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
+index 58b7845..cab841c 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
+@@ -2,6 +2,7 @@ package org.bukkit.craftbukkit.entity;
+ 
+ import java.util.ArrayList;
+ import java.util.Collection;
++import java.util.EnumSet;
+ import java.util.HashSet;
+ import java.util.Iterator;
+ import java.util.List;
+@@ -36,6 +37,7 @@ import net.minecraft.server.MobEffectList;
+ import org.apache.commons.lang.Validate;
+ import org.bukkit.Location;
+ import org.bukkit.Material;
++import org.bukkit.PoseFlag;
+ import org.bukkit.attribute.Attribute;
+ import org.bukkit.attribute.AttributeInstance;
+ import org.bukkit.block.Block;
+@@ -589,4 +591,12 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+     public void setArrowsStuck(int arrows) {
+         getHandle().setArrowsStuck(arrows);
+     }
++
++    @Override
++    public EnumSet<PoseFlag> getPoseFlags() {
++        final EnumSet<PoseFlag> flags = super.getPoseFlags();
++        if(isGliding()) flags.add(PoseFlag.GLIDING);
++        if(isLeashed()) flags.add(PoseFlag.LEASHED);
++        return flags;
++    }
+ }
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+index 26af066..c287fe7 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+@@ -12,6 +12,7 @@ import java.net.InetSocketAddress;
+ import java.net.SocketAddress;
+ import java.util.ArrayList;
+ import java.util.Collection;
++import java.util.EnumSet;
+ import java.util.HashSet;
+ import java.util.LinkedHashMap;
+ import java.util.List;
+@@ -2025,4 +2026,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+     public float getRemainingItemCooldown(Material item) {
+         return getHandle().getItemCooldown().a(CraftMagicNumbers.getItem(item), 0F);
+     }
++
++    @Override
++    public EnumSet<PoseFlag> getPoseFlags() {
++        final EnumSet<PoseFlag> flags = super.getPoseFlags();
++        if(isSneaking()) flags.add(PoseFlag.SNEAKING);
++        if(isSprinting()) flags.add(PoseFlag.SPRINTING);
++        if(isDigging()) flags.add(PoseFlag.DIGGING);
++        if(isFlying()) flags.add(PoseFlag.FLYING);
++        return flags;
++    }
+ }
+diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+index 2c8986f..1f6916f 100644
+--- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
++++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+@@ -13,7 +13,10 @@ import com.google.common.base.Functions;
+ import net.minecraft.server.*;
+ 
+ import org.bukkit.Bukkit;
++import org.bukkit.EntityLocation;
++import org.bukkit.Location;
+ import org.bukkit.Material;
++import org.bukkit.PoseFlag;
+ import org.bukkit.Server;
+ import org.bukkit.Statistic.Type;
+ import org.bukkit.block.Block;
+@@ -267,6 +270,8 @@ public class CraftEventFactory {
+         BlockDamageEvent event = new BlockDamageEvent(player, blockClicked, itemInHand, instaBreak);
+         craftServer.getPluginManager().callEvent(event);
+ 
++        callPlayerPoseFlagEvent(player, PoseFlag.DIGGING, true, event);
++
+         return event;
+     }
+ 
+@@ -274,7 +279,7 @@ public class CraftEventFactory {
+         Player player = who.getBukkitEntity();
+         BlockUndamageEvent event = new BlockUndamageEvent(player, player.getWorld().getBlockAt(x, y, z));
+         player.getServer().getPluginManager().callEvent(event);
+-
++        callPlayerPoseFlagEvent(player, PoseFlag.DIGGING, false, null);
+         return event;
+     }
+ 
+@@ -417,6 +422,8 @@ public class CraftEventFactory {
+         org.bukkit.World world = entity.getWorld();
+         Bukkit.getServer().getPluginManager().callEvent(event);
+ 
++        callPlayerPoseFlagEvent(entity, PoseFlag.DEAD, true, null);
++
+         victim.keepLevel = event.getKeepLevel();
+         victim.newLevel = event.getNewLevel();
+         victim.newTotalExp = event.getNewTotalExp();
+@@ -939,12 +946,18 @@ public class CraftEventFactory {
+     public static PlayerUnleashEntityEvent callPlayerUnleashEntityEvent(EntityInsentient entity, EntityHuman player) {
+         PlayerUnleashEntityEvent event = new PlayerUnleashEntityEvent(entity.getBukkitEntity(), (Player) player.getBukkitEntity());
+         entity.world.getServer().getPluginManager().callEvent(event);
++        if(entity.getBukkitEntity() instanceof Player) {
++            callPlayerPoseFlagEvent((Player) entity.getBukkitEntity(), PoseFlag.LEASHED, false, event);
++        }
+         return event;
+     }
+ 
+     public static PlayerLeashEntityEvent callPlayerLeashEntityEvent(EntityInsentient entity, Entity leashHolder, EntityHuman player) {
+         PlayerLeashEntityEvent event = new PlayerLeashEntityEvent(entity.getBukkitEntity(), leashHolder.getBukkitEntity(), (Player) player.getBukkitEntity());
+         entity.world.getServer().getPluginManager().callEvent(event);
++        if(entity.getBukkitEntity() instanceof Player) {
++            callPlayerPoseFlagEvent((Player) entity.getBukkitEntity(), PoseFlag.LEASHED, true, event);
++        }
+         return event;
+     }
+ 
+@@ -1019,6 +1032,9 @@ public class CraftEventFactory {
+     public static EntityToggleGlideEvent callToggleGlideEvent(EntityLiving entity, boolean gliding) {
+         EntityToggleGlideEvent event = new EntityToggleGlideEvent((LivingEntity) entity.getBukkitEntity(), gliding);
+         entity.world.getServer().getPluginManager().callEvent(event);
++        if(entity.getBukkitEntity() instanceof Player) {
++            callPlayerPoseFlagEvent((Player) entity.getBukkitEntity(), PoseFlag.GLIDING, gliding, event);
++        }
+         return event;
+     }
+ 
+@@ -1098,4 +1114,33 @@ public class CraftEventFactory {
+         world.getServer().getPluginManager().callEvent(event);
+         return event;
+     }
++
++    public static PlayerMoveEvent callPlayerPoseFlagEvent(Player player, PoseFlag flag, boolean newState, Cancellable priorEvent) {
++        return callPlayerPoseFlagEvent(player, flag, newState, player.getEntityLocation(), priorEvent);
++    }
++
++    public static PlayerMoveEvent callPlayerPoseFlagEvent(Player player, PoseFlag flag, boolean newState, EntityLocation to, Cancellable priorEvent) {
++        final EntityLocation from = player.getEntityLocation();
++
++        if(newState) {
++            from.poseFlags().remove(flag);
++            to.poseFlags().add(flag);
++        } else {
++            from.poseFlags().add(flag);
++            to.poseFlags().remove(flag);
++        }
++
++        final PlayerMoveEvent moveEvent = new PlayerMoveEvent(player, from, to);
++        if(priorEvent != null) {
++            moveEvent.setCancelled(priorEvent.isCancelled());
++        }
++
++        player.getServer().getPluginManager().callEvent(moveEvent);
++
++        if(priorEvent != null) {
++            priorEvent.setCancelled(moveEvent.isCancelled());
++        }
++
++        return moveEvent;
++    }
+ }
+-- 
+1.9.0
+


### PR DESCRIPTION
* Add an enum called `MotionFlag` that enumerates several of the `Entity` physical state flags, and `Entity#getMotionFlags()`
* Add `EntityLocation` extending `Location` that includes velocity and motion flags. Return this from `Entity#getLocation()` but also add `Entity#getEntityLocation()` with the narrowed return type.
* Extend `PlayerMoveEvent` to provide `EntityLocation`s (with backwards compatibility) and fire it when any of the flags change (except `BLOCKING`)