### PR TITLE
Server suspend API

### DIFF
--- a/Bukkit/0002-Remove-BukkitMirrorTest.patch
+++ b/Bukkit/0002-Remove-BukkitMirrorTest.patch
@@ -1,0 +1,90 @@
+From 2df9df0c652e987f7ee2946c9a7992fb97b8cbd7 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Sat, 10 Dec 2016 20:15:32 -0500
+Subject: [PATCH] Remove BukkitMirrorTest
+
+
+diff --git a/src/test/java/org/bukkit/BukkitMirrorTest.java b/src/test/java/org/bukkit/BukkitMirrorTest.java
+deleted file mode 100644
+index 219788f..0000000
+--- a/src/test/java/org/bukkit/BukkitMirrorTest.java
++++ /dev/null
+@@ -1,75 +0,0 @@
+-package org.bukkit;
+-
+-import static org.hamcrest.Matchers.*;
+-import static org.junit.Assert.*;
+-
+-import java.lang.reflect.Method;
+-import java.lang.reflect.Modifier;
+-import java.util.Arrays;
+-import java.util.List;
+-
+-import org.junit.Before;
+-import org.junit.Test;
+-import org.junit.runner.RunWith;
+-import org.junit.runners.Parameterized;
+-import org.junit.runners.Parameterized.Parameter;
+-import org.junit.runners.Parameterized.Parameters;
+-
+-import com.google.common.base.Function;
+-import com.google.common.collect.Lists;
+-
+-@RunWith(Parameterized.class)
+-public class BukkitMirrorTest {
+-
+-    @Parameters(name="{index}: {1}")
+-    public static List<Object[]> data() {
+-        return Lists.transform(Arrays.asList(Server.class.getDeclaredMethods()), new Function<Method, Object[]>() {
+-            @Override
+-            public Object[] apply(Method input) {
+-                return new Object[] {
+-                    input,
+-                    input.toGenericString().substring("public abstract ".length()).replace("(", "{").replace(")", "}")
+-                    };
+-            }
+-        });
+-    }
+-
+-    @Parameter(0)
+-    public Method server;
+-
+-    @Parameter(1)
+-    public String name;
+-
+-    private Method bukkit;
+-
+-    @Before
+-    public void makeBukkit() throws Throwable {
+-        bukkit = Bukkit.class.getDeclaredMethod(server.getName(), server.getParameterTypes());
+-    }
+-
+-    @Test
+-    public void isStatic() throws Throwable {
+-        assertThat(Modifier.isStatic(bukkit.getModifiers()), is(true));
+-    }
+-
+-    @Test
+-    public void isDeprecated() throws Throwable {
+-        assertThat(bukkit.isAnnotationPresent(Deprecated.class), is(server.isAnnotationPresent(Deprecated.class)));
+-    }
+-
+-    @Test
+-    public void returnType() throws Throwable {
+-        assertThat(bukkit.getReturnType(), is((Object) server.getReturnType()));
+-        assertThat(bukkit.getGenericReturnType(), is(server.getGenericReturnType()));
+-    }
+-
+-    @Test
+-    public void parameterTypes() throws Throwable {
+-        assertThat(bukkit.getGenericParameterTypes(), is(server.getGenericParameterTypes()));
+-    }
+-
+-    @Test
+-    public void declaredException() throws Throwable {
+-        assertThat(bukkit.getGenericExceptionTypes(), is(server.getGenericExceptionTypes()));
+-    }
+-}
+-- 
+1.9.0
+

--- a/Bukkit/0003-Add-methods-for-working-with-arrows-stuck-in-living-.patch
+++ b/Bukkit/0003-Add-methods-for-working-with-arrows-stuck-in-living-.patch
@@ -1,0 +1,32 @@
+From a15cb555e6bc032fba3106dd6238b2201e4749bb Mon Sep 17 00:00:00 2001
+From: mrapple <tony@oc.tc>
+Date: Sun, 25 Nov 2012 13:47:27 -0600
+Subject: [PATCH] Add methods for working with arrows stuck in living entities
+
+
+diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
+index a938b61..e4ccf5b 100644
+--- a/src/main/java/org/bukkit/entity/LivingEntity.java
++++ b/src/main/java/org/bukkit/entity/LivingEntity.java
+@@ -428,4 +428,18 @@ public interface LivingEntity extends Attributable, Entity, Damageable, Projecti
+      * @return collision status
+      */
+     boolean isCollidable();
++
++    /**
++     * Get the number of arrows stuck in this entity
++     *
++     * @return Number of arrows stuck
++     */
++    public int getArrowsStuck();
++
++    /**
++     * Set the number of arrows stuck in this entity
++     *
++     * @param arrows Number of arrows to stick in this entity
++     */
++    public void setArrowsStuck(int arrows);
+ }
+-- 
+1.9.0
+

--- a/Bukkit/0004-Make-AsyncPlayerPreLoginEvent-more-versatile.patch
+++ b/Bukkit/0004-Make-AsyncPlayerPreLoginEvent-more-versatile.patch
@@ -1,0 +1,39 @@
+From b2627e5777000e108e64023bdb471929a364dd04 Mon Sep 17 00:00:00 2001
+From: mrapple <tony@oc.tc>
+Date: Sat, 17 Nov 2012 12:42:05 -0600
+Subject: [PATCH] Make AsyncPlayerPreLoginEvent more versatile
+
+
+diff --git a/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java b/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
+index 1d57188..78c5ea2 100644
+--- a/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
++++ b/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
+@@ -189,6 +189,10 @@ public class AsyncPlayerPreLoginEvent extends Event {
+          */
+         KICK_WHITELIST,
+         /**
++         * The player's username was not verified with Mojang
++         */
++        KICK_VERIFY,
++        /**
+          * The player is not allowed to log in, for reasons undefined
+          */
+         KICK_OTHER;
+diff --git a/src/main/java/org/bukkit/event/player/PlayerPreLoginEvent.java b/src/main/java/org/bukkit/event/player/PlayerPreLoginEvent.java
+index e8553f0..aa49dfa 100644
+--- a/src/main/java/org/bukkit/event/player/PlayerPreLoginEvent.java
++++ b/src/main/java/org/bukkit/event/player/PlayerPreLoginEvent.java
+@@ -152,6 +152,10 @@ public class PlayerPreLoginEvent extends Event {
+          */
+         KICK_WHITELIST,
+         /**
++         * The player's username was not verified with Mojang
++         */
++        KICK_VERIFY,
++        /**
+          * The player is not allowed to log in, for reasons undefined
+          */
+         KICK_OTHER
+-- 
+1.9.0
+

--- a/Bukkit/0005-Add-BlockDispenseEntityEvent.patch
+++ b/Bukkit/0005-Add-BlockDispenseEntityEvent.patch
@@ -1,0 +1,64 @@
+From 15a5c76017223a12124c7de2659ca481d545482a Mon Sep 17 00:00:00 2001
+From: YukonAppleGeek <yukonvinecki@gmail.com>
+Date: Mon, 8 Apr 2013 20:14:25 -0700
+Subject: [PATCH] Add BlockDispenseEntityEvent
+
+
+diff --git a/src/main/java/org/bukkit/event/block/BlockDispenseEntityEvent.java b/src/main/java/org/bukkit/event/block/BlockDispenseEntityEvent.java
+new file mode 100644
+index 0000000..9d2227e
+--- /dev/null
++++ b/src/main/java/org/bukkit/event/block/BlockDispenseEntityEvent.java
+@@ -0,0 +1,49 @@
++package org.bukkit.event.block;
++
++import org.bukkit.Location;
++import org.bukkit.block.Block;
++import org.bukkit.entity.Entity;
++import org.bukkit.event.Cancellable;
++import org.bukkit.inventory.ItemStack;
++import org.bukkit.util.Vector;
++
++/**
++ * Called when an entity is dispensed from a block.
++ */
++public class BlockDispenseEntityEvent extends BlockDispenseEvent implements Cancellable {
++    private final Entity entity;
++    private Location location;
++
++    public BlockDispenseEntityEvent(final Block block, final ItemStack dispensed, final Entity entity) {
++        this(block, dispensed, entity, entity.getLocation(), entity.getVelocity());
++    }
++
++    public BlockDispenseEntityEvent(final Block block, final ItemStack dispensed, final Entity entity, final Location location, final Vector velocity) {
++        super(block, dispensed, velocity);
++        this.entity = entity;
++        this.location = location;
++    }
++
++    /**
++     * Gets the entity that is being dispensed.
++     *
++     * @return An Entity for the item being dispensed
++     */
++    public Entity getEntity() {
++        return entity;
++    }
++
++    /**
++     * Get the initial location of the dispensed entity
++     */
++    public Location getLocation() {
++        return location;
++    }
++
++    /**
++     * Set the initial location of the dispensed entity
++     */
++    public void setLocation(Location location) {
++        this.location = location;
++    }
++}
+-- 
+1.9.0
+

--- a/Bukkit/0006-Add-BlockFallEvent.patch
+++ b/Bukkit/0006-Add-BlockFallEvent.patch
@@ -1,0 +1,54 @@
+From f05eb52f32d24f03f105d00e885bc47b1eac7659 Mon Sep 17 00:00:00 2001
+From: YukonAppleGeek <yukonvinecki@gmail.com>
+Date: Thu, 27 Jun 2013 22:49:42 -0700
+Subject: [PATCH] Add BlockFallEvent
+
+
+diff --git a/src/main/java/org/bukkit/event/block/BlockFallEvent.java b/src/main/java/org/bukkit/event/block/BlockFallEvent.java
+new file mode 100644
+index 0000000..f1f4e84
+--- /dev/null
++++ b/src/main/java/org/bukkit/event/block/BlockFallEvent.java
+@@ -0,0 +1,39 @@
++package org.bukkit.event.block;
++
++import org.bukkit.block.Block;
++import org.bukkit.entity.FallingBlock;
++import org.bukkit.event.Cancellable;
++import org.bukkit.event.HandlerList;
++
++public class BlockFallEvent extends BlockEvent implements Cancellable {
++    private static final HandlerList handlers = new HandlerList();
++    private FallingBlock fallingBlock;
++    private boolean cancelled = false;
++
++    public BlockFallEvent(final Block block, final FallingBlock fallingBlock) {
++        super(block);
++        this.fallingBlock = fallingBlock;
++    }
++
++    public FallingBlock getEntity() {
++        return fallingBlock;
++    }
++
++    public boolean isCancelled() {
++        return cancelled;
++    }
++
++    public void setCancelled(boolean cancel) {
++        this.cancelled = cancel;
++    }
++
++    @Override
++    public HandlerList getHandlers() {
++        return handlers;
++    }
++
++    public static HandlerList getHandlerList() {
++        return handlers;
++    }
++
++}
+-- 
+1.9.0
+

--- a/Bukkit/0007-Entity-ID-API.patch
+++ b/Bukkit/0007-Entity-ID-API.patch
@@ -1,0 +1,45 @@
+From 91962bdf24e6d73d8ee8977c29d8eed799628b2f Mon Sep 17 00:00:00 2001
+From: mrapple <tony@oc.tc>
+Date: Sun, 16 Jun 2013 16:57:59 -0500
+Subject: [PATCH] Entity ID API
+
+
+diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
+index ce6b761..18441fd 100644
+--- a/src/main/java/org/bukkit/Bukkit.java
++++ b/src/main/java/org/bukkit/Bukkit.java
+@@ -1048,6 +1048,13 @@ public final class Bukkit {
+     }
+ 
+     /**
++     * @see Server#allocateEntityId()
++     */
++    public static int allocateEntityId() {
++        return server.allocateEntityId();
++    }
++
++    /**
+      * Gets an instance of the server's default server-icon.
+      *
+      * @return the default server-icon; null values may be used by the
+diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
+index c25fe22..deae5a1 100644
+--- a/src/main/java/org/bukkit/Server.java
++++ b/src/main/java/org/bukkit/Server.java
+@@ -856,6 +856,13 @@ public interface Server extends PluginMessageRecipient {
+     ScoreboardManager getScoreboardManager();
+ 
+     /**
++     * Allocate and return a unique entity ID.
++     *
++     * The returned ID has never been, and will never be used as the ID of a real entity.
++     */
++    int allocateEntityId();
++
++    /**
+      * Gets an instance of the server's default server-icon.
+      *
+      * @return the default server-icon; null values may be used by the
+-- 
+1.9.0
+

--- a/Bukkit/0008-Add-InventoryClickedEvent-an-informative-event-fired.patch
+++ b/Bukkit/0008-Add-InventoryClickedEvent-an-informative-event-fired.patch
@@ -1,0 +1,126 @@
+From 1debbc207ae7b2f5d1c4076d5218eff4a061504b Mon Sep 17 00:00:00 2001
+From: mrapple <tony@oc.tc>
+Date: Mon, 12 Nov 2012 20:31:30 -0600
+Subject: [PATCH] Add InventoryClickedEvent, an informative event fired after
+ every InventoryClickEvent
+
+
+diff --git a/src/main/java/org/bukkit/event/inventory/InventoryClickedEvent.java b/src/main/java/org/bukkit/event/inventory/InventoryClickedEvent.java
+new file mode 100644
+index 0000000..7d27a6e
+--- /dev/null
++++ b/src/main/java/org/bukkit/event/inventory/InventoryClickedEvent.java
+@@ -0,0 +1,110 @@
++package org.bukkit.event.inventory;
++
++import org.bukkit.inventory.Inventory;
++import org.bukkit.inventory.InventoryView;
++import org.bukkit.entity.HumanEntity;
++import org.bukkit.event.Cancellable;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.inventory.InventoryType.SlotType;
++import org.bukkit.inventory.ItemStack;
++
++public class InventoryClickedEvent extends InventoryEvent {
++    private static final HandlerList handlers = new HandlerList();
++    private SlotType slot_type;
++    private boolean rightClick, shiftClick;
++    private Result result;
++    private int whichSlot;
++    private int rawSlot;
++    private ItemStack current = null;
++
++    public InventoryClickedEvent(InventoryView what, SlotType type, int slot, boolean right, boolean shift) {
++        super(what);
++        this.slot_type = type;
++        this.rightClick = right;
++        this.shiftClick = shift;
++        this.result = Result.DEFAULT;
++        this.rawSlot = slot;
++        this.whichSlot = what.convertSlot(slot);
++    }
++
++    /**
++     * Get the type of slot that was clicked.
++     * @return The slot type.
++     */
++    public SlotType getSlotType() {
++        return slot_type;
++    }
++
++    /**
++     * Get the current item on the cursor.
++     * @return The cursor item
++     */
++    public ItemStack getCursor() {
++        return getView().getCursor();
++    }
++
++    /**
++     * Get the current item in the clicked slot.
++     * @return The slot item.
++     */
++    public ItemStack getCurrentItem() {
++        if(slot_type == SlotType.OUTSIDE) return current;
++        return getView().getItem(rawSlot);
++    }
++
++    /**
++     * @return True if the click is a right-click.
++     */
++    public boolean isRightClick() {
++        return rightClick;
++    }
++
++    /**
++     * @return True if the click is a left-click.
++     */
++    public boolean isLeftClick() {
++        return !rightClick;
++    }
++
++    /**
++     * Shift can be combined with right-click or left-click as a modifier.
++     * @return True if the click is a shift-click.
++     */
++    public boolean isShiftClick() {
++        return shiftClick;
++    }
++
++    /**
++     * Get the player who performed the click.
++     * @return The clicking player.
++     */
++    public HumanEntity getWhoClicked() {
++        return getView().getPlayer();
++    }
++
++    /**
++     * The slot number that was clicked, ready for passing to {@link Inventory#getItem(int)}. Note
++     * that there may be two slots with the same slot number, since a view links two different inventories.
++     * @return The slot number.
++     */
++    public int getSlot() {
++        return whichSlot;
++    }
++
++    /**
++     * The raw slot number, which is unique for the view.
++     * @return The slot number.
++     */
++    public int getRawSlot() {
++        return rawSlot;
++    }
++
++    @Override
++    public HandlerList getHandlers() {
++        return handlers;
++    }
++
++    public static HandlerList getHandlerList() {
++        return handlers;
++    }
++}
+-- 
+1.9.0
+

--- a/Bukkit/0009-Add-onGround-API.patch
+++ b/Bukkit/0009-Add-onGround-API.patch
@@ -1,0 +1,47 @@
+From 296acbcd699a4eba90dd8695ece6f470f2fbe1ac Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Tue, 25 Dec 2012 01:50:07 -0500
+Subject: [PATCH] Add onGround API
+
+
+diff --git a/src/main/java/org/bukkit/event/player/PlayerOnGroundEvent.java b/src/main/java/org/bukkit/event/player/PlayerOnGroundEvent.java
+new file mode 100644
+index 0000000..4a6c3d4
+--- /dev/null
++++ b/src/main/java/org/bukkit/event/player/PlayerOnGroundEvent.java
+@@ -0,0 +1,32 @@
++package org.bukkit.event.player;
++
++import org.bukkit.entity.Player;
++import org.bukkit.event.HandlerList;
++
++public class PlayerOnGroundEvent extends PlayerEvent {
++    private static final HandlerList handlers = new HandlerList();
++    private boolean onGround;
++
++    public PlayerOnGroundEvent(final Player player, boolean onGround) {
++        super(player);
++        this.onGround = onGround;
++    }
++    /**
++     * Returns true of the player is on the ground after the event
++     *
++     * @return if the player is on the ground
++     */
++    public boolean getOnGround() {
++        return this.onGround;
++    }
++
++    @Override
++    public HandlerList getHandlers() {
++        return handlers;
++    }
++
++    public static HandlerList getHandlerList() {
++        return handlers;
++    }
++
++}
+-- 
+1.9.0
+

--- a/Bukkit/0010-Allow-playEffect-to-spawn-particles.patch
+++ b/Bukkit/0010-Allow-playEffect-to-spawn-particles.patch
@@ -1,0 +1,331 @@
+From dafaf5c1cba106d9cf5ed75e5df55743c1813bfc Mon Sep 17 00:00:00 2001
+From: Thinkofdeath <purgames@gmail.com>
+Date: Sun, 17 Mar 2013 22:56:14 +0000
+Subject: [PATCH] Allow playEffect to spawn particles
+
+
+diff --git a/src/main/java/org/bukkit/Effect.java b/src/main/java/org/bukkit/Effect.java
+index ba7dc49..d9cb0ca 100644
+--- a/src/main/java/org/bukkit/Effect.java
++++ b/src/main/java/org/bukkit/Effect.java
+@@ -5,6 +5,7 @@ import java.util.Map;
+ import com.google.common.collect.Maps;
+ 
+ import org.bukkit.block.BlockFace;
++import org.bukkit.material.MaterialData;
+ import org.bukkit.potion.Potion;
+ 
+ /**
+@@ -196,23 +197,173 @@ public enum Effect {
+      * The sound of an enderdragon growling
+      */
+     ENDERDRAGON_GROWL(3001, Type.SOUND),
+-    ;
++    /**
++     * The spark that comes off a fireworks
++     */
++    FIREWORKS_SPARK("fireworksSpark", Type.PARTICLE),
++    /**
++     * Critical hit particles
++     */
++    CRIT("crit", Type.PARTICLE),
++    /**
++     * Blue critical hit particles
++     */
++    MAGIC_CRIT("magicCrit", Type.PARTICLE),
++    /**
++     * Multicolored potion effect particles
++     */
++    POTION_SWIRL("mobSpell", Type.PARTICLE),
++    /**
++     * Multicolored potion effect particles that are slightly transparent
++     */
++    POTION_SWIRL_TRANSPARENT("mobSpellAmbient", Type.PARTICLE),
++    /**
++     * A puff of white potion swirls
++     */
++    SPELL("spell", Type.PARTICLE),
++    /**
++     * A puff of white stars
++     */
++    INSTANT_SPELL("instantSpell", Type.PARTICLE),
++    /**
++     * A puff of purple particles
++     */
++    WITCH_MAGIC("witchMagic", Type.PARTICLE),
++    /**
++     * The note that appears above note blocks
++     */
++    NOTE("note", Type.PARTICLE),
++    /**
++     * The particles shown at nether portals
++     */
++    PORTAL("portal", Type.PARTICLE),
++    /**
++     * The symbols that fly towards the enchantment table
++     */
++    FLYING_GLYPH("enchantmenttable", Type.PARTICLE),
++    /**
++     * Fire particles
++     */
++    FLAME("flame", Type.PARTICLE),
++    /**
++     * The particles that pop out of lava
++     */
++    LAVA_POP("lava", Type.PARTICLE),
++    /**
++     * A small gray square
++     */
++    FOOTSTEP("footstep", Type.PARTICLE),
++    /**
++     * Water particles
++     */
++    SPLASH("splash", Type.PARTICLE),
++    /**
++     * Smoke particles
++     */
++    PARTICLE_SMOKE("smoke", Type.PARTICLE),
++    /**
++     * The biggest explosion particle effect
++     */
++    EXPLOSION_HUGE("hugeexplosion", Type.PARTICLE),
++    /**
++     * A larger version of the explode particle
++     */
++    EXPLOSION_LARGE("largeexplode", Type.PARTICLE),
++    /**
++     * Explosion particles
++     */
++    EXPLOSION("explode", Type.PARTICLE),
++    /**
++     * Small gray particles
++     */
++    VOID_FOG("depthsuspend", Type.PARTICLE),
++    /**
++     * Small gray particles
++     */
++    SMALL_SMOKE("townaura", Type.PARTICLE),
++    /**
++     * A puff of white smoke
++     */
++    CLOUD("cloud", Type.PARTICLE),
++    /**
++     * Multicolored dust particles
++     */
++    COLOURED_DUST("reddust", Type.PARTICLE),
++    /**
++     * Snowball breaking
++     */
++    SNOWBALL_BREAK("snowballpoof", Type.PARTICLE),
++    /**
++     * The water drip particle that appears on blocks under water
++     */
++    WATERDRIP("dripWater", Type.PARTICLE),
++    /**
++     * The lava drip particle that appears on blocks under lava
++     */
++    LAVADRIP("dripLava", Type.PARTICLE),
++    /**
++     * White particles
++     */
++    SNOW_SHOVEL("snowshovel", Type.PARTICLE),
++    /**
++     * The particle shown when a slime jumps
++     */
++    SLIME("slime", Type.PARTICLE),
++    /**
++     * The particle that appears when breading animals
++     */
++    HEART("heart", Type.PARTICLE),
++    /**
++     * The particle that appears when hitting a villager
++     */
++    VILLAGER_THUNDERCLOUD("angryVillager", Type.PARTICLE),
++    /**
++     * The particle that appears when trading with a villager
++     */
++    HAPPY_VILLAGER("happyVillager", Type.PARTICLE),
++    /**
++     * The particles generated when a tool breaks.
++     * This particle requires a Material so that the client can select the correct texture.
++     */
++    ITEM_BREAK("iconcrack", Type.PARTICLE, Material.class),
++    /**
++     * The particles generated while breaking a block.
++     * This particle requires a Material and data value so that the client can select the correct texture.
++     */
++    TILE_BREAK("tilecrack", Type.PARTICLE, MaterialData.class);
+ 
+     private final int id;
+     private final Type type;
+     private final Class<?> data;
+     private static final Map<Integer, Effect> BY_ID = Maps.newHashMap();
++    private static final Map<String, Effect> BY_NAME = Maps.newHashMap();
++    private final String particleName;
+ 
+     Effect(int id, Type type) {
+-        this(id,type,null);
++        this(id, type, null);
+     }
+ 
+     Effect(int id, Type type, Class<?> data) {
+         this.id = id;
+         this.type = type;
+         this.data = data;
++        this.particleName = null;
+     }
+ 
++    Effect(String particleName, Type type, Class<?> data) {
++        this.particleName = particleName;
++        this.type = type;
++        id = 0;
++        this.data = data;
++    }
++
++    Effect(String particleName, Type type) {
++        this.particleName = particleName;
++        this.type = type;
++        id = 0;
++        this.data = null;
++      }
++
+     /**
+      * Gets the ID for this effect.
+      *
+@@ -232,8 +383,17 @@ public enum Effect {
+     }
+ 
+     /**
+-     * @return The class which represents data for this effect, or null if
+-     *     none
++     * Returns the effect's name. This returns null if the effect is not a particle
++     *
++     * @return The effect's name
++     */
++    public String getName() {
++        return this.particleName;
++    }
++
++    /**
++     * @return if this Effect isn't of type PARTICLE it returns the class which represents
++     * data for this effect, or null if none.
+      */
+     public Class<?> getData() {
+         return this.data;
+@@ -253,12 +413,32 @@ public enum Effect {
+ 
+     static {
+         for (Effect effect : values()) {
+-            BY_ID.put(effect.id, effect);
++            if (effect.type != Type.PARTICLE) {
++                BY_ID.put(effect.id, effect);
++            }
++        }
++    }
++
++    /**
++     * Gets the Effect associated with the given name.
++     *
++     * @param name name of the Effect to return
++     * @return Effect with the given name
++     */
++    public static Effect getByName(String name) {
++        return BY_NAME.get(name);
++    }
++
++    static {
++        for (Effect effect : values()) {
++            if (effect.type == Type.PARTICLE) {
++                BY_NAME.put(effect.particleName, effect);
++            }
+         }
+     }
+ 
+     /**
+      * Represents the type of an effect.
+      */
+-    public enum Type {SOUND, VISUAL}
++    public enum Type {SOUND, VISUAL, PARTICLE}
+ }
+diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
+index 02cad41..db29db8 100644
+--- a/src/main/java/org/bukkit/World.java
++++ b/src/main/java/org/bukkit/World.java
+@@ -756,6 +756,16 @@ public interface World extends PluginMessageRecipient, Metadatable {
+      * Plays an effect to all players within a default radius around a given
+      * location.
+      *
++     * @param location the {@link Location} around which players must be to see the effect
++     * @param effect the {@link Effect}
++     * @throws IllegalArgumentException if the location or effect is null. It also throws when
++     *                                  the effect requires a material or a material data
++     */
++    public void playEffect(Location location, Effect effect);
++
++    /**
++     * Plays an effect to all players within a default radius around a given location.
++     *
+      * @param location the {@link Location} around which players must be to
+      *     hear the sound
+      * @param effect the {@link Effect}
+@@ -799,6 +809,27 @@ public interface World extends PluginMessageRecipient, Metadatable {
+     public <T> void playEffect(Location location, Effect effect, T data, int radius);
+ 
+     /**
++     * Plays an effect to all players within a default radius around a given location.
++     * The effect will use the provided material (and material data if required). The particle's
++     * position on the client will be the given location, adjusted on each axis by a normal
++     * distribution with mean 0 and standard deviation given in the offset parameters, each particle
++     * has independently calculated offsets. The effect will have the given speed and particle count
++     * if the effect is a particle. Some effect will create multiple particles.
++     *
++     * @param location the {@link Location} around which players must be to see the effect
++     * @param effect effect the {@link Effect}
++     * @param id the item/block/data id for the effect
++     * @param data the data value of the block/item for the effect
++     * @param offsetX the amount to be randomly offset by in the X axis
++     * @param offsetY the amount to be randomly offset by in the Y axis
++     * @param offsetZ the amount to be randomly offset by in the Z axis
++     * @param speed the speed of the particles
++     * @param particleCount the number of particles
++     * @param radius the radius around the location
++     */
++    public void playEffect(Location location, Effect effect, int id, int data, float offsetX, float offsetY, float offsetZ, float speed, int particleCount, int radius);
++
++    /**
+      * Get empty chunk snapshot (equivalent to all air blocks), optionally
+      * including valid biome data. Used for representing an ungenerated chunk,
+      * or for fetching only biome data without loading a chunk.
+diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
+index 4fa46f0..9ab646a 100644
+--- a/src/main/java/org/bukkit/entity/Player.java
++++ b/src/main/java/org/bukkit/entity/Player.java
+@@ -321,6 +321,8 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
+      */
+     public <T> void playEffect(Location loc, Effect effect, T data);
+ 
++    public void playEffect(Location location, Effect effect, int id, int data, float offsetX, float offsetY, float offsetZ, float speed, int particleCount, int radius);
++
+     /**
+      * Send a block change. This fakes a block change packet for a user at a
+      * certain location. This will not actually change the world in any way.
+diff --git a/src/test/java/org/bukkit/EffectTest.java b/src/test/java/org/bukkit/EffectTest.java
+index 08aa71d..5217aec 100644
+--- a/src/test/java/org/bukkit/EffectTest.java
++++ b/src/test/java/org/bukkit/EffectTest.java
+@@ -9,7 +9,11 @@ public class EffectTest {
+     @Test
+     public void getById() {
+         for (Effect effect : Effect.values()) {
+-            assertThat(Effect.getById(effect.getId()), is(effect));
++            if (effect.getType() != Effect.Type.PARTICLE) {
++                assertThat(Effect.getById(effect.getId()), is(effect));
++            } else {
++                assertThat(Effect.getByName(effect.getName()), is(effect));
++            }
+         }
+     }
+ }
+-- 
+1.9.0
+

--- a/Bukkit/0011-Add-PlayerInitialSpawnEvent-for-changing-a-player-s-.patch
+++ b/Bukkit/0011-Add-PlayerInitialSpawnEvent-for-changing-a-player-s-.patch
@@ -1,0 +1,59 @@
+From c713761287b0bf15ffffbc4952d03fd6057473b3 Mon Sep 17 00:00:00 2001
+From: Steve Anton <anxuiz.nx@gmail.com>
+Date: Thu, 2 Aug 2012 18:25:44 -0700
+Subject: [PATCH] Add PlayerInitialSpawnEvent for changing a player's spawn
+ when they first join the server.
+
+
+diff --git a/src/main/java/org/bukkit/event/player/PlayerInitialSpawnEvent.java b/src/main/java/org/bukkit/event/player/PlayerInitialSpawnEvent.java
+new file mode 100644
+index 0000000..2a9e776
+--- /dev/null
++++ b/src/main/java/org/bukkit/event/player/PlayerInitialSpawnEvent.java
+@@ -0,0 +1,43 @@
++package org.bukkit.event.player;
++
++import org.bukkit.event.player.PlayerEvent;
++import org.bukkit.Location;
++import org.bukkit.entity.Player;
++import org.bukkit.event.HandlerList;
++
++public class PlayerInitialSpawnEvent extends PlayerEvent {
++    private static final HandlerList handlers = new HandlerList();
++    private Location spawnLocation;
++
++    public PlayerInitialSpawnEvent(final Player player, final Location spawnLocation) {
++        super(player);
++        this.spawnLocation = spawnLocation;
++    }
++
++    /**
++     * Gets the current spawn location
++     *
++     * @return Location current spawn location
++     */
++    public Location getSpawnLocation() {
++        return this.spawnLocation;
++    }
++
++    /**
++     * Sets the new spawn location
++     *
++     * @param spawnLocation new location for the spawn
++     */
++    public void setSpawnLocation(Location spawnLocation) {
++        this.spawnLocation = spawnLocation;
++    }
++
++    @Override
++    public HandlerList getHandlers() {
++        return handlers;
++    }
++
++    public static HandlerList getHandlerList() {
++        return handlers;
++    }
++}
+-- 
+1.9.0
+

--- a/Bukkit/0012-Add-PlayerPickupExperienceEvent.patch
+++ b/Bukkit/0012-Add-PlayerPickupExperienceEvent.patch
@@ -1,0 +1,53 @@
+From 9d8760bd424cde3e328c98f7e53aecf59ddc0d44 Mon Sep 17 00:00:00 2001
+From: mrapple <tony@oc.tc>
+Date: Fri, 17 May 2013 20:31:13 -0500
+Subject: [PATCH] Add PlayerPickupExperienceEvent
+
+
+diff --git a/src/main/java/org/bukkit/event/player/PlayerPickupExperienceEvent.java b/src/main/java/org/bukkit/event/player/PlayerPickupExperienceEvent.java
+new file mode 100644
+index 0000000..24a13d9
+--- /dev/null
++++ b/src/main/java/org/bukkit/event/player/PlayerPickupExperienceEvent.java
+@@ -0,0 +1,38 @@
++package org.bukkit.event.player;
++
++import org.bukkit.entity.ExperienceOrb;
++import org.bukkit.entity.Player;
++import org.bukkit.event.Cancellable;
++import org.bukkit.event.HandlerList;
++
++public class PlayerPickupExperienceEvent extends PlayerEvent implements Cancellable {
++    private static final HandlerList handlers = new HandlerList();
++    private final ExperienceOrb experienceorb;
++    private boolean cancel = false;
++
++    public PlayerPickupExperienceEvent(final Player player, final ExperienceOrb experienceorb) {
++        super(player);
++        this.experienceorb = experienceorb;
++    }
++
++    public ExperienceOrb getExperienceOrb() {
++        return experienceorb;
++    }
++
++    public boolean isCancelled() {
++        return cancel;
++    }
++
++    public void setCancelled(boolean cancel) {
++        this.cancel = cancel;
++    }
++
++    @Override
++    public HandlerList getHandlers() {
++        return handlers;
++    }
++
++    public static HandlerList getHandlerList() {
++        return handlers;
++    }
++}
+-- 
+1.9.0
+

--- a/Bukkit/0013-Add-PlayerSpawnEntityEvent.patch
+++ b/Bukkit/0013-Add-PlayerSpawnEntityEvent.patch
@@ -1,0 +1,93 @@
+From c986c8fbc70b74beeec1b48f39bb13f440f0051f Mon Sep 17 00:00:00 2001
+From: YukonAppleGeek <yukonvinecki@gmail.com>
+Date: Sun, 26 May 2013 18:47:29 -0700
+Subject: [PATCH] Add PlayerSpawnEntityEvent
+
+
+diff --git a/src/main/java/org/bukkit/event/player/PlayerSpawnEntityEvent.java b/src/main/java/org/bukkit/event/player/PlayerSpawnEntityEvent.java
+new file mode 100644
+index 0000000..1fdc6ca
+--- /dev/null
++++ b/src/main/java/org/bukkit/event/player/PlayerSpawnEntityEvent.java
+@@ -0,0 +1,78 @@
++package org.bukkit.event.player;
++
++import org.bukkit.Location;
++import org.bukkit.entity.Entity;
++import org.bukkit.entity.Player;
++import org.bukkit.event.Cancellable;
++import org.bukkit.event.HandlerList;
++import org.bukkit.inventory.ItemStack;
++
++public class PlayerSpawnEntityEvent extends PlayerEvent implements Cancellable {
++    private static final HandlerList handlers = new HandlerList();
++    private boolean cancel;
++    private final Entity what;
++    private final ItemStack item;
++    private Location location;
++
++    public PlayerSpawnEntityEvent(final Player who, final Entity what, final Location location, final ItemStack item) {
++        super(who);
++        this.cancel = false;
++        this.what = what;
++        this.item = item;
++        this.location = location;
++    }
++
++    public boolean isCancelled() {
++        return cancel;
++    }
++
++    public void setCancelled(boolean cancel) {
++        this.cancel = cancel;
++    }
++
++    /**
++     * Gets the entity the player is spawning.
++     *
++     * @return the entity the player is spawning
++     */
++    public Entity getEntity() {
++        return what;
++    }
++
++    /**
++     * Gets the item that is being used to spawn an entity.
++     * Modifying the returned item will have no effect.
++     *
++     * @return an ItemStack for the item being used
++     */
++    public ItemStack getItem() {
++        return item.clone();
++    }
++
++    /**
++     * Returns the location and rotation of where the entity is being spawned.
++     *
++     * @return The location and rotation of the entity
++     */
++    public Location getLocation() {
++        return location;
++    }
++
++    /**
++     * Sets the location and rotation of where the entity is being spawned.
++     *
++     * @param The location and rotation of the entity
++     */
++    public void setLocation(Location location) {
++        this.location = location;
++    }
++
++    @Override
++    public HandlerList getHandlers() {
++        return handlers;
++    }
++
++    public static HandlerList getHandlerList() {
++        return handlers;
++    }
++}
+-- 
+1.9.0
+

--- a/Bukkit/0014-Add-getHostname-to-Player.patch
+++ b/Bukkit/0014-Add-getHostname-to-Player.patch
@@ -1,0 +1,27 @@
+From 4e1a2a3b845682ad092deec31bc272392bee7217 Mon Sep 17 00:00:00 2001
+From: Marcos Vives Del Sol <socram8888@gmail.com>
+Date: Sun, 28 Jul 2013 21:56:56 +0200
+Subject: [PATCH] Add getHostname to Player
+
+
+diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
+index 9ab646a..8d40c5e 100644
+--- a/src/main/java/org/bukkit/entity/Player.java
++++ b/src/main/java/org/bukkit/entity/Player.java
+@@ -1333,4 +1333,13 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
+      */
+     public <T> void spawnParticle(Particle particle, double x, double y, double z, int count, double offsetX, double offsetY, double offsetZ, double extra, T data);
+ 
++    /**
++     * Gets the hostname (an IP or a DNS domain) and port the client has used
++     * to connect to this server. This is generated client-side, and it may
++     * return a blank string if the client didn't send it, or an invalid
++     * hostname, as the server doesn't check it.
++     *
++     * @return The hostname and port
++     */
++    public String getHostname();
+ }
+-- 
+1.9.0
+

--- a/Bukkit/0015-Add-EntityDespawnInVoidEvent.patch
+++ b/Bukkit/0015-Add-EntityDespawnInVoidEvent.patch
@@ -1,0 +1,40 @@
+From e07b72954179af7b61332ee61837045eb4d8f99d Mon Sep 17 00:00:00 2001
+From: Isaac Moore <rmsy@me.com>
+Date: Wed, 25 Dec 2013 20:12:57 -0600
+Subject: [PATCH] Add EntityDespawnInVoidEvent
+
+
+diff --git a/src/main/java/org/bukkit/event/entity/EntityDespawnInVoidEvent.java b/src/main/java/org/bukkit/event/entity/EntityDespawnInVoidEvent.java
+new file mode 100644
+index 0000000..f413467
+--- /dev/null
++++ b/src/main/java/org/bukkit/event/entity/EntityDespawnInVoidEvent.java
+@@ -0,0 +1,25 @@
++package org.bukkit.event.entity;
++
++import org.bukkit.entity.Entity;
++import org.bukkit.event.HandlerList;
++
++/**
++ * This event is called when an {@link org.bukkit.entity.Entity} is removed from the world because it has fallen 64
++ * blocks into the void.
++ */
++public class EntityDespawnInVoidEvent extends EntityEvent {
++    private static final HandlerList handlers = new HandlerList();
++
++    public EntityDespawnInVoidEvent(Entity what) {
++        super(what);
++    }
++
++    public static HandlerList getHandlerList() {
++        return handlers;
++    }
++
++    @Override
++    public HandlerList getHandlers() {
++        return handlers;
++    }
++}
+-- 
+1.9.0
+

--- a/Bukkit/0016-Allow-plugins-to-access-player-locale.patch
+++ b/Bukkit/0016-Allow-plugins-to-access-player-locale.patch
@@ -1,0 +1,88 @@
+From d39aae3acdd317a722e6ae1eb45692dbb9d8350e Mon Sep 17 00:00:00 2001
+From: Isaac Moore <rmsy@me.com>
+Date: Sun, 5 Jan 2014 20:32:00 -0600
+Subject: [PATCH] Allow plugins to access player locale
+
+
+diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
+index 8d40c5e..ce6ee84 100644
+--- a/src/main/java/org/bukkit/entity/Player.java
++++ b/src/main/java/org/bukkit/entity/Player.java
+@@ -1342,4 +1342,18 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
+      * @return The hostname and port
+      */
+     public String getHostname();
+-}
++
++    /**
++     * Gets the player's client-determined, ISO-standard locale.
++     *
++     * If the player's locale has not been set, either by the client or the {@link #setLocale} method,
++     * the default locale will be returned, which is "en_US".
++     */
++    public String getLocale();
++
++    /**
++     * Set the player's ISO-standard locale. Passing null will clear the player's locale,
++     * effectively setting it to the default of "en_US".
++     */
++    public void setLocale(String locale);
++ }
+diff --git a/src/main/java/org/bukkit/event/player/PlayerLocaleChangeEvent.java b/src/main/java/org/bukkit/event/player/PlayerLocaleChangeEvent.java
+new file mode 100644
+index 0000000..33c95f3
+--- /dev/null
++++ b/src/main/java/org/bukkit/event/player/PlayerLocaleChangeEvent.java
+@@ -0,0 +1,49 @@
++package org.bukkit.event.player;
++
++import org.bukkit.entity.Player;
++import org.bukkit.event.HandlerList;
++
++/**
++ * Called when the locale of the player is changed.
++ *
++ * This should always happen shortly after a player connects, and when the player
++ * changes their language in the client options menu.
++ */
++public class PlayerLocaleChangeEvent extends PlayerEvent {
++    private static final HandlerList handlers = new HandlerList();
++    private final String oldLocale;
++    private final String newLocale;
++
++    public PlayerLocaleChangeEvent(final Player player, final String oldLocale, final String newLocale) {
++        super(player);
++        this.oldLocale = oldLocale;
++        this.newLocale = newLocale;
++    }
++
++    /**
++     * Gets the player's previous locale, or null if the locale is being initialized.
++     *
++     * @return  player's old locale
++     */
++    public String getOldLocale() {
++        return oldLocale;
++    }
++
++    /**
++     * Gets the locale the player is changed to.
++     *
++     * @return  player's new locale
++     */
++    public String getNewLocale() {
++        return newLocale;
++    }
++
++    @Override
++    public HandlerList getHandlers() {
++        return handlers;
++    }
++
++    public static HandlerList getHandlerList() {
++        return handlers;
++    }
++}
+-- 
+1.9.0
+

--- a/Bukkit/0017-Add-API-to-disable-potion-particles.patch
+++ b/Bukkit/0017-Add-API-to-disable-potion-particles.patch
@@ -1,0 +1,27 @@
+From 0334d12caa09eebd09f947869d254337630bf71e Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Fri, 9 May 2014 23:44:41 -0400
+Subject: [PATCH] Add API to disable potion particles
+
+
+diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
+index e4ccf5b..183134e 100644
+--- a/src/main/java/org/bukkit/entity/LivingEntity.java
++++ b/src/main/java/org/bukkit/entity/LivingEntity.java
+@@ -302,6 +302,13 @@ public interface LivingEntity extends Attributable, Entity, Damageable, Projecti
+     public Collection<PotionEffect> getActivePotionEffects();
+ 
+     /**
++     * Enables or disables potion particles visible around this entity when under
++     * the effect of a potion. If this entity is a player, this also affects the
++     * particles they see in front of them.
++     */
++    public void setPotionParticles(boolean enabled);
++
++    /**
+      * Checks whether the living entity has block line of sight to another.
+      * <p>
+      * This uses the same algorithm that hostile mobs use to find the closest
+-- 
+1.9.0
+

--- a/Bukkit/0018-Simple-bulk-block-replacement.patch
+++ b/Bukkit/0018-Simple-bulk-block-replacement.patch
@@ -1,0 +1,34 @@
+From bd10e8b0666a77482471c279504341b21ee521b9 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Sun, 28 Sep 2014 05:47:53 -0400
+Subject: [PATCH] Simple bulk block replacement
+
+
+diff --git a/src/main/java/org/bukkit/Chunk.java b/src/main/java/org/bukkit/Chunk.java
+index f39aabc..6c4107d 100644
+--- a/src/main/java/org/bukkit/Chunk.java
++++ b/src/main/java/org/bukkit/Chunk.java
+@@ -3,6 +3,7 @@ package org.bukkit;
+ import org.bukkit.block.Block;
+ import org.bukkit.block.BlockState;
+ import org.bukkit.entity.Entity;
++import org.bukkit.material.MaterialData;
+ 
+ /**
+  * Represents a chunk of blocks
+@@ -123,4 +124,12 @@ public interface Chunk {
+      * @return true if the chunk has unloaded successfully, otherwise false
+      */
+     boolean unload();
++
++    /**
++     * Replace all blocks of one material with another
++     * @param original       block to replace
++     * @param replacement    new block
++     * @return               number of blocks replaced
++     */
++    int replaceMaterial(Material original, MaterialData replacement);
+ }
+-- 
+1.9.0
+

--- a/Bukkit/0019-Fix-combustion-events.patch
+++ b/Bukkit/0019-Fix-combustion-events.patch
@@ -1,0 +1,40 @@
+From 9ab2120e3efc855f4d0f4342eeb82238d7dfa5ae Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Thu, 30 Oct 2014 00:40:30 -0400
+Subject: [PATCH] Fix combustion events
+
+
+diff --git a/src/main/java/org/bukkit/event/entity/EntityExtinguishEvent.java b/src/main/java/org/bukkit/event/entity/EntityExtinguishEvent.java
+new file mode 100644
+index 0000000..5833ab7
+--- /dev/null
++++ b/src/main/java/org/bukkit/event/entity/EntityExtinguishEvent.java
+@@ -0,0 +1,25 @@
++package org.bukkit.event.entity;
++
++import org.bukkit.entity.Entity;
++import org.bukkit.event.HandlerList;
++
++/**
++ * Called when a burning entity is extinguished.
++ */
++public class EntityExtinguishEvent extends EntityEvent {
++
++    public EntityExtinguishEvent(Entity combustee) {
++        super(combustee);
++    }
++
++    @Override
++    public HandlerList getHandlers() {
++        return handlers;
++    }
++
++    private static final HandlerList handlers = new HandlerList();
++
++    public static HandlerList getHandlerList() {
++        return handlers;
++    }
++}
+-- 
+1.9.0
+

--- a/Bukkit/0020-Add-PlayerAttackEntityEvent.patch
+++ b/Bukkit/0020-Add-PlayerAttackEntityEvent.patch
@@ -1,0 +1,62 @@
+From 77e44bb0e1cb3010f1290e213158b851c4df56b1 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Sat, 15 Nov 2014 16:17:15 -0500
+Subject: [PATCH] Add PlayerAttackEntityEvent
+
+
+diff --git a/src/main/java/org/bukkit/event/player/PlayerAttackEntityEvent.java b/src/main/java/org/bukkit/event/player/PlayerAttackEntityEvent.java
+new file mode 100644
+index 0000000..b05b231
+--- /dev/null
++++ b/src/main/java/org/bukkit/event/player/PlayerAttackEntityEvent.java
+@@ -0,0 +1,47 @@
++package org.bukkit.event.player;
++
++import org.bukkit.entity.Entity;
++import org.bukkit.entity.Player;
++import org.bukkit.event.Cancellable;
++import org.bukkit.event.HandlerList;
++
++/**
++ * Called when a player left-clicks on any entity. This is called before any other
++ * event, and cancelling it prevents all further effects of the right-click.
++ */
++public class PlayerAttackEntityEvent extends PlayerEvent implements Cancellable {
++    private static final HandlerList handlers = new HandlerList();
++    protected Entity clickedEntity;
++    boolean cancelled = false;
++
++    public PlayerAttackEntityEvent(final Player who, final Entity clickedEntity) {
++        super(who);
++        this.clickedEntity = clickedEntity;
++    }
++
++    public boolean isCancelled() {
++        return cancelled;
++    }
++
++    public void setCancelled(boolean cancel) {
++        this.cancelled = cancel;
++    }
++
++    /**
++     * Gets the entity that was left-clicked by the player.
++     *
++     * @return entity left-clicked by player
++     */
++    public Entity getLeftClicked() {
++        return this.clickedEntity;
++    }
++
++    @Override
++    public HandlerList getHandlers() {
++        return handlers;
++    }
++
++    public static HandlerList getHandlerList() {
++        return handlers;
++    }
++}
+-- 
+1.9.0
+

--- a/Bukkit/0021-Expose-the-server-CommandMap.patch
+++ b/Bukkit/0021-Expose-the-server-CommandMap.patch
@@ -1,0 +1,59 @@
+From af97ffafc3ea406b0fc0cf9d078d828aa2bd71f6 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Wed, 29 Oct 2014 19:08:55 -0400
+Subject: [PATCH] Expose the server CommandMap
+
+
+diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
+index 18441fd..b68d0f6 100644
+--- a/src/main/java/org/bukkit/Bukkit.java
++++ b/src/main/java/org/bukkit/Bukkit.java
+@@ -18,6 +18,7 @@ import org.bukkit.boss.BarFlag;
+ import org.bukkit.boss.BarStyle;
+ import org.bukkit.boss.BossBar;
+ import org.bukkit.command.CommandException;
++import org.bukkit.command.CommandMap;
+ import org.bukkit.command.CommandSender;
+ import org.bukkit.command.ConsoleCommandSender;
+ import org.bukkit.command.PluginCommand;
+@@ -944,6 +945,13 @@ public final class Bukkit {
+     }
+ 
+     /**
++     * @see Server#getCommandMap()
++     */
++    public static CommandMap getCommandMap() {
++        return server.getCommandMap();
++    }
++
++    /**
+      * Gets user-specified limit for number of monsters that can spawn in a
+      * chunk.
+      *
+diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
+index deae5a1..079e991 100644
+--- a/src/main/java/org/bukkit/Server.java
++++ b/src/main/java/org/bukkit/Server.java
+@@ -18,6 +18,7 @@ import org.bukkit.boss.BarFlag;
+ import org.bukkit.boss.BarStyle;
+ import org.bukkit.boss.BossBar;
+ import org.bukkit.command.CommandException;
++import org.bukkit.command.CommandMap;
+ import org.bukkit.command.CommandSender;
+ import org.bukkit.command.ConsoleCommandSender;
+ import org.bukkit.command.PluginCommand;
+@@ -714,6 +715,11 @@ public interface Server extends PluginMessageRecipient {
+     public HelpMap getHelpMap();
+ 
+     /**
++     * Gets the {@link CommandMap} containing all registered commands on this server.
++     */
++    public CommandMap getCommandMap();
++
++    /**
+      * Creates an empty inventory of the specified type. If the type is {@link
+      * InventoryType#CHEST}, the new inventory has a size of 27; otherwise the
+      * new inventory has the normal size for its type.
+-- 
+1.9.0
+

--- a/Bukkit/0022-EventException-knows-the-source-Event.patch
+++ b/Bukkit/0022-EventException-knows-the-source-Event.patch
@@ -1,0 +1,106 @@
+From 7e7bfe2eac60ed0ee88717fa8864cda8fd439a1e Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Tue, 9 Dec 2014 05:23:05 -0500
+Subject: [PATCH] EventException knows the source Event
+
+
+diff --git a/src/main/java/org/bukkit/event/EventException.java b/src/main/java/org/bukkit/event/EventException.java
+index 84638e8..aef8d49 100644
+--- a/src/main/java/org/bukkit/event/EventException.java
++++ b/src/main/java/org/bukkit/event/EventException.java
+@@ -2,7 +2,26 @@ package org.bukkit.event;
+ 
+ public class EventException extends Exception {
+     private static final long serialVersionUID = 3532808232324183999L;
+-    private final Throwable cause;
++    private final Event event;
++
++    /**
++     * Constructs a new EventException based on the given Exception
++     *
++     * @param cause Exception that triggered this Exception
++     */
++    public EventException(Throwable cause, Event event, String message) {
++        super(message, cause);
++        this.event = event;
++    }
++
++    /**
++     * Constructs a new EventException based on the given Exception
++     *
++     * @param throwable Exception that triggered this Exception
++     */
++    public EventException(Throwable throwable, Event event) {
++        this(throwable, event, null);
++    }
+ 
+     /**
+      * Constructs a new EventException based on the given Exception
+@@ -10,14 +29,14 @@ public class EventException extends Exception {
+      * @param throwable Exception that triggered this Exception
+      */
+     public EventException(Throwable throwable) {
+-        cause = throwable;
++        this(throwable, (Event) null);
+     }
+ 
+     /**
+      * Constructs a new EventException
+      */
+     public EventException() {
+-        cause = null;
++        this((Throwable) null);
+     }
+ 
+     /**
+@@ -27,8 +46,7 @@ public class EventException extends Exception {
+      * @param message The message
+      */
+     public EventException(Throwable cause, String message) {
+-        super(message);
+-        this.cause = cause;
++        this(cause, null, message);
+     }
+ 
+     /**
+@@ -37,17 +55,13 @@ public class EventException extends Exception {
+      * @param message The message
+      */
+     public EventException(String message) {
+-        super(message);
+-        cause = null;
++        this(null, message);
+     }
+ 
+     /**
+-     * If applicable, returns the Exception that triggered this Exception
+-     *
+-     * @return Inner exception, or null if one does not exist
++     * @return the {@link Event} that generated this exception
+      */
+-    @Override
+-    public Throwable getCause() {
+-        return cause;
++    public Event getEvent() {
++        return event;
+     }
+ }
+diff --git a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
+index df613b0..885f8ae 100644
+--- a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
++++ b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
+@@ -295,9 +295,9 @@ public final class JavaPluginLoader implements PluginLoader {
+                         }
+                         method.invoke(listener, event);
+                     } catch (InvocationTargetException ex) {
+-                        throw new EventException(ex.getCause());
++                        throw new EventException(ex.getCause(), event);
+                     } catch (Throwable t) {
+-                        throw new EventException(t);
++                        throw new EventException(t, event);
+                     }
+                 }
+             };
+-- 
+1.9.0
+

--- a/Bukkit/0023-Add-setting-to-disable-skull-fetching.patch
+++ b/Bukkit/0023-Add-setting-to-disable-skull-fetching.patch
@@ -1,0 +1,43 @@
+From 773bf03ffa4c21d307e730311601933fd8b9eb09 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Wed, 4 Feb 2015 03:39:54 -0500
+Subject: [PATCH] Add setting to disable skull fetching
+
+
+diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
+index b68d0f6..748aa1a 100644
+--- a/src/main/java/org/bukkit/Bukkit.java
++++ b/src/main/java/org/bukkit/Bukkit.java
+@@ -329,6 +329,13 @@ public final class Bukkit {
+     }
+ 
+     /**
++     * @see Server#getFetchSkulls()
++     */
++    public static boolean getFetchSkulls() {
++        return server.getFetchSkulls();
++    }
++
++    /**
+      * Gets default ticks per animal spawns value.
+      * <p>
+      * <b>Example Usage:</b>
+diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
+index 079e991..fc02479 100644
+--- a/src/main/java/org/bukkit/Server.java
++++ b/src/main/java/org/bukkit/Server.java
+@@ -269,6 +269,11 @@ public interface Server extends PluginMessageRecipient {
+     public long getConnectionThrottle();
+ 
+     /**
++     * Should player skulls with missing skin data be fetched from Mojang?
++     */
++    public boolean getFetchSkulls();
++
++    /**
+      * Gets default ticks per animal spawns value.
+      * <p>
+      * <b>Example Usage:</b>
+-- 
+1.9.0
+

--- a/Bukkit/0024-Fake-name-and-skin-API.patch
+++ b/Bukkit/0024-Fake-name-and-skin-API.patch
@@ -1,0 +1,400 @@
+From 1a6fd6de55230b3d0b086288ffd228c3df2ae937 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Thu, 23 Jan 2014 00:17:31 -0500
+Subject: [PATCH] Fake name and skin API
+
+
+diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
+index 748aa1a..e483168 100644
+--- a/src/main/java/org/bukkit/Bukkit.java
++++ b/src/main/java/org/bukkit/Bukkit.java
+@@ -437,6 +437,27 @@ public final class Bukkit {
+     }
+ 
+     /**
++     * @see Server#getPlayer(String, CommandSender)
++     */
++    public static Player getPlayer(String name, CommandSender viewer) {
++        return server.getPlayer(name, viewer);
++    }
++
++    /**
++     * @see Server#getPlayerExact(String, CommandSender)
++     */
++    public static Player getPlayerExact(String name, CommandSender viewer) {
++        return server.getPlayerExact(name, viewer);
++    }
++
++    /**
++     * @see Server#matchPlayer(String, CommandSender)
++     */
++    public static List<Player> matchPlayer(String name, CommandSender viewer) {
++        return server.matchPlayer(name, viewer);
++    }
++
++    /**
+      * Gets the plugin manager for interfacing with plugins.
+      *
+      * @return a plugin manager for this Server instance
+diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
+index fc02479..a6f2b10 100644
+--- a/src/main/java/org/bukkit/Server.java
++++ b/src/main/java/org/bukkit/Server.java
+@@ -363,7 +363,22 @@ public interface Server extends PluginMessageRecipient {
+     public Player getPlayer(UUID id);
+ 
+     /**
+-     * Gets the plugin manager for interfacing with plugins.
++     * Fake name aware version of {@link #getPlayer(String)}
++     */
++    public Player getPlayer(String name, CommandSender viewer);
++
++    /**
++     * Fake name aware version of {@link #getPlayerExact(String)}
++     */
++    public Player getPlayerExact(String name, CommandSender viewer);
++
++    /**
++     * Fake name aware version of {@link #matchPlayer(String)}
++     */
++    public List<Player> matchPlayer(String name, CommandSender viewer);
++
++    /**
++     * Gets the PluginManager for interfacing with plugins
+      *
+      * @return a plugin manager for this Server instance
+      */
+diff --git a/src/main/java/org/bukkit/Skin.java b/src/main/java/org/bukkit/Skin.java
+new file mode 100644
+index 0000000..5dc9cef
+--- /dev/null
++++ b/src/main/java/org/bukkit/Skin.java
+@@ -0,0 +1,76 @@
++package org.bukkit;
++
++
++/**
++ * A self-contained skin
++ */
++public class Skin {
++    // NOTE: ordinals must match bit positions in packet data
++    public static enum Part {
++        CAPE,
++        JACKET,
++        LEFT_SLEEVE,
++        RIGHT_SLEEVE,
++        LEFT_PANTS_LEG,
++        RIGHT_PANTS_LEG,
++        HAT
++    }
++
++    public static final Skin EMPTY = new Skin(null, null);
++
++    private final String data;
++    private final String signature;
++
++    public Skin(String data, String signature) {
++        this.data = data;
++        this.signature = signature;
++    }
++
++    /**
++     * Return the base64 encoded data for this skin, or null if this
++     * is the empty skin i.e. Steve/Alex
++     */
++    public String getData() {
++        return data;
++    }
++
++    /**
++     * Return the base64 encoded signature for this skin, or null if
++     * this skin has no signature
++     */
++    public String getSignature() {
++        return signature;
++    }
++
++    /**
++     * Return true if this is the empty skin i.e. Steve/Alex
++     */
++    public boolean isEmpty() {
++        return this.data == null;
++    }
++
++    @Override
++    public boolean equals(Object o) {
++        if(this == o) {
++            return true;
++        }
++        if(!(o instanceof Skin)) {
++            return false;
++        }
++        Skin skin = (Skin) o;
++        if(data != null ? !data.equals(skin.data) : skin.data != null) {
++            return false;
++        }
++        if(signature != null ? !signature.equals(skin.signature) : skin.signature != null) {
++            return false;
++        }
++        return true;
++    }
++
++    @Override
++    public int hashCode() {
++        int result = data != null ? data.hashCode() : 0;
++        result = 31 * result + (signature != null ? signature.hashCode() : 0);
++        return result;
++    }
++}
+diff --git a/src/main/java/org/bukkit/command/Command.java b/src/main/java/org/bukkit/command/Command.java
+index 7adc6ee..322c063 100644
+--- a/src/main/java/org/bukkit/command/Command.java
++++ b/src/main/java/org/bukkit/command/Command.java
+@@ -103,7 +103,7 @@ public abstract class Command {
+ 
+         ArrayList<String> matchedPlayers = new ArrayList<String>();
+         for (Player player : sender.getServer().getOnlinePlayers()) {
+-            String name = player.getName();
++            String name = player.getName(sender);
+             if ((senderPlayer == null || senderPlayer.canSee(player)) && StringUtil.startsWithIgnoreCase(name, lastWord)) {
+                 matchedPlayers.add(name);
+             }
+diff --git a/src/main/java/org/bukkit/command/CommandSender.java b/src/main/java/org/bukkit/command/CommandSender.java
+index 148756b..52c5947 100644
+--- a/src/main/java/org/bukkit/command/CommandSender.java
++++ b/src/main/java/org/bukkit/command/CommandSender.java
+@@ -32,4 +32,10 @@ public interface CommandSender extends Permissible {
+      * @return Name of the sender
+      */
+     public String getName();
++
++    /**
++     * Return this sender's name as viewed by the given sender. Used by
++     * {@link org.bukkit.entity.Player}s to support fake names.
++     */
++    public String getName(CommandSender viewer);
+ }
+diff --git a/src/main/java/org/bukkit/command/defaults/ListCommand.java b/src/main/java/org/bukkit/command/defaults/ListCommand.java
+index ea62bee..8442e03 100644
+--- a/src/main/java/org/bukkit/command/defaults/ListCommand.java
++++ b/src/main/java/org/bukkit/command/defaults/ListCommand.java
+@@ -36,7 +36,7 @@ public class ListCommand extends VanillaCommand {
+                 online.append(", ");
+             }
+ 
+-            online.append(player.getDisplayName());
++            online.append(player.getDisplayName(sender instanceof Player ? (Player) sender : null));
+         }
+ 
+         sender.sendMessage("There are " + players.size() + "/" + Bukkit.getMaxPlayers() + " players online:\n" + online.toString());
+diff --git a/src/main/java/org/bukkit/command/defaults/TellCommand.java b/src/main/java/org/bukkit/command/defaults/TellCommand.java
+index 7b0a41c..466691f 100644
+--- a/src/main/java/org/bukkit/command/defaults/TellCommand.java
++++ b/src/main/java/org/bukkit/command/defaults/TellCommand.java
+@@ -25,7 +25,8 @@ public class TellCommand extends VanillaCommand {
+             return false;
+         }
+ 
+-        Player player = Bukkit.getPlayerExact(args[0]);
++        Player viewer = sender instanceof Player ? (Player) sender : null;
++        Player player = Bukkit.getPlayerExact(args[0], viewer);
+ 
+         // If a player is hidden from the sender pretend they are offline
+         if (player == null || (sender instanceof Player && !((Player) sender).canSee(player))) {
+diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
+index ce6ee84..0e2784d 100644
+--- a/src/main/java/org/bukkit/entity/Player.java
++++ b/src/main/java/org/bukkit/entity/Player.java
+@@ -1,6 +1,7 @@
+ package org.bukkit.entity;
+ 
+ import java.net.InetSocketAddress;
++import java.util.Set;
+ 
+ import org.bukkit.Achievement;
+ import org.bukkit.ChatColor;
+@@ -12,6 +13,7 @@ import org.bukkit.Material;
+ import org.bukkit.Note;
+ import org.bukkit.OfflinePlayer;
+ import org.bukkit.Particle;
++import org.bukkit.Skin;
+ import org.bukkit.Sound;
+ import org.bukkit.SoundCategory;
+ import org.bukkit.Statistic;
+@@ -28,6 +30,60 @@ import org.bukkit.scoreboard.Scoreboard;
+ public interface Player extends HumanEntity, Conversable, CommandSender, OfflinePlayer, PluginMessageRecipient {
+ 
+     /**
++     * Set a fake name for this player when viewed by the given player.
++     * If the name is null then the fake name is cleared.
++     */
++    public void setFakeName(CommandSender viewer, String name);
++
++    /**
++     * Return this player's fake name for the given viewer,
++     * or null if no fake name is set for that viewer
++     */
++    public String getFakeName(CommandSender viewer);
++
++    /**
++     * Test if this player has a fake name set for the given viewer
++     */
++    public boolean hasFakeName(CommandSender viewer);
++
++    /**
++     * Clear this player's fake names for all viewers
++     */
++    public void clearFakeNames();
++
++    /**
++     * Set a fake display name for this player when viewed by the given player.
++     * If the name is null then the fake name is cleared.
++     */
++    public void setFakeDisplayName(CommandSender viewer, String name);
++
++    /**
++     * Return this player's fake display name for the given viewer,
++     * or null if no fake name is set for that viewer
++     */
++    public String getFakeDisplayName(CommandSender viewer);
++
++    /**
++     * Test if this player has a fake display name set for the given viewer
++     */
++    public boolean hasFakeDisplayName(CommandSender viewer);
++
++    /**
++     * Clear this player's fake display names for all viewers
++     */
++    public void clearFakeDisplayNames();
++
++    /**
++     * Return this player's list name as viewed by the given player, fake or not
++     */
++    public String getPlayerListName(CommandSender viewer);
++
++    /**
++     * Return this player's display name as viewed by the given player, fake or not
++     */
++    public String getDisplayName(CommandSender viewer);
++
++    /**
+      * Gets the "friendly" name to display of this player. This may include
+      * color.
+      * <p>
+@@ -80,6 +136,74 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
+     public void setPlayerListName(String name);
+ 
+     /**
++     * Test if this Player has a fake skin set for the given viewer
++     */
++    public boolean hasFakeSkin(CommandSender viewer);
++
++    /**
++     * Return the {@link Skin} that the given viewer sees on this player,
++     * or null if the viewer can see this player's real skin.
++     */
++    public Skin getFakeSkin(CommandSender viewer);
++
++    /**
++     * Set the {@link Skin} that the given viewer will see on this player.
++     * If null is given for the skin, any fake skin for the given viewer
++     * will be removed and they will see this player's real skin.
++     */
++    public void setFakeSkin(CommandSender viewer, Skin newSkin);
++
++    /**
++     * Clear any fake {@link org.bukkit.Skin}s set on this player, so that all other
++     * players will see this player's real skin.
++     */
++    public void clearFakeSkins();
++
++    /**
++     * Return the player's real {@link Skin} i.e. the one they have
++     * uploaded to their Minecraft account.
++     */
++    public Skin getRealSkin();
++
++    /**
++     * Return this player's current global {@link Skin}, which is what
++     * other players see as long as there is no fake skin set for them.
++     */
++    public Skin getSkin();
++
++    /**
++     * Return the {@link Skin} that the given viewer sees on this player,
++     * which may be either their current global skin or a fake skin.
++     */
++    public Skin getSkin(CommandSender viewer);
++
++    /**
++     * Set this player's {@link Skin}, which will be visible to
++     * all players who do not have a fake skin set. Passing null
++     * as the skin will reset the player's skin to their real one.
++     */
++    public void setSkin(Skin newSkin);
++
++    /**
++     * Get the set of skin parts that are currently visible on the player
++     */
++    public Set<Skin.Part> getSkinParts();
++
++    /**
++     * Simultaneously set this player's fake name and {@link Skin} for the given viewer.
++     * This method only refreshes the player entity once, whereas calling
++     * {@link #setFakeName} and {@link #setFakeSkin} seperately would refresh it twice.
++     */
++    public void setFakeNameAndSkin(CommandSender viewer, String name, Skin skin);
++
++    /**
++     * Simultaneously clear any fake names or {@link Skin}s set on this player.
++     * This method only refreshes the player entity once, whereas calling
++     * {@link #clearFakeNames} and {@link #clearFakeSkins} seperately would refresh it twice.
++     */
++    public void clearFakeNamesAndSkins();
++
++    /**
+      * Set the target of the player's compass.
+      *
+      * @param loc Location to point to
+diff --git a/src/main/java/org/bukkit/event/player/PlayerSkinPartsChangeEvent.java b/src/main/java/org/bukkit/event/player/PlayerSkinPartsChangeEvent.java
+new file mode 100644
+index 0000000..a222f21
+--- /dev/null
++++ b/src/main/java/org/bukkit/event/player/PlayerSkinPartsChangeEvent.java
+@@ -0,0 +1,32 @@
++package org.bukkit.event.player;
++
++import org.bukkit.Skin;
++import org.bukkit.entity.Player;
++import org.bukkit.event.HandlerList;
++
++import java.util.Set;
++
++public class PlayerSkinPartsChangeEvent extends PlayerEvent {
++
++    private final Set<Skin.Part> parts;
++
++    public PlayerSkinPartsChangeEvent(Player who, Set<Skin.Part> parts) {
++        super(who);
++        this.parts = parts;
++    }
++
++    public Set<Skin.Part> getParts() {
++        return parts;
++    }
++
++    private static final HandlerList handlers = new HandlerList();
++
++    @Override
++    public HandlerList getHandlers() {
++        return handlers;
++    }
++
++    public static HandlerList getHandlerList() {
++        return handlers;
++    }
++}
+-- 
+1.9.0
+

--- a/Bukkit/0025-BungeeCord-Chat-API.patch
+++ b/Bukkit/0025-BungeeCord-Chat-API.patch
@@ -1,0 +1,101 @@
+From f0dc5824bfd7ca190aecc5e131611e0ff75d0da6 Mon Sep 17 00:00:00 2001
+From: md_5 <git@md-5.net>
+Date: Sat, 13 Dec 2014 12:59:14 +1100
+Subject: [PATCH] BungeeCord Chat API
+
+
+diff --git a/pom.xml b/pom.xml
+index 5c4a0c4..91f8160 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -82,6 +82,14 @@
+             <version>1.17</version>
+             <scope>compile</scope>
+         </dependency>
++        <dependency>
++            <groupId>tc.oc</groupId>
++            <artifactId>bungeecord-chat</artifactId>
++            <version>1.11-SNAPSHOT</version>
++            <type>jar</type>
++            <scope>compile</scope>
++        </dependency>
++
+         <!-- testing -->
+         <dependency>
+             <groupId>junit</groupId>
+diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
+index e483168..983a6cc 100644
+--- a/src/main/java/org/bukkit/Bukkit.java
++++ b/src/main/java/org/bukkit/Bukkit.java
+@@ -1192,4 +1192,22 @@ public final class Bukkit {
+     public static UnsafeValues getUnsafe() {
+         return server.getUnsafe();
+     }
++
++    /**
++     * Sends the component to the player
++     *
++     * @param component the components to send
++     */
++    public static void broadcast(net.md_5.bungee.api.chat.BaseComponent component) {
++        server.broadcast(component);
++    }
++
++    /**
++     * Sends an array of components as a single message to the player
++     *
++     * @param components the components to send
++     */
++    public static void broadcast(net.md_5.bungee.api.chat.BaseComponent... components) {
++        server.broadcast(components);
++    }
+ }
+diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
+index a6f2b10..e96f5f4 100644
+--- a/src/main/java/org/bukkit/Server.java
++++ b/src/main/java/org/bukkit/Server.java
+@@ -974,4 +974,18 @@ public interface Server extends PluginMessageRecipient {
+      */
+     @Deprecated
+     UnsafeValues getUnsafe();
++
++    /**
++     * Sends the component to the player
++     *
++     * @param component the components to send
++     */
++    public void broadcast(net.md_5.bungee.api.chat.BaseComponent component);
++
++    /**
++     * Sends an array of components as a single message to the player
++     *
++     * @param components the components to send
++     */
++    public void broadcast(net.md_5.bungee.api.chat.BaseComponent... components);
+ }
+diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
+index 0e2784d..d813f7a 100644
+--- a/src/main/java/org/bukkit/entity/Player.java
++++ b/src/main/java/org/bukkit/entity/Player.java
+@@ -1480,4 +1480,18 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
+      * effectively setting it to the default of "en_US".
+      */
+     public void setLocale(String locale);
++
++    /**
++     * Sends the component to the player
++     *
++     * @param component the components to send
++     */
++    public void sendMessage(net.md_5.bungee.api.chat.BaseComponent component);
++
++    /**
++     * Sends an array of components as a single message to the player
++     *
++     * @param components the components to send
++     */
++    public void sendMessage(net.md_5.bungee.api.chat.BaseComponent... components);
+  }
+-- 
+1.9.0
+

--- a/Bukkit/0026-Player-list-header-footer-API.patch
+++ b/Bukkit/0026-Player-list-header-footer-API.patch
@@ -1,0 +1,35 @@
+From f0944c9a18f6a6a9844d12e1d286688eb712c50c Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Thu, 12 Feb 2015 22:15:03 -0500
+Subject: [PATCH] Player list header/footer API
+
+
+diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
+index d813f7a..c5974ec 100644
+--- a/src/main/java/org/bukkit/entity/Player.java
++++ b/src/main/java/org/bukkit/entity/Player.java
+@@ -1494,4 +1494,20 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
+      * @param components the components to send
+      */
+     public void sendMessage(net.md_5.bungee.api.chat.BaseComponent... components);
+- }
++
++    /**
++     * Set the text displayed in the player list header and footer for this player
++     *
++     * @param header content for the top of the player list
++     * @param footer content for the bottom of the player list
++     */
++    public void setPlayerListHeaderFooter(net.md_5.bungee.api.chat.BaseComponent[] header, net.md_5.bungee.api.chat.BaseComponent[] footer);
++
++    /**
++     * Set the text displayed in the player list header and footer for this player
++     *
++     * @param header content for the top of the player list
++     * @param footer content for the bottom of the player list
++     */
++    public void setPlayerListHeaderFooter(net.md_5.bungee.api.chat.BaseComponent header, net.md_5.bungee.api.chat.BaseComponent footer);
++}
+-- 
+1.9.0
+

--- a/Bukkit/0027-Add-invis-override-API.patch
+++ b/Bukkit/0027-Add-invis-override-API.patch
@@ -1,0 +1,24 @@
+From 61ce13c1cde338f800cf0ebeade28d50a3fd82e7 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Sat, 14 Feb 2015 08:18:40 -0500
+Subject: [PATCH] Add invis override API
+
+
+diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
+index c5974ec..0e05376 100644
+--- a/src/main/java/org/bukkit/entity/Player.java
++++ b/src/main/java/org/bukkit/entity/Player.java
+@@ -1040,6 +1040,10 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
+      */
+     public boolean canSee(Player player);
+ 
++    public boolean canSeeInvisibles();
++
++    public void showInvisibles(boolean see);
++
+     /**
+      * Checks to see if this player is currently standing on a block. This
+      * information may not be reliable, as it is a state provided by the
+-- 
+1.9.0
+

--- a/Bukkit/0028-Efficiently-search-for-blocks-by-material.patch
+++ b/Bukkit/0028-Efficiently-search-for-blocks-by-material.patch
@@ -1,0 +1,37 @@
+From b25a138505ba5beb3ba2245f227a33950a816d2a Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Mon, 16 Feb 2015 04:58:20 -0500
+Subject: [PATCH] Efficiently search for blocks by material
+
+
+diff --git a/src/main/java/org/bukkit/Chunk.java b/src/main/java/org/bukkit/Chunk.java
+index 6c4107d..d5862a1 100644
+--- a/src/main/java/org/bukkit/Chunk.java
++++ b/src/main/java/org/bukkit/Chunk.java
+@@ -5,6 +5,8 @@ import org.bukkit.block.BlockState;
+ import org.bukkit.entity.Entity;
+ import org.bukkit.material.MaterialData;
+ 
++import java.util.Set;
++
+ /**
+  * Represents a chunk of blocks
+  */
+@@ -42,6 +44,14 @@ public interface Chunk {
+     Block getBlock(int x, int y, int z);
+ 
+     /**
++     * Get all blocks in this chunk that are made of the given {@link Material}
++     *
++     * @param material type of block to search for
++     * @return all blocks found
++     */
++    Set<Block> getBlocks(Material material);
++
++    /**
+      * Capture thread-safe read-only snapshot of chunk data
+      *
+      * @return ChunkSnapshot
+-- 
+1.9.0
+

--- a/Bukkit/0029-Fix-TNT-physics.patch
+++ b/Bukkit/0029-Fix-TNT-physics.patch
@@ -1,0 +1,43 @@
+From 602067903bef56e13b7f18198ec039c3d0cb3ee7 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Tue, 17 Feb 2015 08:28:02 -0500
+Subject: [PATCH] Fix TNT physics
+
+
+diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
+index 983a6cc..ed3aa4f 100644
+--- a/src/main/java/org/bukkit/Bukkit.java
++++ b/src/main/java/org/bukkit/Bukkit.java
+@@ -336,6 +336,13 @@ public final class Bukkit {
+     }
+ 
+     /**
++     * @see Server#getWaterPushesTNT()
++     */
++    public static boolean getWaterPushesTNT() {
++        return server.getWaterPushesTNT();
++    }
++
++    /**
+      * Gets default ticks per animal spawns value.
+      * <p>
+      * <b>Example Usage:</b>
+diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
+index e96f5f4..8dd5c65 100644
+--- a/src/main/java/org/bukkit/Server.java
++++ b/src/main/java/org/bukkit/Server.java
+@@ -274,6 +274,11 @@ public interface Server extends PluginMessageRecipient {
+     public boolean getFetchSkulls();
+ 
+     /**
++     * Should flowing water move primed TNT entities?
++     */
++    public boolean getWaterPushesTNT();
++
++    /**
+      * Gets default ticks per animal spawns value.
+      * <p>
+      * <b>Example Usage:</b>
+-- 
+1.9.0
+

--- a/Bukkit/0030-Title-API.patch
+++ b/Bukkit/0030-Title-API.patch
@@ -1,0 +1,71 @@
+From 99e0cce8de080a28eaa8f48c0ad8a0a0c6477f34 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Sat, 28 Feb 2015 04:32:26 -0500
+Subject: [PATCH] Title API
+
+
+diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
+index 0e05376..8ee4444 100644
+--- a/src/main/java/org/bukkit/entity/Player.java
++++ b/src/main/java/org/bukkit/entity/Player.java
+@@ -1514,4 +1514,57 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
+      * @param footer content for the bottom of the player list
+      */
+     public void setPlayerListHeaderFooter(net.md_5.bungee.api.chat.BaseComponent header, net.md_5.bungee.api.chat.BaseComponent footer);
++
++    /**
++     * Set the times for titles displayed to the player
++     * @param fadeInTicks ticks to fade-in
++     * @param stayTicks ticks to stay visible
++     * @param fadeOutTicks ticks to fade-out
++     */
++    public void setTitleTimes(int fadeInTicks, int stayTicks, int fadeOutTicks);
++
++    /**
++     * Set the subtitle of titles displayed to the player
++     */
++    public void setSubtitle(net.md_5.bungee.api.chat.BaseComponent[] subtitle);
++
++    /**
++     * Set the subtitle of titles displayed to the player
++     */
++    public void setSubtitle(net.md_5.bungee.api.chat.BaseComponent subtitle);
++
++    /**
++     * Show the given title to the player, along with the last subtitle set, using the last set times
++     */
++    public void showTitle(net.md_5.bungee.api.chat.BaseComponent[] title);
++
++    /**
++     * Show the given title to the player, along with the last subtitle set, using the last set times
++     */
++    public void showTitle(net.md_5.bungee.api.chat.BaseComponent title);
++
++    /**
++     * Show the given title and subtitle to the player using the given times
++     * @param title big text
++     * @param subtitle little text under it
++     * @param fadeInTicks ticks to fade-in
++     * @param stayTicks ticks to stay visible
++     * @param fadeOutTicks ticks to fade-out
++     */
++    public void showTitle(net.md_5.bungee.api.chat.BaseComponent[] title, net.md_5.bungee.api.chat.BaseComponent[] subtitle, int fadeInTicks, int stayTicks, int fadeOutTicks);
++
++    /**
++     * Show the given title and subtitle to the player using the given times
++     * @param title big text
++     * @param subtitle little text under it
++     * @param fadeInTicks ticks to fade-in
++     * @param stayTicks ticks to stay visible
++     * @param fadeOutTicks ticks to fade-out
++     */
++    public void showTitle(net.md_5.bungee.api.chat.BaseComponent title, net.md_5.bungee.api.chat.BaseComponent subtitle, int fadeInTicks, int stayTicks, int fadeOutTicks);
++
++    /**
++     * Hide any title that is currently visible to the player
++     */
++    public void hideTitle();
+ }
+-- 
+1.9.0
+

--- a/Bukkit/0031-Relative-teleport-API.patch
+++ b/Bukkit/0031-Relative-teleport-API.patch
@@ -1,0 +1,26 @@
+From 38beec8e200a286ebe03a324c8bc805a1ae8a18f Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Tue, 17 Mar 2015 03:02:27 -0400
+Subject: [PATCH] Relative teleport API
+
+
+diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
+index 8ee4444..74dde51 100644
+--- a/src/main/java/org/bukkit/entity/Player.java
++++ b/src/main/java/org/bukkit/entity/Player.java
+@@ -1567,4 +1567,12 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
+      * Hide any title that is currently visible to the player
+      */
+     public void hideTitle();
++
++    /**
++     * Seamlessly move the player by the given offset and rotation angles.
++     * Because the relative calculation is applied by the client, you cannot
++     * know the player's absolute location immediately after teleporting.
++     */
++    public boolean teleportRelative(org.bukkit.util.Vector deltaPos, float deltaYaw, float deltaPitch, org.bukkit.event.player.PlayerTeleportEvent.TeleportCause cause);
++    public boolean teleportRelative(org.bukkit.util.Vector deltaPos, float deltaYaw, float deltaPitch);
+ }
+-- 
+1.9.0
+

--- a/Bukkit/0032-Complete-resource-pack-API.patch
+++ b/Bukkit/0032-Complete-resource-pack-API.patch
@@ -1,0 +1,52 @@
+From 6021d7bab0e5a920830aa95ee0e7abbe4b6470db Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Sat, 4 Apr 2015 22:59:54 -0400
+Subject: [PATCH] Complete resource pack API
+
+
+diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
+index 74dde51..fb60caf 100644
+--- a/src/main/java/org/bukkit/entity/Player.java
++++ b/src/main/java/org/bukkit/entity/Player.java
+@@ -20,6 +20,7 @@ import org.bukkit.Statistic;
+ import org.bukkit.WeatherType;
+ import org.bukkit.command.CommandSender;
+ import org.bukkit.conversations.Conversable;
++import org.bukkit.event.player.PlayerResourcePackStatusEvent;
+ import org.bukkit.map.MapView;
+ import org.bukkit.plugin.messaging.PluginMessageRecipient;
+ import org.bukkit.scoreboard.Scoreboard;
+@@ -1158,13 +1159,30 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
+      * @param url The URL from which the client will download the resource
+      *     pack. The string must contain only US-ASCII characters and should
+      *     be encoded as per RFC 1738.
++     * @param hash A 40 character hexadecimal and lowercase SHA-1 digest of
++     *             the resource pack file.
+      * @throws IllegalArgumentException Thrown if the URL is null.
+      * @throws IllegalArgumentException Thrown if the URL is too long. The
+      *     length restriction is an implementation specific arbitrary value.
+      */
++    public void setResourcePack(String url, String hash);
++
++    @Deprecated
+     public void setResourcePack(String url);
+ 
+     /**
++     * @return the most recent resource pack status received from the player,
++     *         or null if no status has ever been received from this player.
++     */
++    public PlayerResourcePackStatusEvent.Status getResourcePackStatus();
++
++    /**
++     * @return true if the last resource pack status received from this player
++     *         was {@link PlayerResourcePackStatusEvent.Status#SUCCESSFULLY_LOADED}
++     */
++    public boolean hasResourcePack();
++
++    /**
+      * Gets the Scoreboard displayed to this player
+      *
+      * @return The current scoreboard seen by this player
+-- 
+1.9.0
+

--- a/Bukkit/0033-Block-digging-API.patch
+++ b/Bukkit/0033-Block-digging-API.patch
@@ -1,0 +1,75 @@
+From 8a6c45618787242f22854c2217fef79cc8b86c2b Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Sat, 9 May 2015 14:30:04 -0400
+Subject: [PATCH] Block digging API
+
+
+diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
+index fb60caf..6631867 100644
+--- a/src/main/java/org/bukkit/entity/Player.java
++++ b/src/main/java/org/bukkit/entity/Player.java
+@@ -1593,4 +1593,15 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
+      */
+     public boolean teleportRelative(org.bukkit.util.Vector deltaPos, float deltaYaw, float deltaPitch, org.bukkit.event.player.PlayerTeleportEvent.TeleportCause cause);
+     public boolean teleportRelative(org.bukkit.util.Vector deltaPos, float deltaYaw, float deltaPitch);
++
++    /**
++     * Is the player digging a block?
++     */
++    public boolean isDigging();
++
++    /**
++     * Return the {@link org.bukkit.block.Block} that the player is currently digging,
++     * or null if they are not digging any block.
++     */
++    public org.bukkit.block.Block getDiggingBlock();
+ }
+diff --git a/src/main/java/org/bukkit/event/block/BlockUndamageEvent.java b/src/main/java/org/bukkit/event/block/BlockUndamageEvent.java
+new file mode 100644
+index 0000000..4d28dc7
+--- /dev/null
++++ b/src/main/java/org/bukkit/event/block/BlockUndamageEvent.java
+@@ -0,0 +1,40 @@
++package org.bukkit.event.block;
++
++import org.bukkit.block.Block;
++import org.bukkit.entity.Player;
++import org.bukkit.event.HandlerList;
++
++/**
++ * Called when a player stops digging a block WITHOUT breaking it. This is the
++ * counterpart to {@link BlockDamageEvent}, which fires when the player starts
++ * digging. This event will not be called if the player completes the dig and
++ * breaks the block. It will also not be called if the block breaks instantly
++ * when the player starts digging.
++ */
++public class BlockUndamageEvent extends BlockEvent {
++    private static final HandlerList handlers = new HandlerList();
++    private final Player player;
++
++    public BlockUndamageEvent(final Player player, final Block block) {
++        super(block);
++        this.player = player;
++    }
++
++    /**
++     * Gets the player damaging the block involved in this event.
++     *
++     * @return The player damaging the block involved in this event
++     */
++    public Player getPlayer() {
++        return player;
++    }
++
++    @Override
++    public HandlerList getHandlers() {
++        return handlers;
++    }
++
++    public static HandlerList getHandlerList() {
++        return handlers;
++    }
++}
+-- 
+1.9.0
+

--- a/Bukkit/0034-Item-Attribute-Modifier-API.patch
+++ b/Bukkit/0034-Item-Attribute-Modifier-API.patch
@@ -1,0 +1,279 @@
+From f439dff73078f25e7e7c25ed971545b762001c63 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Tue, 19 May 2015 06:30:47 -0400
+Subject: [PATCH] Item Attribute Modifier API
+
+
+diff --git a/src/main/java/org/bukkit/attribute/Attribute.java b/src/main/java/org/bukkit/attribute/Attribute.java
+index 38bea1e..d9e83ad 100644
+--- a/src/main/java/org/bukkit/attribute/Attribute.java
++++ b/src/main/java/org/bukkit/attribute/Attribute.java
+@@ -1,5 +1,8 @@
+ package org.bukkit.attribute;
+ 
++import java.util.HashMap;
++import java.util.Map;
++
+ /**
+  * Types of attributes which may be present on an {@link Attributable}.
+  */
+@@ -8,41 +11,66 @@ public enum Attribute {
+     /**
+      * Maximum health of an Entity.
+      */
+-    GENERIC_MAX_HEALTH,
++    GENERIC_MAX_HEALTH("generic.maxHealth"),
+     /**
+      * Range at which an Entity will follow others.
+      */
+-    GENERIC_FOLLOW_RANGE,
++    GENERIC_FOLLOW_RANGE("generic.followRange"),
+     /**
+      * Resistance of an Entity to knockback.
+      */
+-    GENERIC_KNOCKBACK_RESISTANCE,
++    GENERIC_KNOCKBACK_RESISTANCE("generic.knockbackResistance"),
+     /**
+      * Movement speed of an Entity.
+      */
+-    GENERIC_MOVEMENT_SPEED,
++    GENERIC_MOVEMENT_SPEED("generic.movementSpeed"),
+     /**
+      * Attack damage of an Entity.
+      */
+-    GENERIC_ATTACK_DAMAGE,
++    GENERIC_ATTACK_DAMAGE("generic.attackDamage"),
+     /**
+      * Attack speed of an Entity.
+      */
+-    GENERIC_ATTACK_SPEED,
++    GENERIC_ATTACK_SPEED("generic.attackSpeed"),
+     /**
+      * Armor bonus of an Entity.
+      */
+-    GENERIC_ARMOR,
++    GENERIC_ARMOR("generic.armor"),
+     /**
+      * Luck bonus of an Entity.
+      */
+-    GENERIC_LUCK,
++    GENERIC_LUCK("generic.luck"),
+     /**
+      * Strength with which a horse will jump.
+      */
+-    HORSE_JUMP_STRENGTH,
++    HORSE_JUMP_STRENGTH("horse.jumpStrength"),
+     /**
+      * Chance of a zombie to spawn reinforcements.
+      */
+-    ZOMBIE_SPAWN_REINFORCEMENTS;
++    ZOMBIE_SPAWN_REINFORCEMENTS("zombie.spawnReinforcements");
++
++    private final String name;
++
++    Attribute(String name) {
++        this.name = name;
++    }
++
++    /**
++     * @return the external name of this attribute
++     */
++    public String getName() {
++        return name;
++    }
++
++    private static final Map<String, Attribute> byName = new HashMap<String, Attribute>();
++
++    static {
++        for(Attribute attribute : values()) {
++            byName.put(attribute.getName(), attribute);
++        }
++    }
++
++    public static Attribute byName(String name) {
++        return byName.get(name);
++    }
+ }
+diff --git a/src/main/java/org/bukkit/attribute/AttributeModifier.java b/src/main/java/org/bukkit/attribute/AttributeModifier.java
+index ade7bf0..239c56a 100644
+--- a/src/main/java/org/bukkit/attribute/AttributeModifier.java
++++ b/src/main/java/org/bukkit/attribute/AttributeModifier.java
+@@ -99,5 +99,11 @@ public class AttributeModifier implements ConfigurationSerializable {
+          * Multiply amount by this value, after adding 1 to it.
+          */
+         MULTIPLY_SCALAR_1;
++
++        public static Operation fromOpcode(int code) {
++            if(code < 0) code = 0;
++            if(code >= values().length) code = values().length - 1;
++            return values()[code];
++        }
+     }
+ }
+diff --git a/src/main/java/org/bukkit/attribute/ItemAttributeModifier.java b/src/main/java/org/bukkit/attribute/ItemAttributeModifier.java
+new file mode 100644
+index 0000000..71ae14e
+--- /dev/null
++++ b/src/main/java/org/bukkit/attribute/ItemAttributeModifier.java
+@@ -0,0 +1,65 @@
++package org.bukkit.attribute;
++
++import java.util.Map;
++
++import org.bukkit.configuration.serialization.ConfigurationSerializable;
++import org.bukkit.inventory.EquipmentSlot;
++
++/**
++ * An {@link AttributeModifier} attached to an item, with an optional slot.
++ */
++public class ItemAttributeModifier implements ConfigurationSerializable {
++
++    private final EquipmentSlot slot;
++    private final AttributeModifier modifier;
++
++    public ItemAttributeModifier(EquipmentSlot slot, AttributeModifier modifier) {
++        this.modifier = modifier;
++        this.slot = slot;
++    }
++
++    /**
++     * The slot the item must be in for te modifier to take effect,
++     * or null if the slot doesn't matter.
++     */
++    public EquipmentSlot getSlot() {
++        return slot;
++    }
++
++    public AttributeModifier getModifier() {
++        return modifier;
++    }
++
++    @Override
++    public Map<String, Object> serialize() {
++        final Map<String, Object> map = modifier.serialize();
++        map.put("slot", serializeSlot(slot));
++        return map;
++    }
++    public static ItemAttributeModifier deserialize(Map<String, Object> args) {
++        return new ItemAttributeModifier(deserializeSlot((String) args.get("slot")), AttributeModifier.deserialize(args));
++    }
++
++    public static String serializeSlot(EquipmentSlot slot) {
++        if(slot == null) return null;
++        return slotNames[slot.ordinal()];
++    }
++
++    public static EquipmentSlot deserializeSlot(String slot) {
++        if(slot == null) return null;
++        for(int i = 0; i < slotNames.length; i++) {
++            if(slot.equals(slotNames[i])) return EquipmentSlot.values()[i];
++        }
++        return null;
++    }
++
++    private static final String[] slotNames = new String[EquipmentSlot.values().length];
++    static {
++        slotNames[EquipmentSlot.HAND.ordinal()] = "mainhand";
++        slotNames[EquipmentSlot.OFF_HAND.ordinal()] = "offhand";
++        slotNames[EquipmentSlot.HEAD.ordinal()] = "head";
++        slotNames[EquipmentSlot.CHEST.ordinal()] = "chest";
++        slotNames[EquipmentSlot.LEGS.ordinal()] = "legs";
++        slotNames[EquipmentSlot.FEET.ordinal()] = "feet";
++    }
++}
+diff --git a/src/main/java/org/bukkit/inventory/ItemFactory.java b/src/main/java/org/bukkit/inventory/ItemFactory.java
+index 52a8d4d..ecfd18c 100644
+--- a/src/main/java/org/bukkit/inventory/ItemFactory.java
++++ b/src/main/java/org/bukkit/inventory/ItemFactory.java
+@@ -1,11 +1,18 @@
+ package org.bukkit.inventory;
+ 
++import java.util.Collection;
++import java.util.List;
++import java.util.Map;
++
+ import org.bukkit.Color;
+ import org.bukkit.Material;
+ import org.bukkit.Server;
++import org.bukkit.attribute.Attribute;
++import org.bukkit.attribute.ItemAttributeModifier;
+ import org.bukkit.inventory.meta.BookMeta;
+ import org.bukkit.inventory.meta.ItemMeta;
+ import org.bukkit.inventory.meta.SkullMeta;
++import org.bukkit.material.MaterialData;
+ 
+ /**
+  * An instance of the ItemFactory can be obtained with {@link
+@@ -121,4 +128,20 @@ public interface ItemFactory {
+      * @return the default color for leather armor
+      */
+     Color getDefaultLeatherColor();
++
++    Collection<String> getModifiedAttributes(MaterialData item);
++
++    Map<String, List<ItemAttributeModifier>> getAttributeModifiers(MaterialData item);
++
++    Collection<ItemAttributeModifier> getAttributeModifiers(MaterialData item, String attribute);
++
++    Collection<ItemAttributeModifier> getAttributeModifiers(MaterialData item, Attribute attribute);
++
++    Collection<String> getModifiedAttributes(Material item);
++
++    Map<String, List<ItemAttributeModifier>> getAttributeModifiers(Material item);
++
++    Collection<ItemAttributeModifier> getAttributeModifiers(Material item, String attribute);
++
++    Collection<ItemAttributeModifier> getAttributeModifiers(Material item, Attribute attribute);
+ }
+diff --git a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
+index fa3efe3..92455ce 100644
+--- a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
++++ b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
+@@ -1,9 +1,13 @@
+ package org.bukkit.inventory.meta;
+ 
++import java.util.Collection;
+ import java.util.List;
+ import java.util.Map;
+ import java.util.Set;
+ 
++import org.bukkit.attribute.Attribute;
++import org.bukkit.attribute.AttributeModifier;
++import org.bukkit.attribute.ItemAttributeModifier;
+ import org.bukkit.configuration.serialization.ConfigurationSerializable;
+ import org.bukkit.enchantments.Enchantment;
+ import org.bukkit.inventory.ItemFlag;
+@@ -170,6 +174,30 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable {
+      */
+     void setUnbreakable(boolean unbreakable);
+ 
++    boolean hasAttributeModifiers();
++
++    Collection<String> getModifiedAttributes();
++
++    boolean hasModifiedAttribute(String attribute);
++
++    boolean hasModifiedAttribute(Attribute attribute);
++
++    boolean hasAttributeModifier(String attribute, ItemAttributeModifier modifier);
++
++    boolean hasAttributeModifier(Attribute attribute, ItemAttributeModifier modifier);
++
++    Collection<ItemAttributeModifier> getAttributeModifiers(String attribute);
++
++    Collection<ItemAttributeModifier> getAttributeModifiers(Attribute attribute);
++
++    void addAttributeModifier(String attribute, ItemAttributeModifier modifier);
++
++    void addAttributeModifier(Attribute attribute, ItemAttributeModifier modifier);
++
++    void removeAttributeModifier(String attribute, ItemAttributeModifier modifier);
++
++    void removeAttributeModifier(Attribute attribute, ItemAttributeModifier modifier);
++
+     @SuppressWarnings("javadoc")
+     ItemMeta clone();
+ }
+-- 
+1.9.0
+

--- a/Bukkit/0035-Add-CanDestroy-and-CanPlaceOn-to-ItemMeta.patch
+++ b/Bukkit/0035-Add-CanDestroy-and-CanPlaceOn-to-ItemMeta.patch
@@ -1,0 +1,131 @@
+From 495881278f2b39606822cc2aff309b0203eda25a Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Fri, 22 May 2015 00:45:13 -0400
+Subject: [PATCH] Add CanDestroy and CanPlaceOn to ItemMeta
+
+
+diff --git a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
+index 92455ce..1e37a64 100644
+--- a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
++++ b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
+@@ -5,12 +5,14 @@ import java.util.List;
+ import java.util.Map;
+ import java.util.Set;
+ 
++import org.bukkit.Material;
+ import org.bukkit.attribute.Attribute;
+ import org.bukkit.attribute.AttributeModifier;
+ import org.bukkit.attribute.ItemAttributeModifier;
+ import org.bukkit.configuration.serialization.ConfigurationSerializable;
+ import org.bukkit.enchantments.Enchantment;
+ import org.bukkit.inventory.ItemFlag;
++import org.bukkit.util.ImmutableMaterialSet;
+ 
+ /**
+  * This type represents the storage mechanism for auxiliary item data.
+@@ -198,6 +200,18 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable {
+ 
+     void removeAttributeModifier(Attribute attribute, ItemAttributeModifier modifier);
+ 
++    ImmutableMaterialSet getCanDestroy();
++
++    void setCanDestroy(Collection<Material> materials);
++
++    void setCanDestroy(Material...materials);
++
++    ImmutableMaterialSet getCanPlaceOn();
++
++    void setCanPlaceOn(Collection<Material> materials);
++
++    void setCanPlaceOn(Material...materials);
++
+     @SuppressWarnings("javadoc")
+     ItemMeta clone();
+ }
+diff --git a/src/main/java/org/bukkit/util/ImmutableMaterialSet.java b/src/main/java/org/bukkit/util/ImmutableMaterialSet.java
+new file mode 100644
+index 0000000..a048988
+--- /dev/null
++++ b/src/main/java/org/bukkit/util/ImmutableMaterialSet.java
+@@ -0,0 +1,78 @@
++package org.bukkit.util;
++
++import java.util.Arrays;
++import java.util.Collection;
++import java.util.Collections;
++import java.util.EnumSet;
++import java.util.Set;
++
++import com.google.common.collect.ForwardingSet;
++import org.bukkit.Material;
++
++/**
++ * Highly efficient immutable container for {@link Material}s. Useful for sharing
++ * large material lists.
++ */
++public class ImmutableMaterialSet extends ForwardingSet<Material> {
++
++    private final Set<Material> materials;
++
++    private ImmutableMaterialSet(Set<Material> materials) {
++        this.materials = materials;
++    }
++
++    private static final ImmutableMaterialSet EMPTY = new ImmutableMaterialSet(Collections.<Material>emptySet());
++
++    public static ImmutableMaterialSet of(ImmutableMaterialSet materials) {
++        return materials;
++    }
++
++    public static ImmutableMaterialSet of() {
++        return EMPTY;
++    }
++
++    public static ImmutableMaterialSet of(Material...materials) {
++        return new ImmutableMaterialSet(Collections.unmodifiableSet(EnumSet.copyOf(Arrays.asList(materials))));
++    }
++
++    public static ImmutableMaterialSet of(Collection<Material> materials) {
++        if(materials instanceof ImmutableMaterialSet) {
++            return (ImmutableMaterialSet) materials;
++        } else {
++            return new ImmutableMaterialSet(Collections.unmodifiableSet(EnumSet.copyOf(materials)));
++        }
++    }
++
++    @Override
++    protected Set<Material> delegate() {
++        return materials;
++    }
++
++    public static Builder builder() {
++        return new Builder();
++    }
++
++    public static class Builder {
++        private final EnumSet<Material> materials = EnumSet.noneOf(Material.class);
++        private boolean built;
++
++        private void assertUnbuilt() {
++            if(built) throw new IllegalStateException("Already built");
++        }
++
++        public void add(Material material) {
++            assertUnbuilt();
++            materials.add(material);
++        }
++
++        public boolean isEmpty() {
++            assertUnbuilt();
++            return materials.isEmpty();
++        }
++
++        public ImmutableMaterialSet build() {
++            built = true;
++            return materials.isEmpty() ? EMPTY : new ImmutableMaterialSet(materials);
++        }
++    }
++}
+-- 
+1.9.0
+

--- a/Bukkit/0036-Accurate-block-hit-checking.patch
+++ b/Bukkit/0036-Accurate-block-hit-checking.patch
@@ -1,0 +1,169 @@
+From 4135740f191b089488c969123fd639d88b568341 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Tue, 26 May 2015 04:00:58 -0400
+Subject: [PATCH] Accurate block hit checking
+
+
+diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
+index db29db8..615e29b 100644
+--- a/src/main/java/org/bukkit/World.java
++++ b/src/main/java/org/bukkit/World.java
+@@ -16,6 +16,7 @@ import org.bukkit.inventory.ItemStack;
+ import org.bukkit.material.MaterialData;
+ import org.bukkit.metadata.Metadatable;
+ import org.bukkit.plugin.messaging.PluginMessageRecipient;
++import org.bukkit.util.RayBlockIntersection;
+ import org.bukkit.util.Vector;
+ 
+ /**
+@@ -111,6 +112,26 @@ public interface World extends PluginMessageRecipient, Metadatable {
+     public Block getHighestBlockAt(Location location);
+ 
+     /**
++     * Find the first block intersecting the given ray
++     * @param start             Origin AND direction of the ray
++     * @param distance          Length of the ray (so it's not strictly a ray, but whatever)
++     * @param nonSolids         Include non-colliding blocks (e.g. torch, button, flower, etc)
++     * @param liquids           Include liquids (source blocks only)
++     * @return A data structure describing the intersection, or null if no blocks were hit
++     */
++    RayBlockIntersection rayTraceBlock(Location start, double distance, boolean nonSolids, boolean liquids);
++
++    /**
++     * Find the first block intersecting the given ray
++     * @param start             Origin of the ray
++     * @param end               End point of the ray (so it's not strictly a ray, but whatever)
++     * @param nonSolids         Include non-colliding blocks (e.g. torch, button, flower, etc)
++     * @param liquids           Include liquids (source blocks only)
++     * @return A data structure describing the intersection, or null if no blocks were hit
++     */
++    RayBlockIntersection rayTraceBlock(Vector start, Vector end, boolean nonSolids, boolean liquids);
++
++    /**
+      * Gets the {@link Chunk} at the given coordinates
+      *
+      * @param x X-coordinate of the chunk
+diff --git a/src/main/java/org/bukkit/block/Block.java b/src/main/java/org/bukkit/block/Block.java
+index 235c15b..fe32537 100644
+--- a/src/main/java/org/bukkit/block/Block.java
++++ b/src/main/java/org/bukkit/block/Block.java
+@@ -8,6 +8,8 @@ import org.bukkit.World;
+ import org.bukkit.Location;
+ import org.bukkit.inventory.ItemStack;
+ import org.bukkit.metadata.Metadatable;
++import org.bukkit.util.RayBlockIntersection;
++import org.bukkit.util.Vector;
+ 
+ /**
+  * Represents a block. This is a live object, and only one Block may exist for
+@@ -390,4 +392,19 @@ public interface Block extends Metadatable {
+      */
+     Collection<ItemStack> getDrops(ItemStack tool);
+ 
++    /**
++     * Find the first intersection of the given ray with this block's bounding box
++     * @param start             Origin of the ray
++     * @param end               End point of the ray (so it's not strictly a ray, but whatever)
++     * @return A data structure describing the intersection, or null if there was no intersection
++     */
++    RayBlockIntersection rayTrace(Vector start, Vector end);
++
++    /**
++     * Find the first intersection of the given ray with this block's bounding box
++     * @param start             Origin AND direction of the ray
++     * @param distance          Length of the ray (so it's not strictly a ray, but whatever)
++     * @return A data structure describing the intersection, or null if there was no intersection
++     */
++    RayBlockIntersection rayTrace(Location start, double distance);
+ }
+diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
+index 6631867..41a4bd5 100644
+--- a/src/main/java/org/bukkit/entity/Player.java
++++ b/src/main/java/org/bukkit/entity/Player.java
+@@ -24,6 +24,7 @@ import org.bukkit.event.player.PlayerResourcePackStatusEvent;
+ import org.bukkit.map.MapView;
+ import org.bukkit.plugin.messaging.PluginMessageRecipient;
+ import org.bukkit.scoreboard.Scoreboard;
++import org.bukkit.util.RayBlockIntersection;
+ 
+ /**
+  * Represents a player, connected or not
+@@ -1604,4 +1605,29 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
+      * or null if they are not digging any block.
+      */
+     public org.bukkit.block.Block getDiggingBlock();
++
++    /**
++     * @return The distance from which the player can target blocks in their current gamemode
++     */
++    double getBlockReach();
++
++    /**
++     * Find the first block in the player's line-of-sight, up to the given distance away
++     * @param distance          Maximum distance from the player to search
++     * @param nonSolids         Include non-colliding blocks (e.g. torch, button, flower, etc)
++     * @param liquids           Include liquids (source blocks only)
++     * @return Information about the targeted block, or null if no blocks were found
++     */
++    RayBlockIntersection getTargetedBlock(double distance, boolean nonSolids, boolean liquids);
++
++    /**
++     * Find the block targeted by the player, i.e. the block that (probably) has a black outline on their screen.
++     * This accounts for the player's current gamemode, so players in creative mode will have a longer range.
++     * Players in adventure mode or spectator mode are assumed to be able to target any block, with the same range
++     * as survival mode.
++     * @param nonSolids         Include non-colliding blocks (e.g. torch, button, flower, etc)
++     * @param liquids           Include liquids (source blocks only)
++     * @return Information about the targeted block, or null if no blocks were found
++     */
++    RayBlockIntersection getTargetedBlock(boolean nonSolids, boolean liquids);
+ }
+diff --git a/src/main/java/org/bukkit/util/RayBlockIntersection.java b/src/main/java/org/bukkit/util/RayBlockIntersection.java
+new file mode 100644
+index 0000000..b1ba1d8
+--- /dev/null
++++ b/src/main/java/org/bukkit/util/RayBlockIntersection.java
+@@ -0,0 +1,40 @@
++package org.bukkit.util;
++
++import org.bukkit.block.Block;
++import org.bukkit.block.BlockFace;
++
++/**
++ * Result of a ray-block intersection test
++ */
++public class RayBlockIntersection {
++    private final Block block;
++    private final BlockFace face;
++    private final Vector position;
++
++    public RayBlockIntersection(Block block, BlockFace face, Vector position) {
++        this.block = block;
++        this.face = face;
++        this.position = position;
++    }
++
++    /**
++     * @return The intersected block
++     */
++    public Block getBlock() {
++        return block;
++    }
++
++    /**
++     * @return The first intersected face of the block
++     */
++    public BlockFace getFace() {
++        return face;
++    }
++
++    /**
++     * @return The first intersected point on the surface of the block
++     */
++    public Vector getPosition() {
++        return position;
++    }
++}
+-- 
+1.9.0
+

--- a/Bukkit/0037-Improve-Permissible-interface.patch
+++ b/Bukkit/0037-Improve-Permissible-interface.patch
@@ -1,0 +1,267 @@
+From 8d681f2f5131e153c1519f7c17c9eae0d7452b1e Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Thu, 28 May 2015 04:31:07 -0400
+Subject: [PATCH] Improve Permissible interface
+
+
+diff --git a/src/main/java/org/bukkit/permissions/Permissible.java b/src/main/java/org/bukkit/permissions/Permissible.java
+index 5cd3cff..a7c0ef5 100644
+--- a/src/main/java/org/bukkit/permissions/Permissible.java
++++ b/src/main/java/org/bukkit/permissions/Permissible.java
+@@ -1,5 +1,6 @@
+ package org.bukkit.permissions;
+ 
++import java.util.Collection;
+ import java.util.Set;
+ import org.bukkit.plugin.Plugin;
+ 
+@@ -105,6 +106,38 @@ public interface Permissible extends ServerOperator {
+     public void removeAttachment(PermissionAttachment attachment);
+ 
+     /**
++     * Remove from this object all of the {@link PermissionAttachment}s belonging to the given {@link Plugin}.
++     * @return true if anything was removed, false if nothing changed
++     */
++    boolean removeAttachments(Plugin plugin);
++
++    /**
++     * Remove from this object all of the {@link PermissionAttachment}s that apply to the given permission.
++     * @return true if anything was removed, false if nothing changed
++     */
++    boolean removeAttachments(String name);
++
++    /**
++     * Remove from this object all of the {@link PermissionAttachment}s that apply to the given {@link Permission}.
++     * @return true if anything was removed, false if nothing changed
++     */
++    boolean removeAttachments(Permission permission);
++
++    /**
++     * Remove from this object all of the {@link PermissionAttachment}s belonging to the given {@link Plugin}
++     * and applying to the given permission.
++     * @return true if anything was removed, false if nothing changed
++     */
++    boolean removeAttachments(Plugin plugin, String name);
++
++    /**
++     * Remove from this object all of the {@link PermissionAttachment}s belonging to the given {@link Plugin}
++     * and applying to the given {@link Permission}.
++     * @return true if anything was removed, false if nothing changed
++     */
++    boolean removeAttachments(Plugin plugin, Permission permission);
++
++    /**
+      * Recalculates the permissions for this object, if the attachments have
+      * changed values.
+      * <p>
+@@ -119,4 +152,38 @@ public interface Permissible extends ServerOperator {
+      * @return Set of currently effective permissions
+      */
+     public Set<PermissionAttachmentInfo> getEffectivePermissions();
++
++    PermissionAttachmentInfo getEffectivePermission(String name);
++
++    /**
++     * @return Info about all {@link PermissionAttachment}s attached to this object, effective or not.
++     */
++    Collection<PermissionAttachmentInfo> getAttachments();
++
++    /**
++     * @return Info about all attached {@link PermissionAttachment}s belonging to the given {@link Plugin}.
++     */
++    Collection<PermissionAttachmentInfo> getAttachments(Plugin plugin);
++
++    /**
++     * @return Info about all attached {@link PermissionAttachment}s applying to the given permission.
++     */
++    Collection<PermissionAttachmentInfo> getAttachments(String name);
++
++    /**
++     * @return Info about all attached {@link PermissionAttachment}s applying to the given {@link Permission}.
++     */
++    Collection<PermissionAttachmentInfo> getAttachments(Permission permission);
++
++    /**
++     * @return Info about all attached {@link PermissionAttachment}s belonging to the given {@link Plugin}
++     * and applying to the given permission.
++     */
++    Collection<PermissionAttachmentInfo> getAttachments(Plugin plugin, String name);
++
++    /**
++     * @return Info about all attached {@link PermissionAttachment}s belonging to the given {@link Plugin}
++     * and applying to the given {@link Permission}.
++     */
++    Collection<PermissionAttachmentInfo> getAttachments(Plugin plugin, Permission permission);
+ }
+diff --git a/src/main/java/org/bukkit/permissions/PermissibleBase.java b/src/main/java/org/bukkit/permissions/PermissibleBase.java
+index bc772e5..3f053be 100644
+--- a/src/main/java/org/bukkit/permissions/PermissibleBase.java
++++ b/src/main/java/org/bukkit/permissions/PermissibleBase.java
+@@ -1,12 +1,17 @@
+ package org.bukkit.permissions;
+ 
+-import java.util.HashMap;
++import java.util.Collection;
+ import java.util.HashSet;
+-import java.util.LinkedList;
++import java.util.Iterator;
++import java.util.LinkedHashSet;
+ import java.util.List;
+ import java.util.Map;
+ import java.util.Set;
+ import java.util.logging.Level;
++
++import com.google.common.collect.ArrayListMultimap;
++import com.google.common.collect.ImmutableList;
++import com.google.common.collect.ListMultimap;
+ import org.bukkit.Bukkit;
+ import org.bukkit.plugin.Plugin;
+ 
+@@ -16,8 +21,8 @@ import org.bukkit.plugin.Plugin;
+ public class PermissibleBase implements Permissible {
+     private ServerOperator opable = null;
+     private Permissible parent = this;
+-    private final List<PermissionAttachment> attachments = new LinkedList<PermissionAttachment>();
+-    private final Map<String, PermissionAttachmentInfo> permissions = new HashMap<String, PermissionAttachmentInfo>();
++    private final Set<PermissionAttachment> attachments = new LinkedHashSet<PermissionAttachment>();
++    private final ListMultimap<String, PermissionAttachmentInfo> permissions = ArrayListMultimap.create();
+ 
+     public PermissibleBase(ServerOperator opable) {
+         this.opable = opable;
+@@ -69,7 +74,7 @@ public class PermissibleBase implements Permissible {
+         String name = inName.toLowerCase(java.util.Locale.ENGLISH);
+ 
+         if (isPermissionSet(name)) {
+-            return permissions.get(name).getValue();
++            return getEffectivePermission(name).getValue();
+         } else {
+             Permission perm = Bukkit.getServer().getPluginManager().getPermission(name);
+ 
+@@ -89,7 +94,7 @@ public class PermissibleBase implements Permissible {
+         String name = perm.getName().toLowerCase(java.util.Locale.ENGLISH);
+ 
+         if (isPermissionSet(name)) {
+-            return permissions.get(name).getValue();
++            return getEffectivePermission(name).getValue();
+         }
+         return perm.getDefault().getValue(isOp());
+     }
+@@ -145,6 +150,54 @@ public class PermissibleBase implements Permissible {
+         }
+     }
+ 
++    @Override
++    public boolean removeAttachments(Plugin plugin) {
++        boolean changed = false;
++        for(Iterator<PermissionAttachment> iterator = attachments.iterator(); iterator.hasNext(); ) {
++            PermissionAttachment attachment = iterator.next();
++            if(attachment.getPlugin() == plugin) {
++                iterator.remove();
++                changed = true;
++            }
++        }
++        if(changed) recalculatePermissions();
++        return changed;
++    }
++
++    @Override
++    public boolean removeAttachments(String name) {
++        boolean changed = false;
++        for(PermissionAttachmentInfo info : permissions.get(name.toLowerCase())) {
++            attachments.remove(info.getAttachment());
++            changed = true;
++        }
++        if(changed) recalculatePermissions();
++        return changed;
++    }
++
++    @Override
++    public boolean removeAttachments(Permission permission) {
++        return removeAttachments(permission.getName());
++    }
++
++    @Override
++    public boolean removeAttachments(Plugin plugin, String name) {
++        boolean changed = false;
++        for(PermissionAttachmentInfo info : permissions.get(name.toLowerCase())) {
++            if(info.getAttachment().getPlugin() == plugin) {
++                attachments.remove(info.getAttachment());
++                changed = true;
++            }
++        }
++        if(changed) recalculatePermissions();
++        return changed;
++    }
++
++    @Override
++    public boolean removeAttachments(Plugin plugin, Permission permission) {
++        return removeAttachments(plugin, permission.getName());
++    }
++
+     public void recalculatePermissions() {
+         clearPermissions();
+         Set<Permission> defaults = Bukkit.getServer().getPluginManager().getDefaultPermissions(isOp());
+@@ -229,7 +282,59 @@ public class PermissibleBase implements Permissible {
+     }
+ 
+     public Set<PermissionAttachmentInfo> getEffectivePermissions() {
+-        return new HashSet<PermissionAttachmentInfo>(permissions.values());
++        HashSet<PermissionAttachmentInfo> effective = new HashSet<PermissionAttachmentInfo>(permissions.keySet().size());
++        for(String name : permissions.keySet()) {
++            effective.add(getEffectivePermission(name));
++        }
++        return effective;
++    }
++
++    @Override
++    public PermissionAttachmentInfo getEffectivePermission(String name) {
++        List<PermissionAttachmentInfo> list = permissions.get(name.toLowerCase());
++        return list.isEmpty() ? null : list.get(list.size() - 1);
++    }
++
++    @Override
++    public Collection<PermissionAttachmentInfo> getAttachments() {
++        return ImmutableList.copyOf(permissions.values());
++    }
++
++    @Override
++    public Collection<PermissionAttachmentInfo> getAttachments(Plugin plugin) {
++        ImmutableList.Builder<PermissionAttachmentInfo> builder = ImmutableList.builder();
++        for(PermissionAttachmentInfo info : permissions.values()) {
++            if(info.getAttachment() != null && info.getAttachment().getPlugin() == plugin) {
++                builder.add(info);
++            }
++        }
++        return builder.build();
++    }
++
++    @Override
++    public Collection<PermissionAttachmentInfo> getAttachments(String name) {
++        return ImmutableList.copyOf(permissions.get(name.toLowerCase()));
++    }
++
++    @Override
++    public Collection<PermissionAttachmentInfo> getAttachments(Permission permission) {
++        return getAttachments(permission.getName());
++    }
++
++    @Override
++    public Collection<PermissionAttachmentInfo> getAttachments(Plugin plugin, String name) {
++        ImmutableList.Builder<PermissionAttachmentInfo> builder = ImmutableList.builder();
++        for(PermissionAttachmentInfo info : permissions.get(name.toLowerCase())) {
++            if(info.getAttachment() != null && info.getAttachment().getPlugin() == plugin) {
++                builder.add(info);
++            }
++        }
++        return builder.build();
++    }
++
++    @Override
++    public Collection<PermissionAttachmentInfo> getAttachments(Plugin plugin, Permission permission) {
++        return getAttachments(plugin, permission.getName());
+     }
+ 
+     private class RemoveAttachmentRunnable implements Runnable {
+-- 
+1.9.0
+

--- a/Bukkit/0038-Add-a-non-deprecated-constructor-to-EntityChangeBloc.patch
+++ b/Bukkit/0038-Add-a-non-deprecated-constructor-to-EntityChangeBloc.patch
@@ -1,0 +1,83 @@
+From 8fd8b6d813bd2aee5c664d29de1ea2e6df39f058 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Sat, 30 May 2015 06:53:57 -0400
+Subject: [PATCH] Add a non-deprecated constructor to EntityChangeBlockEvent
+
+
+diff --git a/src/main/java/org/bukkit/event/entity/EntityChangeBlockEvent.java b/src/main/java/org/bukkit/event/entity/EntityChangeBlockEvent.java
+index 9f69ded..849e57d 100644
+--- a/src/main/java/org/bukkit/event/entity/EntityChangeBlockEvent.java
++++ b/src/main/java/org/bukkit/event/entity/EntityChangeBlockEvent.java
+@@ -5,6 +5,7 @@ import org.bukkit.block.Block;
+ import org.bukkit.entity.Entity;
+ import org.bukkit.event.Cancellable;
+ import org.bukkit.event.HandlerList;
++import org.bukkit.material.MaterialData;
+ 
+ /**
+  * Called when any Entity, excluding players, changes a block.
+@@ -13,8 +14,18 @@ public class EntityChangeBlockEvent extends EntityEvent implements Cancellable {
+     private static final HandlerList handlers = new HandlerList();
+     private final Block block;
+     private boolean cancel;
+-    private final Material to;
+-    private final byte data;
++    private final MaterialData to;
++
++    /**
++     * @param what the LivingEntity causing the change
++     * @param block the block (before the change)
++     * @param to the future material being changed to
++     */
++    public EntityChangeBlockEvent(final Entity what, final Block block, final MaterialData to) {
++        super(what);
++        this.block = block;
++        this.to = to;
++    }
+ 
+     /**
+      *
+@@ -26,11 +37,7 @@ public class EntityChangeBlockEvent extends EntityEvent implements Cancellable {
+      */
+     @Deprecated
+     public EntityChangeBlockEvent(final Entity what, final Block block, final Material to, final byte data) {
+-        super(what);
+-        this.block = block;
+-        this.cancel = false;
+-        this.to = to;
+-        this.data = data;
++        this(what, block, new MaterialData(to, data));
+     }
+ 
+     /**
+@@ -50,13 +57,17 @@ public class EntityChangeBlockEvent extends EntityEvent implements Cancellable {
+         this.cancel = cancel;
+     }
+ 
++    public MaterialData getToData() {
++        return to;
++    }
++
+     /**
+      * Gets the Material that the block is changing into
+      *
+      * @return the material that the block is changing into
+      */
+     public Material getTo() {
+-        return to;
++        return to.getItemType();
+     }
+ 
+     /**
+@@ -67,7 +78,7 @@ public class EntityChangeBlockEvent extends EntityEvent implements Cancellable {
+      */
+     @Deprecated
+     public byte getData() {
+-        return data;
++        return to.getData();
+     }
+ 
+     @Override
+-- 
+1.9.0
+

--- a/Bukkit/0039-Improve-BlockState-API.patch
+++ b/Bukkit/0039-Improve-BlockState-API.patch
@@ -1,0 +1,87 @@
+From 3d34ab6ef2461df2a0603b237a3f6b40d244d674 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Mon, 1 Jun 2015 06:28:48 -0400
+Subject: [PATCH] Improve BlockState API
+
+
+diff --git a/src/main/java/org/bukkit/block/BlockState.java b/src/main/java/org/bukkit/block/BlockState.java
+index 866a73d..911a4d1 100644
+--- a/src/main/java/org/bukkit/block/BlockState.java
++++ b/src/main/java/org/bukkit/block/BlockState.java
+@@ -26,17 +26,49 @@ public interface BlockState extends Metadatable {
+     Block getBlock();
+ 
+     /**
++     * Get the material of this block state.
++     */
++    Material getMaterial();
++
++    /**
++     * Get the material and metadata of this block state.
++     */
++    MaterialData getMaterialData();
++
++    /**
++     * Set the material of this block state. If the new material is different
++     * from the current material, any metadata for the new material will be set
++     * to default values.
++     *
++     * This changes only the state of this object, not any blocks.
++     * Call {@link #update} to apply changes to actual blocks.
++     */
++    void setMaterial(Material material);
++
++    /**
++     * Set the material and metadata of this block state.
++     *
++     * This changes only the state of this object, not any blocks.
++     * Call {@link #update} to apply changes to actual blocks.
++     */
++    void setMaterialData(MaterialData materialData);
++
++    /**
+      * Gets the metadata for this block
+      *
+      * @return block specific metadata
++     * @deprecated Confusing name
+      */
++    @Deprecated
+     MaterialData getData();
+ 
+     /**
+      * Gets the type of this block
+      *
+      * @return block type
++     * @deprecated Confusing name
+      */
++    @Deprecated
+     Material getType();
+ 
+     /**
+@@ -109,17 +141,22 @@ public interface BlockState extends Metadatable {
+     Chunk getChunk();
+ 
+     /**
+-     * Sets the metadata for this block
++     * Sets the metadata ONLY for this block (NOT the material).
++     * The {@link Material} of the given data must match that of the block.
+      *
+      * @param data New block specific metadata
++     * @deprecated Confusing name, strange behavior
+      */
++    @Deprecated
+     void setData(MaterialData data);
+ 
+     /**
+      * Sets the type of this block
+      *
+      * @param type Material to change this block to
++     * @deprecated Confusing name
+      */
++    @Deprecated
+     void setType(Material type);
+ 
+     /**
+-- 
+1.9.0
+

--- a/Bukkit/0040-Mutable-ChunkSnapshots.patch
+++ b/Bukkit/0040-Mutable-ChunkSnapshots.patch
@@ -1,0 +1,79 @@
+From 1b953d5a6c26d3eaccc47f85e1bf8cedf057aae2 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Wed, 3 Jun 2015 19:09:27 -0400
+Subject: [PATCH] Mutable ChunkSnapshots
+
+
+diff --git a/src/main/java/org/bukkit/ChunkSnapshot.java b/src/main/java/org/bukkit/ChunkSnapshot.java
+index 83fccc8..28f4442 100644
+--- a/src/main/java/org/bukkit/ChunkSnapshot.java
++++ b/src/main/java/org/bukkit/ChunkSnapshot.java
+@@ -1,6 +1,9 @@
+ package org.bukkit;
+ 
+ import org.bukkit.block.Biome;
++import org.bukkit.block.BlockState;
++import org.bukkit.material.MaterialData;
++import org.bukkit.util.Vector;
+ 
+ /**
+  * Represents a static, thread-safe snapshot of chunk of blocks.
+@@ -56,6 +59,16 @@ public interface ChunkSnapshot {
+     int getBlockData(int x, int y, int z);
+ 
+     /**
++     * Get the material of the block at the given position in the chunk
++     */
++    MaterialData getMaterialData(int x, int y, int z);
++
++    /**
++     * Get the material of the block at the given position in the chunk
++     */
++    MaterialData getMaterialData(Vector pos);
++
++    /**
+      * Get sky light level for block at corresponding coordinate in the chunk
+      *
+      * @param x 0-15
+@@ -126,4 +139,38 @@ public interface ChunkSnapshot {
+      * @return true if empty, false if not
+      */
+     boolean isSectionEmpty(int sy);
++
++    /**
++     * Set the block type at the given position in the chunk.
++     * Note that mutating the snapshot will compromise its thread safety.
++     */
++    void setBlockTypeId(int x, int y, int z, int typeId);
++
++    /**
++     * Set the block data at the given position in the chunk.
++     * Note that mutating the snapshot will compromise its thread safety.
++     */
++    void setBlockData(int x, int y, int z, int data);
++
++    /**
++     * Set the block material (type and data) at the given position in the chunk.
++     * Note that mutating the snapshot will compromise its thread safety.
++     */
++    void setMaterialData(int x, int y, int z, MaterialData material);
++
++    /**
++     * Set the block material (type and data) at the given position in the chunk.
++     * Note that mutating the snapshot will compromise its thread safety.
++     */
++    void setMaterialData(Vector pos, MaterialData material);
++
++    /**
++     * Update the material (type and data) of the given block in the snapshot to
++     * match the given state. The chunk coordinates saved in the snapshot are used
++     * to transform the given block's position into local coordinates. If the block
++     * is not inside this chunk, nothing happens.
++     *
++     * Note that mutating the snapshot will compromise its thread safety.
++     */
++    void updateBlock(BlockState state);
+ }
+-- 
+1.9.0
+

--- a/Bukkit/0041-Add-ExplosionPrimeByEntityEvent.patch
+++ b/Bukkit/0041-Add-ExplosionPrimeByEntityEvent.patch
@@ -1,0 +1,49 @@
+From 92306258d464f739ef03383a49306544f23bdde1 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Sun, 14 Jun 2015 04:13:42 -0400
+Subject: [PATCH] Add ExplosionPrimeByEntityEvent
+
+
+diff --git a/src/main/java/org/bukkit/event/entity/ExplosionPrimeByEntityEvent.java b/src/main/java/org/bukkit/event/entity/ExplosionPrimeByEntityEvent.java
+new file mode 100644
+index 0000000..6b7d13f
+--- /dev/null
++++ b/src/main/java/org/bukkit/event/entity/ExplosionPrimeByEntityEvent.java
+@@ -0,0 +1,34 @@
++package org.bukkit.event.entity;
++
++import org.bukkit.entity.Entity;
++import org.bukkit.entity.Explosive;
++
++import static com.google.common.base.Preconditions.checkNotNull;
++
++/**
++ * Called when an entity has made another entity decide to explode, specifically when:
++ *  - a player activates a TNT block or Creeper with Flint & Steel
++ *  - an entity's explosion chains to a TNT block
++ *  - a flaming arrow activates a TNT block
++ *  - an entity damages an Ender Crystal
++ */
++public class ExplosionPrimeByEntityEvent extends ExplosionPrimeEvent {
++
++    private final Entity primer;
++
++    public ExplosionPrimeByEntityEvent(Entity what, float radius, boolean fire, Entity primer) {
++        super(what, radius, fire);
++        this.primer = checkNotNull(primer);
++    }
++
++    public ExplosionPrimeByEntityEvent(Explosive explosive, Entity primer) {
++        this(explosive, explosive.getYield(), explosive.isIncendiary(), primer);
++    }
++
++    /**
++     * @return The {@link Entity} that caused this entity to become primed
++     */
++    public Entity getPrimer() {
++        return primer;
++    }
++}
+-- 
+1.9.0
+

--- a/Bukkit/0042-Retrieve-metadata-by-plugin.patch
+++ b/Bukkit/0042-Retrieve-metadata-by-plugin.patch
@@ -1,0 +1,68 @@
+From d4827f063b1949c1cc809e5f97745b2a451f3cf8 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Fri, 19 Jun 2015 14:50:13 -0400
+Subject: [PATCH] Retrieve metadata by plugin
+
+
+diff --git a/src/main/java/org/bukkit/metadata/MetadataStore.java b/src/main/java/org/bukkit/metadata/MetadataStore.java
+index 700d0bf..1be17ad 100644
+--- a/src/main/java/org/bukkit/metadata/MetadataStore.java
++++ b/src/main/java/org/bukkit/metadata/MetadataStore.java
+@@ -17,6 +17,16 @@ public interface MetadataStore<T> {
+     public void setMetadata(T subject, String metadataKey, MetadataValue newMetadataValue);
+ 
+     /**
++     * Returns the metadata value attached to an object and belonging to the given plugin.
++     *
++     * @param subject the object being interrogated.
++     * @param metadataKey the unique metadata key being sought.
++     * @param owningPlugin the plugin that owns the metadata
++     * @return a metadata value, or null if the given plugin has not set a value for the given key
++     */
++    public MetadataValue getMetadata(T subject, String metadataKey, Plugin owningPlugin);
++
++    /**
+      * Returns all metadata values attached to an object. If multiple plugins
+      * have attached metadata, each will value will be included.
+      *
+diff --git a/src/main/java/org/bukkit/metadata/MetadataStoreBase.java b/src/main/java/org/bukkit/metadata/MetadataStoreBase.java
+index 093c144..6db0616 100644
+--- a/src/main/java/org/bukkit/metadata/MetadataStoreBase.java
++++ b/src/main/java/org/bukkit/metadata/MetadataStoreBase.java
+@@ -43,6 +43,12 @@ public abstract class MetadataStoreBase<T> {
+         entry.put(owningPlugin, newMetadataValue);
+     }
+ 
++    public synchronized MetadataValue getMetadata(T subject, String metadataKey, Plugin owningPlugin) {
++        String key = disambiguate(subject, metadataKey);
++        Map<Plugin, MetadataValue> values = metadataMap.get(key);
++        return values == null ? null : values.get(owningPlugin);
++    }
++
+     /**
+      * Returns all metadata values attached to an object. If multiple
+      * have attached metadata, each will value will be included.
+diff --git a/src/main/java/org/bukkit/metadata/Metadatable.java b/src/main/java/org/bukkit/metadata/Metadatable.java
+index b47cf2b..b1df863 100644
+--- a/src/main/java/org/bukkit/metadata/Metadatable.java
++++ b/src/main/java/org/bukkit/metadata/Metadatable.java
+@@ -20,6 +20,16 @@ public interface Metadatable {
+     public void setMetadata(String metadataKey, MetadataValue newMetadataValue);
+ 
+     /**
++     * Returns a metadata value set by a specific plugin from the implementing
++     * object's metadata store.
++     *
++     * @param metadataKey the unique metadata key being sought.
++     * @param owningPlugin the plugin that owns the metadata
++     * @return A metadata value, or null if the given plugin has not set a value
++     */
++    public MetadataValue getMetadata(String metadataKey, Plugin owningPlugin);
++
++    /**
+      * Returns a list of previously set metadata values from the implementing
+      * object's metadata store.
+      *
+-- 
+1.9.0
+

--- a/Bukkit/0043-Call-onDisable-before-disabling-the-plugin.patch
+++ b/Bukkit/0043-Call-onDisable-before-disabling-the-plugin.patch
@@ -1,0 +1,61 @@
+From c77373b801a58405e7c1e7f4b19d9b46f689a895 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Sat, 20 Jun 2015 12:27:57 -0400
+Subject: [PATCH] Call onDisable before disabling the plugin
+
+
+diff --git a/src/main/java/org/bukkit/plugin/SimplePluginManager.java b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
+index 74f6d0d..dc71961 100644
+--- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
++++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
+@@ -394,6 +394,18 @@ public final class SimplePluginManager implements PluginManager {
+ 
+     public void enablePlugin(final Plugin plugin) {
+         if (!plugin.isEnabled()) {
++            boolean dependenciesEnabled = true;
++            for(String dependency : plugin.getDescription().getDepend()) {
++                if(!this.isPluginEnabled(dependency)) {
++                    dependenciesEnabled = false;
++                    plugin.getLogger().warning(
++                        "Cannot enable " + plugin.getDescription().getFullName() +
++                        " because dependency " + dependency + " is not enabled"
++                    );
++                }
++            }
++            if(!dependenciesEnabled) return;
++
+             List<Command> pluginCommands = PluginCommandYamlParser.parse(plugin);
+ 
+             if (!pluginCommands.isEmpty()) {
+diff --git a/src/main/java/org/bukkit/plugin/java/JavaPlugin.java b/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
+index bcb8a67..273d14b 100644
+--- a/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
++++ b/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
+@@ -264,13 +264,19 @@ public abstract class JavaPlugin extends PluginBase {
+      * @param enabled true if enabled, otherwise false
+      */
+     protected final void setEnabled(final boolean enabled) {
+-        if (isEnabled != enabled) {
+-            isEnabled = enabled;
+-
+-            if (isEnabled) {
++        if(!isEnabled && enabled) {
++            isEnabled = true;
++            try {
+                 onEnable();
+-            } else {
++            } catch(RuntimeException e) {
++                isEnabled = false;
++                throw e;
++            }
++        } else if(isEnabled && !enabled) {
++            try {
+                 onDisable();
++            } finally {
++                isEnabled = false;
+             }
+         }
+     }
+-- 
+1.9.0
+

--- a/Bukkit/0044-Custom-replacement-for-eaten-items.patch
+++ b/Bukkit/0044-Custom-replacement-for-eaten-items.patch
@@ -1,0 +1,44 @@
+From 7e8be05482c5eb2407bc380fd4deedc5a6418cd9 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Sun, 21 Jun 2015 15:05:21 -0400
+Subject: [PATCH] Custom replacement for eaten items
+
+
+diff --git a/src/main/java/org/bukkit/event/player/PlayerItemConsumeEvent.java b/src/main/java/org/bukkit/event/player/PlayerItemConsumeEvent.java
+index 8ab76b1..a81b642 100644
+--- a/src/main/java/org/bukkit/event/player/PlayerItemConsumeEvent.java
++++ b/src/main/java/org/bukkit/event/player/PlayerItemConsumeEvent.java
+@@ -20,6 +20,7 @@ public class PlayerItemConsumeEvent extends PlayerEvent implements Cancellable {
+     private static final HandlerList handlers = new HandlerList();
+     private boolean isCancelled = false;
+     private ItemStack item;
++    private ItemStack replacement;
+ 
+     /**
+      * @param player the player consuming
+@@ -55,6 +56,22 @@ public class PlayerItemConsumeEvent extends PlayerEvent implements Cancellable {
+         }
+     }
+ 
++    /**
++     * Return the custom item stack that will replace the consumed item, or null if no
++     * custom replacement has been set (which means the default replacement will be used).
++     */
++    public ItemStack getReplacement() {
++        return replacement;
++    }
++
++    /**
++     * Set a custom item stack to replace the consumed item. Pass null to clear any custom
++     * stack that has been set and use the default replacement.
++     */
++    public void setReplacement(ItemStack replacement) {
++        this.replacement = replacement;
++    }
++
+     public boolean isCancelled() {
+         return this.isCancelled;
+     }
+-- 
+1.9.0
+

--- a/Bukkit/0045-Override-creation-settings-of-existing-world.patch
+++ b/Bukkit/0045-Override-creation-settings-of-existing-world.patch
@@ -1,0 +1,90 @@
+From 597e7ed68339a6eaeb0cb076ab5c083ea758a9da Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Sun, 28 Jun 2015 03:37:39 -0400
+Subject: [PATCH] Override creation settings of existing world
+
+
+diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
+index ed3aa4f..192f52c 100644
+--- a/src/main/java/org/bukkit/Bukkit.java
++++ b/src/main/java/org/bukkit/Bukkit.java
+@@ -500,6 +500,14 @@ public final class Bukkit {
+         return server.getWorlds();
+     }
+ 
++    public static WorldCreator detectWorld(String name) {
++        return server.detectWorld(name);
++    }
++
++    public static World createWorld(String name) {
++        return server.createWorld(name);
++    }
++
+     /**
+      * Creates or loads a world with the given name using the specified
+      * options.
+diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
+index 8dd5c65..b74d880 100644
+--- a/src/main/java/org/bukkit/Server.java
++++ b/src/main/java/org/bukkit/Server.java
+@@ -411,6 +411,29 @@ public interface Server extends PluginMessageRecipient {
+     public List<World> getWorlds();
+ 
+     /**
++     * Check for a level.dat file belonging to a world with the given name.
++     * If found, return a {@link WorldCreator} configured to match the settings
++     * in the level.dat file. If the file is not found, return null. This works
++     * regardless of whether the world is loaded or not.
++     *
++     * The returned object will have the following fields set explicitly:
++     *  - Name {@link WorldCreator#name()}
++     *  - Type {@link WorldCreator#type()}
++     *  - Seed {@link WorldCreator#seed()}
++     *  - Structure flag {@link WorldCreator#generateStructures()}
++     *  - Generator settings {@link WorldCreator#generatorSettings()}
++     *  - Hardcore flag {@link WorldCreator#hardcore()}
++     */
++    WorldCreator detectWorld(String name);
++
++    /**
++     * Creates or loads a world with the given name. If the world is already loaded,
++     * it will just return the equivalent of getWorld(creator.name()). If the world
++     * is created, {@link #detectWorld} will be called to try and detect settings.
++     */
++    World createWorld(String name);
++
++    /**
+      * Creates or loads a world with the given name using the specified
+      * options.
+      * <p>
+diff --git a/src/main/java/org/bukkit/WorldCreator.java b/src/main/java/org/bukkit/WorldCreator.java
+index 53980fd..81c95d1 100644
+--- a/src/main/java/org/bukkit/WorldCreator.java
++++ b/src/main/java/org/bukkit/WorldCreator.java
+@@ -16,6 +16,7 @@ public class WorldCreator {
+     private WorldType type = WorldType.NORMAL;
+     private boolean generateStructures = true;
+     private String generatorSettings = "";
++    private boolean hardcore;
+ 
+     /**
+      * Creates an empty WorldCreationOptions for the given world name
+@@ -249,6 +250,15 @@ public class WorldCreator {
+         return generateStructures;
+     }
+ 
++    public WorldCreator hardcore(boolean hardcore) {
++        this.hardcore = hardcore;
++        return this;
++    }
++
++    public boolean hardcore() {
++        return hardcore;
++    }
++
+     /**
+      * Creates a world with the specified options.
+      * <p>
+-- 
+1.9.0
+

--- a/Bukkit/0046-Potion-effect-events.patch
+++ b/Bukkit/0046-Potion-effect-events.patch
@@ -1,0 +1,198 @@
+From 6900d7952c918ed2b692078f7f80be7ccee311f9 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Mon, 29 Jun 2015 04:38:33 -0400
+Subject: [PATCH] Potion effect events
+
+
+diff --git a/src/main/java/org/bukkit/event/entity/PotionEffectAddEvent.java b/src/main/java/org/bukkit/event/entity/PotionEffectAddEvent.java
+new file mode 100644
+index 0000000..a0e0634
+--- /dev/null
++++ b/src/main/java/org/bukkit/event/entity/PotionEffectAddEvent.java
+@@ -0,0 +1,32 @@
++package org.bukkit.event.entity;
++
++import org.bukkit.entity.LivingEntity;
++import org.bukkit.event.Cancellable;
++import org.bukkit.event.HandlerList;
++import org.bukkit.potion.PotionEffect;
++
++/**
++ * Called when a potion effect is applied to an entity, or an existing effect is extended or upgraded
++ */
++public class PotionEffectAddEvent extends PotionEffectEvent implements Cancellable {
++
++    private boolean cancelled;
++
++    public PotionEffectAddEvent(LivingEntity entity, PotionEffect effect) {
++        super(entity, effect);
++    }
++
++    @Override
++    public boolean isCancelled() {
++        return cancelled;
++    }
++
++    @Override
++    public void setCancelled(boolean cancel) {
++        this.cancelled = cancel;
++    }
++
++    private static final HandlerList handlers = new HandlerList();
++    @Override public HandlerList getHandlers() { return handlers; }
++    public static HandlerList getHandlerList() { return handlers; }
++}
+diff --git a/src/main/java/org/bukkit/event/entity/PotionEffectEvent.java b/src/main/java/org/bukkit/event/entity/PotionEffectEvent.java
+new file mode 100644
+index 0000000..b0571a6
+--- /dev/null
++++ b/src/main/java/org/bukkit/event/entity/PotionEffectEvent.java
+@@ -0,0 +1,23 @@
++package org.bukkit.event.entity;
++
++import org.bukkit.entity.LivingEntity;
++import org.bukkit.potion.PotionEffect;
++
++public abstract class PotionEffectEvent extends EntityEvent {
++
++    private final PotionEffect effect;
++
++    public PotionEffectEvent(LivingEntity what, PotionEffect effect) {
++        super(what);
++        this.effect = effect;
++    }
++
++    @Override
++    public LivingEntity getEntity() {
++        return (LivingEntity) super.getEntity();
++    }
++
++    public PotionEffect getEffect() {
++        return effect;
++    }
++}
+diff --git a/src/main/java/org/bukkit/event/entity/PotionEffectExpireEvent.java b/src/main/java/org/bukkit/event/entity/PotionEffectExpireEvent.java
+new file mode 100644
+index 0000000..0fc2840
+--- /dev/null
++++ b/src/main/java/org/bukkit/event/entity/PotionEffectExpireEvent.java
+@@ -0,0 +1,45 @@
++package org.bukkit.event.entity;
++
++import org.bukkit.entity.LivingEntity;
++import org.bukkit.potion.PotionEffect;
++
++/**
++ * Called when a potion effect on an entity runs out. Cancelling the event extends
++ * the effect with a practically infinite duration. The new duration can also be set
++ * explicitly by calling {@link #setDuration}.
++ *
++ * Handlers of {@link PotionEffectRemoveEvent} will also receive this event.
++ */
++public class PotionEffectExpireEvent extends PotionEffectRemoveEvent {
++
++    private int duration = 0;
++
++    public PotionEffectExpireEvent(LivingEntity entity, PotionEffect effect) {
++        super(entity, effect);
++    }
++
++    /**
++     * Get the new duration for the potion effect. This is initially 0.
++     */
++    public int getDuration() {
++        return duration;
++    }
++
++    /**
++     * Set a new duration for the potion effect. Passing 0 to this method un-cancels
++     * the event, and passing anything above 0 cancels it.
++     */
++    public void setDuration(int duration) {
++        this.duration = Math.max(0, duration);
++    }
++
++    @Override
++    public boolean isCancelled() {
++        return duration > 0;
++    }
++
++    @Override
++    public void setCancelled(boolean cancel) {
++        this.duration = cancel ? Integer.MAX_VALUE : 0;
++    }
++}
+diff --git a/src/main/java/org/bukkit/event/entity/PotionEffectExtendEvent.java b/src/main/java/org/bukkit/event/entity/PotionEffectExtendEvent.java
+new file mode 100644
+index 0000000..02164cf
+--- /dev/null
++++ b/src/main/java/org/bukkit/event/entity/PotionEffectExtendEvent.java
+@@ -0,0 +1,26 @@
++package org.bukkit.event.entity;
++
++import org.bukkit.entity.LivingEntity;
++import org.bukkit.potion.PotionEffect;
++
++/**
++ * Called when an entity's active potion effect is extended or upgraded.
++ *
++ * Handlers of {@link PotionEffectAddEvent} will also receive this event.
++ */
++public class PotionEffectExtendEvent extends PotionEffectAddEvent {
++
++    private final PotionEffect oldEffect;
++
++    public PotionEffectExtendEvent(LivingEntity entity, PotionEffect effect, PotionEffect oldEffect) {
++        super(entity, effect);
++        this.oldEffect = oldEffect;
++    }
++
++    /**
++     * Get the state of the potion effect prior to the change
++     */
++    public PotionEffect getOldEffect() {
++        return oldEffect;
++    }
++}
+diff --git a/src/main/java/org/bukkit/event/entity/PotionEffectRemoveEvent.java b/src/main/java/org/bukkit/event/entity/PotionEffectRemoveEvent.java
+new file mode 100644
+index 0000000..c95af16
+--- /dev/null
++++ b/src/main/java/org/bukkit/event/entity/PotionEffectRemoveEvent.java
+@@ -0,0 +1,33 @@
++package org.bukkit.event.entity;
++
++import org.bukkit.entity.LivingEntity;
++import org.bukkit.event.Cancellable;
++import org.bukkit.event.HandlerList;
++import org.bukkit.potion.PotionEffect;
++
++/**
++ * Called when a potion effect is removed from an entity for whatever reason
++ */
++public class PotionEffectRemoveEvent extends PotionEffectEvent implements Cancellable {
++
++    private boolean cancelled;
++
++    public PotionEffectRemoveEvent(LivingEntity entity, PotionEffect effect) {
++        super(entity, effect);
++    }
++
++    @Override
++    public boolean isCancelled() {
++        return cancelled;
++    }
++
++    @Override
++    public void setCancelled(boolean cancel) {
++        this.cancelled = cancel;
++    }
++
++    private static final HandlerList handlers = new HandlerList();
++    @Override public HandlerList getHandlers() { return handlers; }
++    public static HandlerList getHandlerList() { return handlers; }
++
++}
+-- 
+1.9.0
+

--- a/Bukkit/0047-Physical-interface.patch
+++ b/Bukkit/0047-Physical-interface.patch
@@ -1,0 +1,559 @@
+From ca73880202febd3fc0fde130c3609597ff48f7ae Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Fri, 3 Jul 2015 01:08:40 -0400
+Subject: [PATCH] Physical interface
+
+
+diff --git a/src/main/java/org/bukkit/Chunk.java b/src/main/java/org/bukkit/Chunk.java
+index d5862a1..7ee47f4 100644
+--- a/src/main/java/org/bukkit/Chunk.java
++++ b/src/main/java/org/bukkit/Chunk.java
+@@ -10,7 +10,7 @@ import java.util.Set;
+ /**
+  * Represents a chunk of blocks
+  */
+-public interface Chunk {
++public interface Chunk extends Physical {
+ 
+     /**
+      * Gets the X-coordinate of this chunk
+diff --git a/src/main/java/org/bukkit/Location.java b/src/main/java/org/bukkit/Location.java
+index e7af316..cd7ac2f 100644
+--- a/src/main/java/org/bukkit/Location.java
++++ b/src/main/java/org/bukkit/Location.java
+@@ -12,7 +12,7 @@ import org.bukkit.util.Vector;
+ /**
+  * Represents a 3-dimensional position in a world
+  */
+-public class Location implements Cloneable, ConfigurationSerializable {
++public class Location implements Cloneable, ConfigurationSerializable, Physical {
+     private World world;
+     private double x;
+     private double y;
+diff --git a/src/main/java/org/bukkit/Physical.java b/src/main/java/org/bukkit/Physical.java
+new file mode 100644
+index 0000000..24a58ff
+--- /dev/null
++++ b/src/main/java/org/bukkit/Physical.java
+@@ -0,0 +1,14 @@
++package org.bukkit;
++
++/**
++ * Common interface for any type of object that can be associated with a specific world.
++ * This interface makes no guarantees about the mutability or nullability of the world.
++ */
++public interface Physical {
++
++    /**
++     * Return the world this object is associated with. May return null if the world
++     * is not available (i.e. not loaded), or this object does not have a world.
++     */
++    World getWorld();
++}
+diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
+index 615e29b..0cb6b2d 100644
+--- a/src/main/java/org/bukkit/World.java
++++ b/src/main/java/org/bukkit/World.java
+@@ -13,7 +13,6 @@ import org.bukkit.block.Block;
+ import org.bukkit.entity.*;
+ import org.bukkit.generator.BlockPopulator;
+ import org.bukkit.inventory.ItemStack;
+-import org.bukkit.material.MaterialData;
+ import org.bukkit.metadata.Metadatable;
+ import org.bukkit.plugin.messaging.PluginMessageRecipient;
+ import org.bukkit.util.RayBlockIntersection;
+@@ -22,7 +21,7 @@ import org.bukkit.util.Vector;
+ /**
+  * Represents a world, which may contain entities, chunks and blocks
+  */
+-public interface World extends PluginMessageRecipient, Metadatable {
++public interface World extends PluginMessageRecipient, Metadatable, Physical {
+ 
+     /**
+      * Gets the {@link Block} at the given coordinates
+diff --git a/src/main/java/org/bukkit/block/Block.java b/src/main/java/org/bukkit/block/Block.java
+index fe32537..158bd8f 100644
+--- a/src/main/java/org/bukkit/block/Block.java
++++ b/src/main/java/org/bukkit/block/Block.java
+@@ -6,6 +6,7 @@ import org.bukkit.Chunk;
+ import org.bukkit.Material;
+ import org.bukkit.World;
+ import org.bukkit.Location;
++import org.bukkit.Physical;
+ import org.bukkit.inventory.ItemStack;
+ import org.bukkit.metadata.Metadatable;
+ import org.bukkit.util.RayBlockIntersection;
+@@ -17,7 +18,7 @@ import org.bukkit.util.Vector;
+  * concurrently to your own handling of it; use block.getState() to get a
+  * snapshot state of a block which will not be modified.
+  */
+-public interface Block extends Metadatable {
++public interface Block extends Metadatable, Physical {
+ 
+     /**
+      * Gets the metadata for this block
+diff --git a/src/main/java/org/bukkit/block/BlockState.java b/src/main/java/org/bukkit/block/BlockState.java
+index 911a4d1..7899117 100644
+--- a/src/main/java/org/bukkit/block/BlockState.java
++++ b/src/main/java/org/bukkit/block/BlockState.java
+@@ -4,6 +4,7 @@ import org.bukkit.Chunk;
+ import org.bukkit.Location;
+ import org.bukkit.Material;
+ import org.bukkit.World;
++import org.bukkit.Physical;
+ import org.bukkit.material.MaterialData;
+ import org.bukkit.metadata.Metadatable;
+ 
+@@ -16,7 +17,7 @@ import org.bukkit.metadata.Metadatable;
+  * change the state of the block and you will not know, or they may change the
+  * block to another type entirely, causing your BlockState to become invalid.
+  */
+-public interface BlockState extends Metadatable {
++public interface BlockState extends Metadatable, Physical {
+ 
+     /**
+      * Gets the block represented by this BlockState
+diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
+index 759e3f0..100de93 100644
+--- a/src/main/java/org/bukkit/entity/Entity.java
++++ b/src/main/java/org/bukkit/entity/Entity.java
+@@ -5,6 +5,7 @@ import org.bukkit.EntityEffect;
+ import org.bukkit.Nameable;
+ import org.bukkit.Server;
+ import org.bukkit.World;
++import org.bukkit.Physical;
+ import org.bukkit.event.entity.EntityDamageEvent;
+ import org.bukkit.metadata.Metadatable;
+ import org.bukkit.util.Vector;
+@@ -18,7 +19,7 @@ import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
+ /**
+  * Represents a base entity in the world
+  */
+-public interface Entity extends Metadatable, CommandSender, Nameable {
++public interface Entity extends Metadatable, CommandSender, Nameable, Physical {
+ 
+     /**
+      * Gets the entity's current position
+diff --git a/src/main/java/org/bukkit/event/block/BlockEvent.java b/src/main/java/org/bukkit/event/block/BlockEvent.java
+index 2405205..4fdf37e 100644
+--- a/src/main/java/org/bukkit/event/block/BlockEvent.java
++++ b/src/main/java/org/bukkit/event/block/BlockEvent.java
+@@ -1,12 +1,14 @@
+ package org.bukkit.event.block;
+ 
++import org.bukkit.World;
++import org.bukkit.Physical;
+ import org.bukkit.block.Block;
+ import org.bukkit.event.Event;
+ 
+ /**
+  * Represents a block related event.
+  */
+-public abstract class BlockEvent extends Event {
++public abstract class BlockEvent extends Event implements Physical {
+     protected Block block;
+ 
+     public BlockEvent(final Block theBlock) {
+@@ -21,4 +23,9 @@ public abstract class BlockEvent extends Event {
+     public final Block getBlock() {
+         return block;
+     }
++
++    @Override
++    public World getWorld() {
++        return getBlock().getWorld();
++    }
+ }
+diff --git a/src/main/java/org/bukkit/event/entity/EntityEvent.java b/src/main/java/org/bukkit/event/entity/EntityEvent.java
+index c9a4ab3..0cebd9f 100644
+--- a/src/main/java/org/bukkit/event/entity/EntityEvent.java
++++ b/src/main/java/org/bukkit/event/entity/EntityEvent.java
+@@ -1,5 +1,7 @@
+ package org.bukkit.event.entity;
+ 
++import org.bukkit.World;
++import org.bukkit.Physical;
+ import org.bukkit.entity.Entity;
+ import org.bukkit.entity.EntityType;
+ import org.bukkit.event.Event;
+@@ -7,7 +9,7 @@ import org.bukkit.event.Event;
+ /**
+  * Represents an Entity-related event
+  */
+-public abstract class EntityEvent extends Event {
++public abstract class EntityEvent extends Event implements Physical {
+     protected Entity entity;
+ 
+     public EntityEvent(final Entity what) {
+@@ -31,4 +33,9 @@ public abstract class EntityEvent extends Event {
+     public EntityType getEntityType() {
+         return entity.getType();
+     }
++
++    @Override
++    public World getWorld() {
++        return getEntity().getWorld();
++    }
+ }
+diff --git a/src/main/java/org/bukkit/event/entity/PlayerLeashEntityEvent.java b/src/main/java/org/bukkit/event/entity/PlayerLeashEntityEvent.java
+index 74d458a..b4d0f3c 100644
+--- a/src/main/java/org/bukkit/event/entity/PlayerLeashEntityEvent.java
++++ b/src/main/java/org/bukkit/event/entity/PlayerLeashEntityEvent.java
+@@ -1,5 +1,7 @@
+ package org.bukkit.event.entity;
+ 
++import org.bukkit.World;
++import org.bukkit.Physical;
+ import org.bukkit.entity.Entity;
+ import org.bukkit.entity.Player;
+ import org.bukkit.event.Cancellable;
+@@ -9,7 +11,7 @@ import org.bukkit.event.HandlerList;
+ /**
+  * Called immediately prior to a creature being leashed by a player.
+  */
+-public class PlayerLeashEntityEvent extends Event implements Cancellable {
++public class PlayerLeashEntityEvent extends Event implements Cancellable, Physical {
+     private static final HandlerList handlers = new HandlerList();
+     private final Entity leashHolder;
+     private final Entity entity;
+@@ -50,6 +52,11 @@ public class PlayerLeashEntityEvent extends Event implements Cancellable {
+     }
+ 
+     @Override
++    public World getWorld() {
++        return getEntity().getWorld();
++    }
++
++    @Override
+     public HandlerList getHandlers() {
+         return handlers;
+     }
+diff --git a/src/main/java/org/bukkit/event/hanging/HangingEvent.java b/src/main/java/org/bukkit/event/hanging/HangingEvent.java
+index b370afe..a680c80 100644
+--- a/src/main/java/org/bukkit/event/hanging/HangingEvent.java
++++ b/src/main/java/org/bukkit/event/hanging/HangingEvent.java
+@@ -1,15 +1,16 @@
+ package org.bukkit.event.hanging;
+ 
+ import org.bukkit.entity.Hanging;
+-import org.bukkit.event.Event;
++import org.bukkit.event.entity.EntityEvent;
+ 
+ /**
+  * Represents a hanging entity-related event.
+  */
+-public abstract class HangingEvent extends Event {
++public abstract class HangingEvent extends EntityEvent {
+     protected Hanging hanging;
+ 
+     protected HangingEvent(final Hanging painting) {
++        super(painting);
+         this.hanging = painting;
+     }
+ 
+diff --git a/src/main/java/org/bukkit/event/inventory/InventoryEvent.java b/src/main/java/org/bukkit/event/inventory/InventoryEvent.java
+index 973c392..fd0fc2f 100644
+--- a/src/main/java/org/bukkit/event/inventory/InventoryEvent.java
++++ b/src/main/java/org/bukkit/event/inventory/InventoryEvent.java
+@@ -3,6 +3,8 @@ package org.bukkit.event.inventory;
+ 
+ import java.util.List;
+ 
++import org.bukkit.World;
++import org.bukkit.Physical;
+ import org.bukkit.event.HandlerList;
+ import org.bukkit.entity.HumanEntity;
+ import org.bukkit.event.Event;
+@@ -12,7 +14,7 @@ import org.bukkit.inventory.InventoryView;
+ /**
+  * Represents a player related inventory event
+  */
+-public class InventoryEvent extends Event {
++public class InventoryEvent extends Event implements Physical {
+     private static final HandlerList handlers = new HandlerList();
+     protected InventoryView transaction;
+ 
+@@ -49,6 +51,11 @@ public class InventoryEvent extends Event {
+     }
+ 
+     @Override
++    public World getWorld() {
++        return getInventory().getWorld();
++    }
++
++    @Override
+     public HandlerList getHandlers() {
+         return handlers;
+     }
+diff --git a/src/main/java/org/bukkit/event/inventory/InventoryMoveItemEvent.java b/src/main/java/org/bukkit/event/inventory/InventoryMoveItemEvent.java
+index 06ec99a..05ef7ec 100644
+--- a/src/main/java/org/bukkit/event/inventory/InventoryMoveItemEvent.java
++++ b/src/main/java/org/bukkit/event/inventory/InventoryMoveItemEvent.java
+@@ -1,6 +1,8 @@
+ package org.bukkit.event.inventory;
+ 
+ import org.apache.commons.lang.Validate;
++import org.bukkit.World;
++import org.bukkit.Physical;
+ import org.bukkit.event.Cancellable;
+ import org.bukkit.event.Event;
+ import org.bukkit.event.HandlerList;
+@@ -23,7 +25,7 @@ import org.bukkit.inventory.ItemStack;
+  * has not been modified, the source inventory slot will be restored to its
+  * former state. Otherwise any additional items will be discarded.
+  */
+-public class InventoryMoveItemEvent extends Event implements Cancellable {
++public class InventoryMoveItemEvent extends Event implements Cancellable, Physical {
+     private static final HandlerList handlers = new HandlerList();
+     private boolean cancelled;
+     private final Inventory sourceInventory;
+@@ -89,6 +91,11 @@ public class InventoryMoveItemEvent extends Event implements Cancellable {
+         return didSourceInitiate ? sourceInventory : destinationInventory;
+     }
+ 
++    @Override
++    public World getWorld() {
++        return getInitiator().getWorld();
++    }
++
+     public boolean isCancelled() {
+         return cancelled;
+     }
+diff --git a/src/main/java/org/bukkit/event/inventory/InventoryPickupItemEvent.java b/src/main/java/org/bukkit/event/inventory/InventoryPickupItemEvent.java
+index af6ad5b..9958e63 100644
+--- a/src/main/java/org/bukkit/event/inventory/InventoryPickupItemEvent.java
++++ b/src/main/java/org/bukkit/event/inventory/InventoryPickupItemEvent.java
+@@ -1,5 +1,7 @@
+ package org.bukkit.event.inventory;
+ 
++import org.bukkit.World;
++import org.bukkit.Physical;
+ import org.bukkit.entity.Item;
+ import org.bukkit.event.Cancellable;
+ import org.bukkit.event.Event;
+@@ -9,7 +11,7 @@ import org.bukkit.inventory.Inventory;
+ /**
+  * Called when a hopper or hopper minecart picks up a dropped item.
+  */
+-public class InventoryPickupItemEvent extends Event implements Cancellable {
++public class InventoryPickupItemEvent extends Event implements Cancellable, Physical {
+     private static final HandlerList handlers = new HandlerList();
+     private boolean cancelled;
+     private final Inventory inventory;
+@@ -39,6 +41,11 @@ public class InventoryPickupItemEvent extends Event implements Cancellable {
+         return item;
+     }
+ 
++    @Override
++    public World getWorld() {
++        return getInventory().getHolder().getWorld();
++    }
++
+     public boolean isCancelled() {
+         return cancelled;
+     }
+diff --git a/src/main/java/org/bukkit/event/player/PlayerEvent.java b/src/main/java/org/bukkit/event/player/PlayerEvent.java
+index 0d4833f..8e0ddfc 100644
+--- a/src/main/java/org/bukkit/event/player/PlayerEvent.java
++++ b/src/main/java/org/bukkit/event/player/PlayerEvent.java
+@@ -1,12 +1,14 @@
+ package org.bukkit.event.player;
+ 
++import org.bukkit.World;
++import org.bukkit.Physical;
+ import org.bukkit.entity.Player;
+ import org.bukkit.event.Event;
+ 
+ /**
+  * Represents a player related event
+  */
+-public abstract class PlayerEvent extends Event {
++public abstract class PlayerEvent extends Event implements Physical {
+     protected Player player;
+ 
+     public PlayerEvent(final Player who) {
+@@ -27,4 +29,9 @@ public abstract class PlayerEvent extends Event {
+     public final Player getPlayer() {
+         return player;
+     }
++
++    @Override
++    public World getWorld() {
++        return getPlayer().getWorld();
++    }
+ }
+diff --git a/src/main/java/org/bukkit/event/server/MapInitializeEvent.java b/src/main/java/org/bukkit/event/server/MapInitializeEvent.java
+index 8834489..f0e1672 100644
+--- a/src/main/java/org/bukkit/event/server/MapInitializeEvent.java
++++ b/src/main/java/org/bukkit/event/server/MapInitializeEvent.java
+@@ -1,12 +1,14 @@
+ package org.bukkit.event.server;
+ 
++import org.bukkit.World;
++import org.bukkit.Physical;
+ import org.bukkit.event.HandlerList;
+ import org.bukkit.map.MapView;
+ 
+ /**
+  * Called when a map is initialized.
+  */
+-public class MapInitializeEvent extends ServerEvent {
++public class MapInitializeEvent extends ServerEvent implements Physical {
+     private static final HandlerList handlers = new HandlerList();
+     private final MapView mapView;
+ 
+@@ -24,6 +26,11 @@ public class MapInitializeEvent extends ServerEvent {
+     }
+ 
+     @Override
++    public World getWorld() {
++        return getMap().getWorld();
++    }
++
++    @Override
+     public HandlerList getHandlers() {
+         return handlers;
+     }
+diff --git a/src/main/java/org/bukkit/event/vehicle/VehicleEvent.java b/src/main/java/org/bukkit/event/vehicle/VehicleEvent.java
+index b8255c0..3a00b5b 100644
+--- a/src/main/java/org/bukkit/event/vehicle/VehicleEvent.java
++++ b/src/main/java/org/bukkit/event/vehicle/VehicleEvent.java
+@@ -1,12 +1,14 @@
+ package org.bukkit.event.vehicle;
+ 
++import org.bukkit.World;
++import org.bukkit.Physical;
+ import org.bukkit.entity.Vehicle;
+ import org.bukkit.event.Event;
+ 
+ /**
+  * Represents a vehicle-related event.
+  */
+-public abstract class VehicleEvent extends Event {
++public abstract class VehicleEvent extends Event implements Physical {
+     protected Vehicle vehicle;
+ 
+     public VehicleEvent(final Vehicle vehicle) {
+@@ -21,4 +23,9 @@ public abstract class VehicleEvent extends Event {
+     public final Vehicle getVehicle() {
+         return vehicle;
+     }
++
++    @Override
++    public World getWorld() {
++        return getVehicle().getWorld();
++    }
+ }
+diff --git a/src/main/java/org/bukkit/event/weather/WeatherEvent.java b/src/main/java/org/bukkit/event/weather/WeatherEvent.java
+index 0cae9bc..2f41ab4 100644
+--- a/src/main/java/org/bukkit/event/weather/WeatherEvent.java
++++ b/src/main/java/org/bukkit/event/weather/WeatherEvent.java
+@@ -1,12 +1,13 @@
+ package org.bukkit.event.weather;
+ 
+ import org.bukkit.World;
++import org.bukkit.Physical;
+ import org.bukkit.event.Event;
+ 
+ /**
+  * Represents a Weather-related event
+  */
+-public abstract class WeatherEvent extends Event {
++public abstract class WeatherEvent extends Event implements Physical {
+     protected World world;
+ 
+     public WeatherEvent(final World where) {
+diff --git a/src/main/java/org/bukkit/event/world/WorldEvent.java b/src/main/java/org/bukkit/event/world/WorldEvent.java
+index bd89b81..10845d1 100644
+--- a/src/main/java/org/bukkit/event/world/WorldEvent.java
++++ b/src/main/java/org/bukkit/event/world/WorldEvent.java
+@@ -1,12 +1,13 @@
+ package org.bukkit.event.world;
+ 
+ import org.bukkit.World;
++import org.bukkit.Physical;
+ import org.bukkit.event.Event;
+ 
+ /**
+  * Represents events within a world
+  */
+-public abstract class WorldEvent extends Event {
++public abstract class WorldEvent extends Event implements Physical {
+     private final World world;
+ 
+     public WorldEvent(final World world) {
+diff --git a/src/main/java/org/bukkit/inventory/Inventory.java b/src/main/java/org/bukkit/inventory/Inventory.java
+index 3275e17..bac683b 100644
+--- a/src/main/java/org/bukkit/inventory/Inventory.java
++++ b/src/main/java/org/bukkit/inventory/Inventory.java
+@@ -6,6 +6,7 @@ import java.util.ListIterator;
+ 
+ import org.bukkit.Location;
+ import org.bukkit.Material;
++import org.bukkit.Physical;
+ import org.bukkit.entity.HumanEntity;
+ import org.bukkit.event.inventory.InventoryType;
+ 
+@@ -13,7 +14,7 @@ import org.bukkit.event.inventory.InventoryType;
+  * Interface to the various inventories. Behavior relating to {@link
+  * Material#AIR} is unspecified.
+  */
+-public interface Inventory extends Iterable<ItemStack> {
++public interface Inventory extends Iterable<ItemStack>, Physical {
+ 
+     /**
+      * Returns the size of the inventory
+diff --git a/src/main/java/org/bukkit/inventory/InventoryHolder.java b/src/main/java/org/bukkit/inventory/InventoryHolder.java
+index 9c06a3d..6e128ba 100644
+--- a/src/main/java/org/bukkit/inventory/InventoryHolder.java
++++ b/src/main/java/org/bukkit/inventory/InventoryHolder.java
+@@ -1,6 +1,8 @@
+ package org.bukkit.inventory;
+ 
+-public interface InventoryHolder {
++import org.bukkit.Physical;
++
++public interface InventoryHolder extends Physical {
+ 
+     /**
+      * Get the object's inventory.
+diff --git a/src/main/java/org/bukkit/map/MapView.java b/src/main/java/org/bukkit/map/MapView.java
+index 18a9936..c1bbd57 100644
+--- a/src/main/java/org/bukkit/map/MapView.java
++++ b/src/main/java/org/bukkit/map/MapView.java
+@@ -2,11 +2,12 @@ package org.bukkit.map;
+ 
+ import java.util.List;
+ import org.bukkit.World;
++import org.bukkit.Physical;
+ 
+ /**
+  * Represents a map item.
+  */
+-public interface MapView {
++public interface MapView extends Physical {
+ 
+     /**
+      * An enum representing all possible scales a map can be set to.
+diff --git a/src/main/java/org/bukkit/projectiles/ProjectileSource.java b/src/main/java/org/bukkit/projectiles/ProjectileSource.java
+index cf90946..bd2d3a1 100644
+--- a/src/main/java/org/bukkit/projectiles/ProjectileSource.java
++++ b/src/main/java/org/bukkit/projectiles/ProjectileSource.java
+@@ -1,12 +1,13 @@
+ package org.bukkit.projectiles;
+ 
++import org.bukkit.Physical;
+ import org.bukkit.entity.Projectile;
+ import org.bukkit.util.Vector;
+ 
+ /**
+  * Represents a valid source of a projectile.
+  */
+-public interface ProjectileSource {
++public interface ProjectileSource extends Physical {
+ 
+     /**
+      * Launches a {@link Projectile} from the ProjectileSource.
+-- 
+1.9.0
+

--- a/Bukkit/0048-Action-event-interfaces.patch
+++ b/Bukkit/0048-Action-event-interfaces.patch
@@ -1,0 +1,1558 @@
+From 0d2f7d095b4affd8141441c54067ed3b9eb967e6 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Fri, 3 Jul 2015 03:39:45 -0400
+Subject: [PATCH] Action event interfaces
+
+
+diff --git a/src/main/java/org/bukkit/event/EntityAction.java b/src/main/java/org/bukkit/event/EntityAction.java
+new file mode 100644
+index 0000000..26870fc
+--- /dev/null
++++ b/src/main/java/org/bukkit/event/EntityAction.java
+@@ -0,0 +1,28 @@
++package org.bukkit.event;
++
++import org.bukkit.entity.Entity;
++
++/**
++ * Implemented by {@link Event}s which can be caused by an {@link Entity}.
++ *
++ * There is no formal definition of "caused" in this case, only an intuitive one.
++ * Events that involve an entity doing something to another entity, or some other
++ * object, will typically implement this interface. Events involving only a single
++ * entity may or may not implement it, depending on whether the event feels like
++ * an "action" by the entity.
++ *
++ * Examples of the types of events that DO implement this interface include:
++ * movements, attacks, item pickup/drop, block place/break, "using" items/entities/blocks,
++ * inventory actions, and collisions (with the obstructing entity as the actor).
++ *
++ * Examples of event types that DO NOT implement this interface include:
++ * spawning, despawning, environmental damage/death, natural depletion/recovery of vitals,
++ * and events with no direct in-game effect, such as chatting and running commands.
++ */
++public interface EntityAction {
++    /**
++     * @return the entity that performed this action, or null if the event was not caused
++     *         by an entity, or the causing entity is unavailable for some reason.
++     */
++    Entity getActor();
++}
+diff --git a/src/main/java/org/bukkit/event/PlayerAction.java b/src/main/java/org/bukkit/event/PlayerAction.java
+new file mode 100644
+index 0000000..5cbbf3d
+--- /dev/null
++++ b/src/main/java/org/bukkit/event/PlayerAction.java
+@@ -0,0 +1,14 @@
++package org.bukkit.event;
++
++import org.bukkit.entity.Player;
++
++/**
++ * Implemented by {@link Event}s which may represent the action of a {@link Player}
++ */
++public interface PlayerAction extends EntityAction {
++    /**
++     * @return the player that performed this action, or null if the event was not caused
++     *         by a player, or the causing player is unavailable for some reason.
++     */
++    Player getActor();
++}
+diff --git a/src/main/java/org/bukkit/event/block/BlockBreakEvent.java b/src/main/java/org/bukkit/event/block/BlockBreakEvent.java
+index a011f61..6175915 100644
+--- a/src/main/java/org/bukkit/event/block/BlockBreakEvent.java
++++ b/src/main/java/org/bukkit/event/block/BlockBreakEvent.java
+@@ -4,6 +4,7 @@ import org.bukkit.block.Block;
+ import org.bukkit.entity.Player;
+ import org.bukkit.event.Cancellable;
+ import org.bukkit.event.HandlerList;
++import org.bukkit.event.PlayerAction;
+ 
+ /**
+  * Called when a block is broken by a player.
+@@ -26,7 +27,7 @@ import org.bukkit.event.HandlerList;
+  * If a Block Break event is cancelled, the block will not break and
+  * experience will not drop.
+  */
+-public class BlockBreakEvent extends BlockExpEvent implements Cancellable {
++public class BlockBreakEvent extends BlockExpEvent implements Cancellable, PlayerAction {
+     private final Player player;
+     private boolean cancel;
+ 
+@@ -45,6 +46,11 @@ public class BlockBreakEvent extends BlockExpEvent implements Cancellable {
+         return player;
+     }
+ 
++    @Override
++    public Player getActor() {
++        return getPlayer();
++    }
++
+     public boolean isCancelled() {
+         return cancel;
+     }
+diff --git a/src/main/java/org/bukkit/event/block/BlockDamageEvent.java b/src/main/java/org/bukkit/event/block/BlockDamageEvent.java
+index d80e00e..77f36df 100644
+--- a/src/main/java/org/bukkit/event/block/BlockDamageEvent.java
++++ b/src/main/java/org/bukkit/event/block/BlockDamageEvent.java
+@@ -4,6 +4,7 @@ import org.bukkit.block.Block;
+ import org.bukkit.entity.Player;
+ import org.bukkit.event.Cancellable;
+ import org.bukkit.event.HandlerList;
++import org.bukkit.event.PlayerAction;
+ import org.bukkit.inventory.ItemStack;
+ 
+ /**
+@@ -11,7 +12,7 @@ import org.bukkit.inventory.ItemStack;
+  * <p>
+  * If a Block Damage event is cancelled, the block will not be damaged.
+  */
+-public class BlockDamageEvent extends BlockEvent implements Cancellable {
++public class BlockDamageEvent extends BlockEvent implements Cancellable, PlayerAction {
+     private static final HandlerList handlers = new HandlerList();
+     private final Player player;
+     private boolean instaBreak;
+@@ -35,6 +36,11 @@ public class BlockDamageEvent extends BlockEvent implements Cancellable {
+         return player;
+     }
+ 
++    @Override
++    public Player getActor() {
++        return getPlayer();
++    }
++
+     /**
+      * Gets if the block is set to instantly break when damaged by the player.
+      *
+diff --git a/src/main/java/org/bukkit/event/block/BlockIgniteEvent.java b/src/main/java/org/bukkit/event/block/BlockIgniteEvent.java
+index 3c85866..1518281 100644
+--- a/src/main/java/org/bukkit/event/block/BlockIgniteEvent.java
++++ b/src/main/java/org/bukkit/event/block/BlockIgniteEvent.java
+@@ -4,6 +4,7 @@ import org.bukkit.block.Block;
+ import org.bukkit.entity.Entity;
+ import org.bukkit.entity.Player;
+ import org.bukkit.event.Cancellable;
++import org.bukkit.event.EntityAction;
+ import org.bukkit.event.HandlerList;
+ 
+ /**
+@@ -12,7 +13,7 @@ import org.bukkit.event.HandlerList;
+  * <p>
+  * If a Block Ignite event is cancelled, the block will not be ignited.
+  */
+-public class BlockIgniteEvent extends BlockEvent implements Cancellable {
++public class BlockIgniteEvent extends BlockEvent implements Cancellable, EntityAction {
+     private static final HandlerList handlers = new HandlerList();
+     private final IgniteCause cause;
+     private final Entity ignitingEntity;
+@@ -65,6 +66,11 @@ public class BlockIgniteEvent extends BlockEvent implements Cancellable {
+         return null;
+     }
+ 
++    @Override
++    public Entity getActor() {
++        return getIgnitingEntity();
++    }
++
+     /**
+      * Gets the entity who ignited this block
+      *
+diff --git a/src/main/java/org/bukkit/event/block/BlockPlaceEvent.java b/src/main/java/org/bukkit/event/block/BlockPlaceEvent.java
+index 0ee9e46..e83cd5e 100644
+--- a/src/main/java/org/bukkit/event/block/BlockPlaceEvent.java
++++ b/src/main/java/org/bukkit/event/block/BlockPlaceEvent.java
+@@ -5,6 +5,7 @@ import org.bukkit.block.BlockState;
+ import org.bukkit.entity.Player;
+ import org.bukkit.event.Cancellable;
+ import org.bukkit.event.HandlerList;
++import org.bukkit.event.PlayerAction;
+ import org.bukkit.inventory.EquipmentSlot;
+ import org.bukkit.inventory.ItemStack;
+ 
+@@ -13,7 +14,7 @@ import org.bukkit.inventory.ItemStack;
+  * <p>
+  * If a Block Place event is cancelled, the block will not be placed.
+  */
+-public class BlockPlaceEvent extends BlockEvent implements Cancellable {
++public class BlockPlaceEvent extends BlockEvent implements Cancellable, PlayerAction {
+     private static final HandlerList handlers = new HandlerList();
+     protected boolean cancel;
+     protected boolean canBuild;
+@@ -56,6 +57,11 @@ public class BlockPlaceEvent extends BlockEvent implements Cancellable {
+         return player;
+     }
+ 
++    @Override
++    public Player getActor() {
++        return getPlayer();
++    }
++
+     /**
+      * Clarity method for getting the placed block. Not really needed except
+      * for reasons of clarity.
+diff --git a/src/main/java/org/bukkit/event/block/BlockUndamageEvent.java b/src/main/java/org/bukkit/event/block/BlockUndamageEvent.java
+index 4d28dc7..da5221f 100644
+--- a/src/main/java/org/bukkit/event/block/BlockUndamageEvent.java
++++ b/src/main/java/org/bukkit/event/block/BlockUndamageEvent.java
+@@ -3,6 +3,7 @@ package org.bukkit.event.block;
+ import org.bukkit.block.Block;
+ import org.bukkit.entity.Player;
+ import org.bukkit.event.HandlerList;
++import org.bukkit.event.PlayerAction;
+ 
+ /**
+  * Called when a player stops digging a block WITHOUT breaking it. This is the
+@@ -11,7 +12,7 @@ import org.bukkit.event.HandlerList;
+  * breaks the block. It will also not be called if the block breaks instantly
+  * when the player starts digging.
+  */
+-public class BlockUndamageEvent extends BlockEvent {
++public class BlockUndamageEvent extends BlockEvent implements PlayerAction {
+     private static final HandlerList handlers = new HandlerList();
+     private final Player player;
+ 
+@@ -30,6 +31,11 @@ public class BlockUndamageEvent extends BlockEvent {
+     }
+ 
+     @Override
++    public Player getActor() {
++        return getPlayer();
++    }
++
++    @Override
+     public HandlerList getHandlers() {
+         return handlers;
+     }
+diff --git a/src/main/java/org/bukkit/event/block/EntityBlockFormEvent.java b/src/main/java/org/bukkit/event/block/EntityBlockFormEvent.java
+index 4ce034f..5ae084c 100644
+--- a/src/main/java/org/bukkit/event/block/EntityBlockFormEvent.java
++++ b/src/main/java/org/bukkit/event/block/EntityBlockFormEvent.java
+@@ -3,6 +3,7 @@ package org.bukkit.event.block;
+ import org.bukkit.block.Block;
+ import org.bukkit.block.BlockState;
+ import org.bukkit.entity.Entity;
++import org.bukkit.event.EntityAction;
+ 
+ /**
+  * Called when a block is formed by entities.
+@@ -13,7 +14,7 @@ import org.bukkit.entity.Entity;
+  * <li>Frosted Ice formed by the Frost Walker enchantment.
+  * </ul>
+  */
+-public class EntityBlockFormEvent extends BlockFormEvent {
++public class EntityBlockFormEvent extends BlockFormEvent implements EntityAction {
+     private final Entity entity;
+ 
+     public EntityBlockFormEvent(final Entity entity, final Block block, final BlockState blockstate) {
+@@ -30,4 +31,9 @@ public class EntityBlockFormEvent extends BlockFormEvent {
+     public Entity getEntity() {
+         return entity;
+     }
++
++    @Override
++    public Entity getActor() {
++        return getEntity();
++    }
+ }
+\ No newline at end of file
+diff --git a/src/main/java/org/bukkit/event/block/SignChangeEvent.java b/src/main/java/org/bukkit/event/block/SignChangeEvent.java
+index 83188cf..702eca0 100644
+--- a/src/main/java/org/bukkit/event/block/SignChangeEvent.java
++++ b/src/main/java/org/bukkit/event/block/SignChangeEvent.java
+@@ -4,13 +4,14 @@ import org.bukkit.block.Block;
+ import org.bukkit.entity.Player;
+ import org.bukkit.event.Cancellable;
+ import org.bukkit.event.HandlerList;
++import org.bukkit.event.PlayerAction;
+ 
+ /**
+  * Called when a sign is changed by a player.
+  * <p>
+  * If a Sign Change event is cancelled, the sign will not be changed.
+  */
+-public class SignChangeEvent extends BlockEvent implements Cancellable {
++public class SignChangeEvent extends BlockEvent implements Cancellable, PlayerAction {
+     private static final HandlerList handlers = new HandlerList();
+     private boolean cancel = false;
+     private final Player player;
+@@ -31,6 +32,11 @@ public class SignChangeEvent extends BlockEvent implements Cancellable {
+         return player;
+     }
+ 
++    @Override
++    public Player getActor() {
++        return getPlayer();
++    }
++
+     /**
+      * Gets all of the lines of text from the sign involved in this event.
+      *
+diff --git a/src/main/java/org/bukkit/event/entity/CreeperPowerEvent.java b/src/main/java/org/bukkit/event/entity/CreeperPowerEvent.java
+index b103a6a..c07a210 100644
+--- a/src/main/java/org/bukkit/event/entity/CreeperPowerEvent.java
++++ b/src/main/java/org/bukkit/event/entity/CreeperPowerEvent.java
+@@ -3,6 +3,7 @@ package org.bukkit.event.entity;
+ import org.bukkit.entity.Creeper;
+ import org.bukkit.entity.LightningStrike;
+ import org.bukkit.event.Cancellable;
++import org.bukkit.event.EntityAction;
+ import org.bukkit.event.HandlerList;
+ 
+ /**
+@@ -10,7 +11,7 @@ import org.bukkit.event.HandlerList;
+  * <p>
+  * If a Creeper Power event is cancelled, the Creeper will not be powered.
+  */
+-public class CreeperPowerEvent extends EntityEvent implements Cancellable {
++public class CreeperPowerEvent extends EntityEvent implements Cancellable, EntityAction {
+     private static final HandlerList handlers = new HandlerList();
+     private boolean canceled;
+     private final PowerCause cause;
+@@ -48,6 +49,11 @@ public class CreeperPowerEvent extends EntityEvent implements Cancellable {
+         return bolt;
+     }
+ 
++    @Override
++    public LightningStrike getActor() {
++        return getLightning();
++    }
++
+     /**
+      * Gets the cause of the creeper being (un)powered.
+      *
+diff --git a/src/main/java/org/bukkit/event/entity/EntityActionBase.java b/src/main/java/org/bukkit/event/entity/EntityActionBase.java
+new file mode 100644
+index 0000000..6e806f9
+--- /dev/null
++++ b/src/main/java/org/bukkit/event/entity/EntityActionBase.java
+@@ -0,0 +1,16 @@
++package org.bukkit.event.entity;
++
++import org.bukkit.entity.Entity;
++import org.bukkit.event.EntityAction;
++
++public abstract class EntityActionBase extends EntityEvent implements EntityAction {
++
++    public EntityActionBase(Entity what) {
++        super(what);
++    }
++
++    @Override
++    public Entity getActor() {
++        return getEntity();
++    }
++}
+diff --git a/src/main/java/org/bukkit/event/entity/EntityChangeBlockEvent.java b/src/main/java/org/bukkit/event/entity/EntityChangeBlockEvent.java
+index 849e57d..93e5d52 100644
+--- a/src/main/java/org/bukkit/event/entity/EntityChangeBlockEvent.java
++++ b/src/main/java/org/bukkit/event/entity/EntityChangeBlockEvent.java
+@@ -10,7 +10,7 @@ import org.bukkit.material.MaterialData;
+ /**
+  * Called when any Entity, excluding players, changes a block.
+  */
+-public class EntityChangeBlockEvent extends EntityEvent implements Cancellable {
++public class EntityChangeBlockEvent extends EntityActionBase implements Cancellable {
+     private static final HandlerList handlers = new HandlerList();
+     private final Block block;
+     private boolean cancel;
+diff --git a/src/main/java/org/bukkit/event/entity/EntityCombustByEntityEvent.java b/src/main/java/org/bukkit/event/entity/EntityCombustByEntityEvent.java
+index 639567b..0c5d568 100644
+--- a/src/main/java/org/bukkit/event/entity/EntityCombustByEntityEvent.java
++++ b/src/main/java/org/bukkit/event/entity/EntityCombustByEntityEvent.java
+@@ -1,11 +1,12 @@
+ package org.bukkit.event.entity;
+ 
+ import org.bukkit.entity.Entity;
++import org.bukkit.event.EntityAction;
+ 
+ /**
+  * Called when an entity causes another entity to combust.
+  */
+-public class EntityCombustByEntityEvent extends EntityCombustEvent {
++public class EntityCombustByEntityEvent extends EntityCombustEvent implements EntityAction {
+     private final Entity combuster;
+ 
+     public EntityCombustByEntityEvent(final Entity combuster, final Entity combustee, final int duration) {
+@@ -21,4 +22,9 @@ public class EntityCombustByEntityEvent extends EntityCombustEvent {
+     public Entity getCombuster() {
+         return combuster;
+     }
++
++    @Override
++    public Entity getActor() {
++        return getCombuster();
++    }
+ }
+diff --git a/src/main/java/org/bukkit/event/entity/EntityCreatePortalEvent.java b/src/main/java/org/bukkit/event/entity/EntityCreatePortalEvent.java
+index 286c206..abf9b8d 100644
+--- a/src/main/java/org/bukkit/event/entity/EntityCreatePortalEvent.java
++++ b/src/main/java/org/bukkit/event/entity/EntityCreatePortalEvent.java
+@@ -10,7 +10,7 @@ import org.bukkit.event.HandlerList;
+ /**
+  * Thrown when a Living Entity creates a portal in a world.
+  */
+-public class EntityCreatePortalEvent extends EntityEvent implements Cancellable {
++public class EntityCreatePortalEvent extends EntityActionBase implements Cancellable {
+     private static final HandlerList handlers = new HandlerList();
+     private final List<BlockState> blocks;
+     private boolean cancelled = false;
+diff --git a/src/main/java/org/bukkit/event/entity/EntityDamageByEntityEvent.java b/src/main/java/org/bukkit/event/entity/EntityDamageByEntityEvent.java
+index f121786..cd7e3cd 100644
+--- a/src/main/java/org/bukkit/event/entity/EntityDamageByEntityEvent.java
++++ b/src/main/java/org/bukkit/event/entity/EntityDamageByEntityEvent.java
+@@ -4,11 +4,12 @@ import java.util.Map;
+ 
+ import com.google.common.base.Function;
+ import org.bukkit.entity.Entity;
++import org.bukkit.event.EntityAction;
+ 
+ /**
+  * Called when an entity is damaged by an entity
+  */
+-public class EntityDamageByEntityEvent extends EntityDamageEvent {
++public class EntityDamageByEntityEvent extends EntityDamageEvent implements EntityAction {
+     private final Entity damager;
+ 
+     @Deprecated
+@@ -30,4 +31,9 @@ public class EntityDamageByEntityEvent extends EntityDamageEvent {
+     public Entity getDamager() {
+         return damager;
+     }
++
++    @Override
++    public Entity getActor() {
++        return getDamager();
++    }
+ }
+diff --git a/src/main/java/org/bukkit/event/entity/EntityExplodeEvent.java b/src/main/java/org/bukkit/event/entity/EntityExplodeEvent.java
+index 287035d..f464f15 100644
+--- a/src/main/java/org/bukkit/event/entity/EntityExplodeEvent.java
++++ b/src/main/java/org/bukkit/event/entity/EntityExplodeEvent.java
+@@ -11,7 +11,7 @@ import java.util.List;
+ /**
+  * Called when an entity explodes
+  */
+-public class EntityExplodeEvent extends EntityEvent implements Cancellable {
++public class EntityExplodeEvent extends EntityActionBase implements Cancellable {
+     private static final HandlerList handlers = new HandlerList();
+     private boolean cancel;
+     private final Location location;
+diff --git a/src/main/java/org/bukkit/event/entity/EntityInteractEvent.java b/src/main/java/org/bukkit/event/entity/EntityInteractEvent.java
+index 1c4e100..18d0a34 100644
+--- a/src/main/java/org/bukkit/event/entity/EntityInteractEvent.java
++++ b/src/main/java/org/bukkit/event/entity/EntityInteractEvent.java
+@@ -8,7 +8,7 @@ import org.bukkit.event.HandlerList;
+ /**
+  * Called when an entity interacts with an object
+  */
+-public class EntityInteractEvent extends EntityEvent implements Cancellable {
++public class EntityInteractEvent extends EntityActionBase implements Cancellable {
+     private static final HandlerList handlers = new HandlerList();
+     protected Block block;
+     private boolean cancelled;
+diff --git a/src/main/java/org/bukkit/event/entity/EntityPortalEnterEvent.java b/src/main/java/org/bukkit/event/entity/EntityPortalEnterEvent.java
+index 87d57b0..faf7eb8 100644
+--- a/src/main/java/org/bukkit/event/entity/EntityPortalEnterEvent.java
++++ b/src/main/java/org/bukkit/event/entity/EntityPortalEnterEvent.java
+@@ -7,7 +7,7 @@ import org.bukkit.event.HandlerList;
+ /**
+  * Called when an entity comes into contact with a portal
+  */
+-public class EntityPortalEnterEvent extends EntityEvent {
++public class EntityPortalEnterEvent extends EntityActionBase {
+     private static final HandlerList handlers = new HandlerList();
+     private final Location location;
+ 
+diff --git a/src/main/java/org/bukkit/event/entity/EntityShootBowEvent.java b/src/main/java/org/bukkit/event/entity/EntityShootBowEvent.java
+index f8c91a1..51e6d7a 100644
+--- a/src/main/java/org/bukkit/event/entity/EntityShootBowEvent.java
++++ b/src/main/java/org/bukkit/event/entity/EntityShootBowEvent.java
+@@ -10,7 +10,7 @@ import org.bukkit.inventory.ItemStack;
+ /**
+  * Called when a LivingEntity shoots a bow firing an arrow
+  */
+-public class EntityShootBowEvent extends EntityEvent implements Cancellable {
++public class EntityShootBowEvent extends EntityActionBase implements Cancellable {
+     private static final HandlerList handlers = new HandlerList();
+     private final ItemStack bow;
+     private Entity projectile;
+@@ -29,6 +29,11 @@ public class EntityShootBowEvent extends EntityEvent implements Cancellable {
+         return (LivingEntity) entity;
+     }
+ 
++    @Override
++    public LivingEntity getActor() {
++        return getEntity();
++    }
++
+     /**
+      * Gets the bow ItemStack used to fire the arrow.
+      *
+diff --git a/src/main/java/org/bukkit/event/entity/EntityTameEvent.java b/src/main/java/org/bukkit/event/entity/EntityTameEvent.java
+index f105817..4115e07 100644
+--- a/src/main/java/org/bukkit/event/entity/EntityTameEvent.java
++++ b/src/main/java/org/bukkit/event/entity/EntityTameEvent.java
+@@ -2,13 +2,15 @@ package org.bukkit.event.entity;
+ 
+ import org.bukkit.entity.AnimalTamer;
+ import org.bukkit.entity.LivingEntity;
++import org.bukkit.entity.Player;
+ import org.bukkit.event.Cancellable;
+ import org.bukkit.event.HandlerList;
++import org.bukkit.event.PlayerAction;
+ 
+ /**
+  * Thrown when a LivingEntity is tamed
+  */
+-public class EntityTameEvent extends EntityEvent implements Cancellable {
++public class EntityTameEvent extends EntityEvent implements Cancellable, PlayerAction {
+     private static final HandlerList handlers = new HandlerList();
+     private boolean cancelled;
+     private final AnimalTamer owner;
+@@ -41,6 +43,11 @@ public class EntityTameEvent extends EntityEvent implements Cancellable {
+     }
+ 
+     @Override
++    public Player getActor() {
++        return getEntity().getServer().getPlayer(getOwner().getUniqueId());
++    }
++
++    @Override
+     public HandlerList getHandlers() {
+         return handlers;
+     }
+diff --git a/src/main/java/org/bukkit/event/entity/EntityTargetEvent.java b/src/main/java/org/bukkit/event/entity/EntityTargetEvent.java
+index dd26e74..12850b0 100644
+--- a/src/main/java/org/bukkit/event/entity/EntityTargetEvent.java
++++ b/src/main/java/org/bukkit/event/entity/EntityTargetEvent.java
+@@ -7,7 +7,7 @@ import org.bukkit.event.HandlerList;
+ /**
+  * Called when a creature targets or untargets another entity
+  */
+-public class EntityTargetEvent extends EntityEvent implements Cancellable {
++public class EntityTargetEvent extends EntityActionBase implements Cancellable {
+     private static final HandlerList handlers = new HandlerList();
+     private boolean cancel = false;
+     private Entity target;
+diff --git a/src/main/java/org/bukkit/event/entity/EntityTeleportEvent.java b/src/main/java/org/bukkit/event/entity/EntityTeleportEvent.java
+index 619f8d4..da1f3bc 100644
+--- a/src/main/java/org/bukkit/event/entity/EntityTeleportEvent.java
++++ b/src/main/java/org/bukkit/event/entity/EntityTeleportEvent.java
+@@ -9,7 +9,7 @@ import org.bukkit.event.HandlerList;
+  * Thrown when a non-player entity (such as an Enderman) tries to teleport
+  * from one location to another.
+  */
+-public class EntityTeleportEvent extends EntityEvent implements Cancellable {
++public class EntityTeleportEvent extends EntityActionBase implements Cancellable {
+     private static final HandlerList handlers = new HandlerList();
+     private boolean cancel;
+     private Location from;
+diff --git a/src/main/java/org/bukkit/event/entity/ExplosionPrimeByEntityEvent.java b/src/main/java/org/bukkit/event/entity/ExplosionPrimeByEntityEvent.java
+index 6b7d13f..580513c 100644
+--- a/src/main/java/org/bukkit/event/entity/ExplosionPrimeByEntityEvent.java
++++ b/src/main/java/org/bukkit/event/entity/ExplosionPrimeByEntityEvent.java
+@@ -2,6 +2,7 @@ package org.bukkit.event.entity;
+ 
+ import org.bukkit.entity.Entity;
+ import org.bukkit.entity.Explosive;
++import org.bukkit.event.EntityAction;
+ 
+ import static com.google.common.base.Preconditions.checkNotNull;
+ 
+@@ -12,7 +13,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
+  *  - a flaming arrow activates a TNT block
+  *  - an entity damages an Ender Crystal
+  */
+-public class ExplosionPrimeByEntityEvent extends ExplosionPrimeEvent {
++public class ExplosionPrimeByEntityEvent extends ExplosionPrimeEvent implements EntityAction {
+ 
+     private final Entity primer;
+ 
+@@ -31,4 +32,9 @@ public class ExplosionPrimeByEntityEvent extends ExplosionPrimeEvent {
+     public Entity getPrimer() {
+         return primer;
+     }
++
++    @Override
++    public Entity getActor() {
++        return getPrimer();
++    }
+ }
+diff --git a/src/main/java/org/bukkit/event/entity/HorseJumpEvent.java b/src/main/java/org/bukkit/event/entity/HorseJumpEvent.java
+index 1794913..7efc20f 100644
+--- a/src/main/java/org/bukkit/event/entity/HorseJumpEvent.java
++++ b/src/main/java/org/bukkit/event/entity/HorseJumpEvent.java
+@@ -7,7 +7,7 @@ import org.bukkit.entity.AbstractHorse;
+ /**
+  * Called when a horse jumps.
+  */
+-public class HorseJumpEvent extends EntityEvent implements Cancellable {
++public class HorseJumpEvent extends EntityActionBase implements Cancellable {
+     private static final HandlerList handlers = new HandlerList();
+     private boolean cancelled;
+     private float power;
+@@ -34,6 +34,11 @@ public class HorseJumpEvent extends EntityEvent implements Cancellable {
+         return (AbstractHorse) entity;
+     }
+ 
++    @Override
++    public AbstractHorse getActor() {
++        return getEntity();
++    }
++
+     /**
+      * Gets the power of the jump.
+      * <p>
+diff --git a/src/main/java/org/bukkit/event/entity/PigZapEvent.java b/src/main/java/org/bukkit/event/entity/PigZapEvent.java
+index aa80ebf..f494064 100644
+--- a/src/main/java/org/bukkit/event/entity/PigZapEvent.java
++++ b/src/main/java/org/bukkit/event/entity/PigZapEvent.java
+@@ -4,12 +4,13 @@ import org.bukkit.entity.LightningStrike;
+ import org.bukkit.entity.Pig;
+ import org.bukkit.entity.PigZombie;
+ import org.bukkit.event.Cancellable;
++import org.bukkit.event.EntityAction;
+ import org.bukkit.event.HandlerList;
+ 
+ /**
+  * Stores data for pigs being zapped
+  */
+-public class PigZapEvent extends EntityEvent implements Cancellable {
++public class PigZapEvent extends EntityEvent implements Cancellable, EntityAction {
+     private static final HandlerList handlers = new HandlerList();
+     private boolean canceled;
+     private final PigZombie pigzombie;
+@@ -43,6 +44,11 @@ public class PigZapEvent extends EntityEvent implements Cancellable {
+         return bolt;
+     }
+ 
++    @Override
++    public LightningStrike getActor() {
++        return getLightning();
++    }
++
+     /**
+      * Gets the zombie pig that will replace the pig, provided the event is
+      * not cancelled first.
+diff --git a/src/main/java/org/bukkit/event/entity/PlayerLeashEntityEvent.java b/src/main/java/org/bukkit/event/entity/PlayerLeashEntityEvent.java
+index b4d0f3c..5bf8590 100644
+--- a/src/main/java/org/bukkit/event/entity/PlayerLeashEntityEvent.java
++++ b/src/main/java/org/bukkit/event/entity/PlayerLeashEntityEvent.java
+@@ -7,11 +7,12 @@ import org.bukkit.entity.Player;
+ import org.bukkit.event.Cancellable;
+ import org.bukkit.event.Event;
+ import org.bukkit.event.HandlerList;
++import org.bukkit.event.PlayerAction;
+ 
+ /**
+  * Called immediately prior to a creature being leashed by a player.
+  */
+-public class PlayerLeashEntityEvent extends Event implements Cancellable, Physical {
++public class PlayerLeashEntityEvent extends Event implements Cancellable, Physical, PlayerAction {
+     private static final HandlerList handlers = new HandlerList();
+     private final Entity leashHolder;
+     private final Entity entity;
+@@ -52,6 +53,11 @@ public class PlayerLeashEntityEvent extends Event implements Cancellable, Physic
+     }
+ 
+     @Override
++    public Player getActor() {
++        return getPlayer();
++    }
++
++    @Override
+     public World getWorld() {
+         return getEntity().getWorld();
+     }
+diff --git a/src/main/java/org/bukkit/event/entity/ProjectileHitEvent.java b/src/main/java/org/bukkit/event/entity/ProjectileHitEvent.java
+index 5bcc294..f794b7c 100644
+--- a/src/main/java/org/bukkit/event/entity/ProjectileHitEvent.java
++++ b/src/main/java/org/bukkit/event/entity/ProjectileHitEvent.java
+@@ -7,7 +7,7 @@ import org.bukkit.event.HandlerList;
+ /**
+  * Called when a projectile hits an object
+  */
+-public class ProjectileHitEvent extends EntityEvent {
++public class ProjectileHitEvent extends EntityActionBase {
+     private static final HandlerList handlers = new HandlerList();
+     private final Entity hitEntity;
+ 
+@@ -35,6 +35,11 @@ public class ProjectileHitEvent extends EntityEvent {
+     }
+ 
+     @Override
++    public Projectile getActor() {
++        return getEntity();
++    }
++
++    @Override
+     public HandlerList getHandlers() {
+         return handlers;
+     }
+diff --git a/src/main/java/org/bukkit/event/entity/ProjectileLaunchEvent.java b/src/main/java/org/bukkit/event/entity/ProjectileLaunchEvent.java
+index 0c9190c..0e633d9 100644
+--- a/src/main/java/org/bukkit/event/entity/ProjectileLaunchEvent.java
++++ b/src/main/java/org/bukkit/event/entity/ProjectileLaunchEvent.java
+@@ -3,12 +3,14 @@ package org.bukkit.event.entity;
+ import org.bukkit.entity.Entity;
+ import org.bukkit.entity.Projectile;
+ import org.bukkit.event.Cancellable;
++import org.bukkit.event.EntityAction;
+ import org.bukkit.event.HandlerList;
++import org.bukkit.projectiles.ProjectileSource;
+ 
+ /**
+  * Called when a projectile is launched.
+  */
+-public class ProjectileLaunchEvent extends EntityEvent implements Cancellable {
++public class ProjectileLaunchEvent extends EntityEvent implements Cancellable, EntityAction {
+     private static final HandlerList handlers = new HandlerList();
+     private boolean cancelled;
+ 
+@@ -30,6 +32,12 @@ public class ProjectileLaunchEvent extends EntityEvent implements Cancellable {
+     }
+ 
+     @Override
++    public Entity getActor() {
++        ProjectileSource source = getEntity().getShooter();
++        return source instanceof Entity ? (Entity) source : null;
++    }
++
++    @Override
+     public HandlerList getHandlers() {
+         return handlers;
+     }
+diff --git a/src/main/java/org/bukkit/event/hanging/HangingBreakByEntityEvent.java b/src/main/java/org/bukkit/event/hanging/HangingBreakByEntityEvent.java
+index d371168..e1b5098 100644
+--- a/src/main/java/org/bukkit/event/hanging/HangingBreakByEntityEvent.java
++++ b/src/main/java/org/bukkit/event/hanging/HangingBreakByEntityEvent.java
+@@ -2,11 +2,12 @@ package org.bukkit.event.hanging;
+ 
+ import org.bukkit.entity.Entity;
+ import org.bukkit.entity.Hanging;
++import org.bukkit.event.EntityAction;
+ 
+ /**
+  * Triggered when a hanging entity is removed by an entity
+  */
+-public class HangingBreakByEntityEvent extends HangingBreakEvent {
++public class HangingBreakByEntityEvent extends HangingBreakEvent implements EntityAction {
+     private final Entity remover;
+ 
+     public HangingBreakByEntityEvent(final Hanging hanging, final Entity remover) {
+@@ -26,4 +27,9 @@ public class HangingBreakByEntityEvent extends HangingBreakEvent {
+     public Entity getRemover() {
+         return remover;
+     }
++
++    @Override
++    public Entity getActor() {
++        return getRemover();
++    }
+ }
+diff --git a/src/main/java/org/bukkit/event/hanging/HangingPlaceEvent.java b/src/main/java/org/bukkit/event/hanging/HangingPlaceEvent.java
+index b511c55..f7826d3 100644
+--- a/src/main/java/org/bukkit/event/hanging/HangingPlaceEvent.java
++++ b/src/main/java/org/bukkit/event/hanging/HangingPlaceEvent.java
+@@ -6,11 +6,12 @@ import org.bukkit.entity.Hanging;
+ import org.bukkit.entity.Player;
+ import org.bukkit.event.Cancellable;
+ import org.bukkit.event.HandlerList;
++import org.bukkit.event.PlayerAction;
+ 
+ /**
+  * Triggered when a hanging entity is created in the world
+  */
+-public class HangingPlaceEvent extends HangingEvent implements Cancellable {
++public class HangingPlaceEvent extends HangingEvent implements Cancellable, PlayerAction {
+     private static final HandlerList handlers = new HandlerList();
+     private boolean cancelled;
+     private final Player player;
+@@ -33,6 +34,11 @@ public class HangingPlaceEvent extends HangingEvent implements Cancellable {
+         return player;
+     }
+ 
++    @Override
++    public Player getActor() {
++        return getPlayer();
++    }
++
+     /**
+      * Returns the block that the hanging entity was placed on
+      *
+diff --git a/src/main/java/org/bukkit/event/inventory/FurnaceExtractEvent.java b/src/main/java/org/bukkit/event/inventory/FurnaceExtractEvent.java
+index b7381fa..1d6bdd6 100644
+--- a/src/main/java/org/bukkit/event/inventory/FurnaceExtractEvent.java
++++ b/src/main/java/org/bukkit/event/inventory/FurnaceExtractEvent.java
+@@ -3,12 +3,13 @@ package org.bukkit.event.inventory;
+ import org.bukkit.Material;
+ import org.bukkit.block.Block;
+ import org.bukkit.entity.Player;
++import org.bukkit.event.PlayerAction;
+ import org.bukkit.event.block.BlockExpEvent;
+ 
+ /**
+  * This event is called when a player takes items out of the furnace
+  */
+-public class FurnaceExtractEvent extends BlockExpEvent {
++public class FurnaceExtractEvent extends BlockExpEvent implements PlayerAction {
+     private final Player player;
+     private final Material itemType;
+     private final int itemAmount;
+@@ -29,6 +30,11 @@ public class FurnaceExtractEvent extends BlockExpEvent {
+         return player;
+     }
+ 
++    @Override
++    public Player getActor() {
++        return getPlayer();
++    }
++
+     /**
+      * Get the Material of the item being retrieved
+      *
+diff --git a/src/main/java/org/bukkit/event/inventory/InventoryEvent.java b/src/main/java/org/bukkit/event/inventory/InventoryEvent.java
+index fd0fc2f..804ff44 100644
+--- a/src/main/java/org/bukkit/event/inventory/InventoryEvent.java
++++ b/src/main/java/org/bukkit/event/inventory/InventoryEvent.java
+@@ -5,16 +5,18 @@ import java.util.List;
+ 
+ import org.bukkit.World;
+ import org.bukkit.Physical;
++import org.bukkit.entity.Player;
+ import org.bukkit.event.HandlerList;
+ import org.bukkit.entity.HumanEntity;
+ import org.bukkit.event.Event;
++import org.bukkit.event.PlayerAction;
+ import org.bukkit.inventory.Inventory;
+ import org.bukkit.inventory.InventoryView;
+ 
+ /**
+  * Represents a player related inventory event
+  */
+-public class InventoryEvent extends Event implements Physical {
++public class InventoryEvent extends Event implements Physical, PlayerAction {
+     private static final HandlerList handlers = new HandlerList();
+     protected InventoryView transaction;
+ 
+@@ -56,6 +58,11 @@ public class InventoryEvent extends Event implements Physical {
+     }
+ 
+     @Override
++    public Player getActor() {
++        return (Player) getView().getPlayer();
++    }
++
++    @Override
+     public HandlerList getHandlers() {
+         return handlers;
+     }
+diff --git a/src/main/java/org/bukkit/event/inventory/InventoryMoveItemEvent.java b/src/main/java/org/bukkit/event/inventory/InventoryMoveItemEvent.java
+index 05ef7ec..d3cbe0b 100644
+--- a/src/main/java/org/bukkit/event/inventory/InventoryMoveItemEvent.java
++++ b/src/main/java/org/bukkit/event/inventory/InventoryMoveItemEvent.java
+@@ -3,10 +3,13 @@ package org.bukkit.event.inventory;
+ import org.apache.commons.lang.Validate;
+ import org.bukkit.World;
+ import org.bukkit.Physical;
++import org.bukkit.entity.Entity;
+ import org.bukkit.event.Cancellable;
++import org.bukkit.event.EntityAction;
+ import org.bukkit.event.Event;
+ import org.bukkit.event.HandlerList;
+ import org.bukkit.inventory.Inventory;
++import org.bukkit.inventory.InventoryHolder;
+ import org.bukkit.inventory.ItemStack;
+ 
+ /**
+@@ -25,7 +28,7 @@ import org.bukkit.inventory.ItemStack;
+  * has not been modified, the source inventory slot will be restored to its
+  * former state. Otherwise any additional items will be discarded.
+  */
+-public class InventoryMoveItemEvent extends Event implements Cancellable, Physical {
++public class InventoryMoveItemEvent extends Event implements Cancellable, Physical, EntityAction {
+     private static final HandlerList handlers = new HandlerList();
+     private boolean cancelled;
+     private final Inventory sourceInventory;
+@@ -92,6 +95,12 @@ public class InventoryMoveItemEvent extends Event implements Cancellable, Physic
+     }
+ 
+     @Override
++    public Entity getActor() {
++        InventoryHolder holder = getInitiator().getHolder();
++        return holder instanceof Entity ? (Entity) holder : null;
++    }
++
++    @Override
+     public World getWorld() {
+         return getInitiator().getWorld();
+     }
+diff --git a/src/main/java/org/bukkit/event/inventory/InventoryPickupItemEvent.java b/src/main/java/org/bukkit/event/inventory/InventoryPickupItemEvent.java
+index 9958e63..98357d9 100644
+--- a/src/main/java/org/bukkit/event/inventory/InventoryPickupItemEvent.java
++++ b/src/main/java/org/bukkit/event/inventory/InventoryPickupItemEvent.java
+@@ -2,16 +2,19 @@ package org.bukkit.event.inventory;
+ 
+ import org.bukkit.World;
+ import org.bukkit.Physical;
++import org.bukkit.entity.Entity;
+ import org.bukkit.entity.Item;
+ import org.bukkit.event.Cancellable;
++import org.bukkit.event.EntityAction;
+ import org.bukkit.event.Event;
+ import org.bukkit.event.HandlerList;
+ import org.bukkit.inventory.Inventory;
++import org.bukkit.inventory.InventoryHolder;
+ 
+ /**
+  * Called when a hopper or hopper minecart picks up a dropped item.
+  */
+-public class InventoryPickupItemEvent extends Event implements Cancellable, Physical {
++public class InventoryPickupItemEvent extends Event implements Cancellable, Physical, EntityAction {
+     private static final HandlerList handlers = new HandlerList();
+     private boolean cancelled;
+     private final Inventory inventory;
+@@ -32,6 +35,12 @@ public class InventoryPickupItemEvent extends Event implements Cancellable, Phys
+         return inventory;
+     }
+ 
++    @Override
++    public Entity getActor() {
++        InventoryHolder holder = getInventory().getHolder();
++        return holder instanceof Entity ? (Entity) holder : null;
++    }
++
+     /**
+      * Gets the Item entity that was picked up
+      *
+diff --git a/src/main/java/org/bukkit/event/player/PlayerActionBase.java b/src/main/java/org/bukkit/event/player/PlayerActionBase.java
+new file mode 100644
+index 0000000..178360d
+--- /dev/null
++++ b/src/main/java/org/bukkit/event/player/PlayerActionBase.java
+@@ -0,0 +1,20 @@
++package org.bukkit.event.player;
++
++import org.bukkit.entity.Player;
++import org.bukkit.event.PlayerAction;
++
++public abstract class PlayerActionBase extends PlayerEvent implements PlayerAction {
++
++    public PlayerActionBase(Player who) {
++        super(who);
++    }
++
++    PlayerActionBase(Player who, boolean async) {
++        super(who, async);
++    }
++
++    @Override
++    public Player getActor() {
++        return getPlayer();
++    }
++}
+diff --git a/src/main/java/org/bukkit/event/player/PlayerAnimationEvent.java b/src/main/java/org/bukkit/event/player/PlayerAnimationEvent.java
+index cabe77d..13cd912 100644
+--- a/src/main/java/org/bukkit/event/player/PlayerAnimationEvent.java
++++ b/src/main/java/org/bukkit/event/player/PlayerAnimationEvent.java
+@@ -7,7 +7,7 @@ import org.bukkit.event.HandlerList;
+ /**
+  * Represents a player animation event
+  */
+-public class PlayerAnimationEvent extends PlayerEvent implements Cancellable {
++public class PlayerAnimationEvent extends PlayerActionBase implements Cancellable {
+     private static final HandlerList handlers = new HandlerList();
+     private final PlayerAnimationType animationType;
+     private boolean isCancelled = false;
+diff --git a/src/main/java/org/bukkit/event/player/PlayerAttackEntityEvent.java b/src/main/java/org/bukkit/event/player/PlayerAttackEntityEvent.java
+index b05b231..589a3dd 100644
+--- a/src/main/java/org/bukkit/event/player/PlayerAttackEntityEvent.java
++++ b/src/main/java/org/bukkit/event/player/PlayerAttackEntityEvent.java
+@@ -9,7 +9,7 @@ import org.bukkit.event.HandlerList;
+  * Called when a player left-clicks on any entity. This is called before any other
+  * event, and cancelling it prevents all further effects of the right-click.
+  */
+-public class PlayerAttackEntityEvent extends PlayerEvent implements Cancellable {
++public class PlayerAttackEntityEvent extends PlayerActionBase implements Cancellable {
+     private static final HandlerList handlers = new HandlerList();
+     protected Entity clickedEntity;
+     boolean cancelled = false;
+diff --git a/src/main/java/org/bukkit/event/player/PlayerBedEnterEvent.java b/src/main/java/org/bukkit/event/player/PlayerBedEnterEvent.java
+index 09f1a66..ce9ed50 100644
+--- a/src/main/java/org/bukkit/event/player/PlayerBedEnterEvent.java
++++ b/src/main/java/org/bukkit/event/player/PlayerBedEnterEvent.java
+@@ -8,7 +8,7 @@ import org.bukkit.event.HandlerList;
+ /**
+  * This event is fired when the player is almost about to enter the bed.
+  */
+-public class PlayerBedEnterEvent extends PlayerEvent implements Cancellable {
++public class PlayerBedEnterEvent extends PlayerActionBase implements Cancellable {
+     private static final HandlerList handlers = new HandlerList();
+     private boolean cancel = false;
+     private final Block bed;
+diff --git a/src/main/java/org/bukkit/event/player/PlayerBedLeaveEvent.java b/src/main/java/org/bukkit/event/player/PlayerBedLeaveEvent.java
+index 628ab0b..933b5e2 100644
+--- a/src/main/java/org/bukkit/event/player/PlayerBedLeaveEvent.java
++++ b/src/main/java/org/bukkit/event/player/PlayerBedLeaveEvent.java
+@@ -7,7 +7,7 @@ import org.bukkit.event.HandlerList;
+ /**
+  * This event is fired when the player is leaving a bed.
+  */
+-public class PlayerBedLeaveEvent extends PlayerEvent {
++public class PlayerBedLeaveEvent extends PlayerActionBase {
+     private static final HandlerList handlers = new HandlerList();
+     private final Block bed;
+ 
+diff --git a/src/main/java/org/bukkit/event/player/PlayerBucketEvent.java b/src/main/java/org/bukkit/event/player/PlayerBucketEvent.java
+index d32c55e..ffb4c4f 100644
+--- a/src/main/java/org/bukkit/event/player/PlayerBucketEvent.java
++++ b/src/main/java/org/bukkit/event/player/PlayerBucketEvent.java
+@@ -10,7 +10,7 @@ import org.bukkit.inventory.ItemStack;
+ /**
+  * Called when a player interacts with a Bucket
+  */
+-public abstract class PlayerBucketEvent extends PlayerEvent implements Cancellable {
++public abstract class PlayerBucketEvent extends PlayerActionBase implements Cancellable {
+     private ItemStack itemStack;
+     private boolean cancelled = false;
+     private final Block blockClicked;
+diff --git a/src/main/java/org/bukkit/event/player/PlayerDropItemEvent.java b/src/main/java/org/bukkit/event/player/PlayerDropItemEvent.java
+index 5b41b65..f37ce2b 100644
+--- a/src/main/java/org/bukkit/event/player/PlayerDropItemEvent.java
++++ b/src/main/java/org/bukkit/event/player/PlayerDropItemEvent.java
+@@ -8,7 +8,7 @@ import org.bukkit.event.HandlerList;
+ /**
+  * Thrown when a player drops an item from their inventory
+  */
+-public class PlayerDropItemEvent extends PlayerEvent implements Cancellable {
++public class PlayerDropItemEvent extends PlayerActionBase implements Cancellable {
+     private static final HandlerList handlers = new HandlerList();
+     private final Item drop;
+     private boolean cancel = false;
+diff --git a/src/main/java/org/bukkit/event/player/PlayerEditBookEvent.java b/src/main/java/org/bukkit/event/player/PlayerEditBookEvent.java
+index ea7ecef..1229984 100644
+--- a/src/main/java/org/bukkit/event/player/PlayerEditBookEvent.java
++++ b/src/main/java/org/bukkit/event/player/PlayerEditBookEvent.java
+@@ -11,7 +11,7 @@ import org.bukkit.inventory.meta.BookMeta;
+  * Called when a player edits or signs a book and quill item. If the event is
+  * cancelled, no changes are made to the BookMeta
+  */
+-public class PlayerEditBookEvent extends PlayerEvent implements Cancellable {
++public class PlayerEditBookEvent extends PlayerActionBase implements Cancellable {
+     private static final HandlerList handlers = new HandlerList();
+ 
+     private final BookMeta previousBookMeta;
+diff --git a/src/main/java/org/bukkit/event/player/PlayerEggThrowEvent.java b/src/main/java/org/bukkit/event/player/PlayerEggThrowEvent.java
+index 4b5075b..89ac3bb 100644
+--- a/src/main/java/org/bukkit/event/player/PlayerEggThrowEvent.java
++++ b/src/main/java/org/bukkit/event/player/PlayerEggThrowEvent.java
+@@ -8,7 +8,7 @@ import org.bukkit.event.HandlerList;
+ /**
+  * Called when a player throws an egg and it might hatch
+  */
+-public class PlayerEggThrowEvent extends PlayerEvent {
++public class PlayerEggThrowEvent extends PlayerActionBase {
+     private static final HandlerList handlers = new HandlerList();
+     private final Egg egg;
+     private boolean hatching;
+diff --git a/src/main/java/org/bukkit/event/player/PlayerFishEvent.java b/src/main/java/org/bukkit/event/player/PlayerFishEvent.java
+index 72eebe9..2696ed4 100644
+--- a/src/main/java/org/bukkit/event/player/PlayerFishEvent.java
++++ b/src/main/java/org/bukkit/event/player/PlayerFishEvent.java
+@@ -9,7 +9,7 @@ import org.bukkit.event.HandlerList;
+ /**
+  * Thrown when a player is fishing
+  */
+-public class PlayerFishEvent extends PlayerEvent implements Cancellable {
++public class PlayerFishEvent extends PlayerActionBase implements Cancellable {
+     private static final HandlerList handlers = new HandlerList();
+     private final Entity entity;
+     private boolean cancel = false;
+diff --git a/src/main/java/org/bukkit/event/player/PlayerInteractEntityEvent.java b/src/main/java/org/bukkit/event/player/PlayerInteractEntityEvent.java
+index 9460957..13d6c6d 100644
+--- a/src/main/java/org/bukkit/event/player/PlayerInteractEntityEvent.java
++++ b/src/main/java/org/bukkit/event/player/PlayerInteractEntityEvent.java
+@@ -9,7 +9,7 @@ import org.bukkit.inventory.EquipmentSlot;
+ /**
+  * Represents an event that is called when a player right clicks an entity.
+  */
+-public class PlayerInteractEntityEvent extends PlayerEvent implements Cancellable {
++public class PlayerInteractEntityEvent extends PlayerActionBase implements Cancellable {
+     private static final HandlerList handlers = new HandlerList();
+     protected Entity clickedEntity;
+     boolean cancelled = false;
+diff --git a/src/main/java/org/bukkit/event/player/PlayerInteractEvent.java b/src/main/java/org/bukkit/event/player/PlayerInteractEvent.java
+index 818b481..170332e 100644
+--- a/src/main/java/org/bukkit/event/player/PlayerInteractEvent.java
++++ b/src/main/java/org/bukkit/event/player/PlayerInteractEvent.java
+@@ -16,7 +16,7 @@ import org.bukkit.inventory.EquipmentSlot;
+  * This event will fire as cancelled if the vanilla behavior
+  * is to do nothing (e.g interacting with air)
+  */
+-public class PlayerInteractEvent extends PlayerEvent implements Cancellable {
++public class PlayerInteractEvent extends PlayerActionBase implements Cancellable {
+     private static final HandlerList handlers = new HandlerList();
+     protected ItemStack item;
+     protected Action action;
+diff --git a/src/main/java/org/bukkit/event/player/PlayerItemBreakEvent.java b/src/main/java/org/bukkit/event/player/PlayerItemBreakEvent.java
+index 176cd91..9016a46 100644
+--- a/src/main/java/org/bukkit/event/player/PlayerItemBreakEvent.java
++++ b/src/main/java/org/bukkit/event/player/PlayerItemBreakEvent.java
+@@ -10,7 +10,7 @@ import org.bukkit.inventory.ItemStack;
+  * The item that's breaking will exist in the inventory with a stack size of
+  * 0. After the event, the item's durability will be reset to 0.
+  */
+-public class PlayerItemBreakEvent extends PlayerEvent {
++public class PlayerItemBreakEvent extends PlayerActionBase {
+     private static final HandlerList handlers = new HandlerList();
+     private final ItemStack brokenItem;
+ 
+diff --git a/src/main/java/org/bukkit/event/player/PlayerItemConsumeEvent.java b/src/main/java/org/bukkit/event/player/PlayerItemConsumeEvent.java
+index a81b642..cf38dd1 100644
+--- a/src/main/java/org/bukkit/event/player/PlayerItemConsumeEvent.java
++++ b/src/main/java/org/bukkit/event/player/PlayerItemConsumeEvent.java
+@@ -16,7 +16,7 @@ import org.bukkit.inventory.ItemStack;
+  * If the event is cancelled the effect will not be applied and the item will
+  * not be removed from the player's inventory.
+  */
+-public class PlayerItemConsumeEvent extends PlayerEvent implements Cancellable {
++public class PlayerItemConsumeEvent extends PlayerActionBase implements Cancellable {
+     private static final HandlerList handlers = new HandlerList();
+     private boolean isCancelled = false;
+     private ItemStack item;
+diff --git a/src/main/java/org/bukkit/event/player/PlayerItemHeldEvent.java b/src/main/java/org/bukkit/event/player/PlayerItemHeldEvent.java
+index f0d055a..37e7ac1 100644
+--- a/src/main/java/org/bukkit/event/player/PlayerItemHeldEvent.java
++++ b/src/main/java/org/bukkit/event/player/PlayerItemHeldEvent.java
+@@ -7,7 +7,7 @@ import org.bukkit.event.HandlerList;
+ /**
+  * Fired when a player changes their currently held item
+  */
+-public class PlayerItemHeldEvent extends PlayerEvent implements Cancellable {
++public class PlayerItemHeldEvent extends PlayerActionBase implements Cancellable {
+     private static final HandlerList handlers = new HandlerList();
+     private boolean cancel = false;
+     private final int previous;
+diff --git a/src/main/java/org/bukkit/event/player/PlayerMoveEvent.java b/src/main/java/org/bukkit/event/player/PlayerMoveEvent.java
+index d56b7e4..7687667 100644
+--- a/src/main/java/org/bukkit/event/player/PlayerMoveEvent.java
++++ b/src/main/java/org/bukkit/event/player/PlayerMoveEvent.java
+@@ -9,7 +9,7 @@ import org.bukkit.event.HandlerList;
+ /**
+  * Holds information for player movement events
+  */
+-public class PlayerMoveEvent extends PlayerEvent implements Cancellable {
++public class PlayerMoveEvent extends PlayerActionBase implements Cancellable {
+     private static final HandlerList handlers = new HandlerList();
+     private boolean cancel = false;
+     private Location from;
+diff --git a/src/main/java/org/bukkit/event/player/PlayerOnGroundEvent.java b/src/main/java/org/bukkit/event/player/PlayerOnGroundEvent.java
+index 4a6c3d4..61f9641 100644
+--- a/src/main/java/org/bukkit/event/player/PlayerOnGroundEvent.java
++++ b/src/main/java/org/bukkit/event/player/PlayerOnGroundEvent.java
+@@ -3,7 +3,7 @@ package org.bukkit.event.player;
+ import org.bukkit.entity.Player;
+ import org.bukkit.event.HandlerList;
+ 
+-public class PlayerOnGroundEvent extends PlayerEvent {
++public class PlayerOnGroundEvent extends PlayerActionBase {
+     private static final HandlerList handlers = new HandlerList();
+     private boolean onGround;
+ 
+diff --git a/src/main/java/org/bukkit/event/player/PlayerPickupExperienceEvent.java b/src/main/java/org/bukkit/event/player/PlayerPickupExperienceEvent.java
+index 24a13d9..788fe46 100644
+--- a/src/main/java/org/bukkit/event/player/PlayerPickupExperienceEvent.java
++++ b/src/main/java/org/bukkit/event/player/PlayerPickupExperienceEvent.java
+@@ -5,7 +5,7 @@ import org.bukkit.entity.Player;
+ import org.bukkit.event.Cancellable;
+ import org.bukkit.event.HandlerList;
+ 
+-public class PlayerPickupExperienceEvent extends PlayerEvent implements Cancellable {
++public class PlayerPickupExperienceEvent extends PlayerActionBase implements Cancellable {
+     private static final HandlerList handlers = new HandlerList();
+     private final ExperienceOrb experienceorb;
+     private boolean cancel = false;
+diff --git a/src/main/java/org/bukkit/event/player/PlayerPickupItemEvent.java b/src/main/java/org/bukkit/event/player/PlayerPickupItemEvent.java
+index dfba816..30e450c 100644
+--- a/src/main/java/org/bukkit/event/player/PlayerPickupItemEvent.java
++++ b/src/main/java/org/bukkit/event/player/PlayerPickupItemEvent.java
+@@ -8,7 +8,7 @@ import org.bukkit.event.HandlerList;
+ /**
+  * Thrown when a player picks an item up from the ground
+  */
+-public class PlayerPickupItemEvent extends PlayerEvent implements Cancellable {
++public class PlayerPickupItemEvent extends PlayerActionBase implements Cancellable {
+     private static final HandlerList handlers = new HandlerList();
+     private final Item item;
+     private boolean cancel = false;
+diff --git a/src/main/java/org/bukkit/event/player/PlayerShearEntityEvent.java b/src/main/java/org/bukkit/event/player/PlayerShearEntityEvent.java
+index 38afb3c..9448685 100644
+--- a/src/main/java/org/bukkit/event/player/PlayerShearEntityEvent.java
++++ b/src/main/java/org/bukkit/event/player/PlayerShearEntityEvent.java
+@@ -8,7 +8,7 @@ import org.bukkit.event.HandlerList;
+ /**
+  * Called when a player shears an entity
+  */
+-public class PlayerShearEntityEvent extends PlayerEvent implements Cancellable {
++public class PlayerShearEntityEvent extends PlayerActionBase implements Cancellable {
+     private static final HandlerList handlers = new HandlerList();
+     private boolean cancel;
+     private final Entity what;
+diff --git a/src/main/java/org/bukkit/event/player/PlayerSpawnEntityEvent.java b/src/main/java/org/bukkit/event/player/PlayerSpawnEntityEvent.java
+index 1fdc6ca..8e98f37 100644
+--- a/src/main/java/org/bukkit/event/player/PlayerSpawnEntityEvent.java
++++ b/src/main/java/org/bukkit/event/player/PlayerSpawnEntityEvent.java
+@@ -7,7 +7,7 @@ import org.bukkit.event.Cancellable;
+ import org.bukkit.event.HandlerList;
+ import org.bukkit.inventory.ItemStack;
+ 
+-public class PlayerSpawnEntityEvent extends PlayerEvent implements Cancellable {
++public class PlayerSpawnEntityEvent extends PlayerActionBase implements Cancellable {
+     private static final HandlerList handlers = new HandlerList();
+     private boolean cancel;
+     private final Entity what;
+diff --git a/src/main/java/org/bukkit/event/player/PlayerToggleFlightEvent.java b/src/main/java/org/bukkit/event/player/PlayerToggleFlightEvent.java
+index 1c5ec37..b846be1 100644
+--- a/src/main/java/org/bukkit/event/player/PlayerToggleFlightEvent.java
++++ b/src/main/java/org/bukkit/event/player/PlayerToggleFlightEvent.java
+@@ -7,7 +7,7 @@ import org.bukkit.event.HandlerList;
+ /**
+  * Called when a player toggles their flying state
+  */
+-public class PlayerToggleFlightEvent extends PlayerEvent implements Cancellable {
++public class PlayerToggleFlightEvent extends PlayerActionBase implements Cancellable {
+     private static final HandlerList handlers = new HandlerList();
+     private final boolean isFlying;
+     private boolean cancel = false;
+diff --git a/src/main/java/org/bukkit/event/player/PlayerToggleSneakEvent.java b/src/main/java/org/bukkit/event/player/PlayerToggleSneakEvent.java
+index 667acad..63b6ec6 100644
+--- a/src/main/java/org/bukkit/event/player/PlayerToggleSneakEvent.java
++++ b/src/main/java/org/bukkit/event/player/PlayerToggleSneakEvent.java
+@@ -7,7 +7,7 @@ import org.bukkit.event.HandlerList;
+ /**
+  * Called when a player toggles their sneaking state
+  */
+-public class PlayerToggleSneakEvent extends PlayerEvent implements Cancellable {
++public class PlayerToggleSneakEvent extends PlayerActionBase implements Cancellable {
+     private static final HandlerList handlers = new HandlerList();
+     private final boolean isSneaking;
+     private boolean cancel = false;
+diff --git a/src/main/java/org/bukkit/event/player/PlayerToggleSprintEvent.java b/src/main/java/org/bukkit/event/player/PlayerToggleSprintEvent.java
+index cf065e1..f36f034 100644
+--- a/src/main/java/org/bukkit/event/player/PlayerToggleSprintEvent.java
++++ b/src/main/java/org/bukkit/event/player/PlayerToggleSprintEvent.java
+@@ -7,7 +7,7 @@ import org.bukkit.event.HandlerList;
+ /**
+  * Called when a player toggles their sprinting state
+  */
+-public class PlayerToggleSprintEvent extends PlayerEvent implements Cancellable {
++public class PlayerToggleSprintEvent extends PlayerActionBase implements Cancellable {
+     private static final HandlerList handlers = new HandlerList();
+     private final boolean isSprinting;
+     private boolean cancel = false;
+diff --git a/src/main/java/org/bukkit/event/player/PlayerUnleashEntityEvent.java b/src/main/java/org/bukkit/event/player/PlayerUnleashEntityEvent.java
+index f6aebef..97870dd 100644
+--- a/src/main/java/org/bukkit/event/player/PlayerUnleashEntityEvent.java
++++ b/src/main/java/org/bukkit/event/player/PlayerUnleashEntityEvent.java
+@@ -3,12 +3,13 @@ package org.bukkit.event.player;
+ import org.bukkit.entity.Entity;
+ import org.bukkit.entity.Player;
+ import org.bukkit.event.Cancellable;
++import org.bukkit.event.PlayerAction;
+ import org.bukkit.event.entity.EntityUnleashEvent;
+ 
+ /**
+  * Called prior to an entity being unleashed due to a player's action.
+  */
+-public class PlayerUnleashEntityEvent extends EntityUnleashEvent implements Cancellable {
++public class PlayerUnleashEntityEvent extends EntityUnleashEvent implements Cancellable, PlayerAction {
+     private final Player player;
+     private boolean cancelled = false;
+ 
+@@ -26,6 +27,11 @@ public class PlayerUnleashEntityEvent extends EntityUnleashEvent implements Canc
+         return player;
+     }
+ 
++    @Override
++    public Player getActor() {
++        return getPlayer();
++    }
++
+     public boolean isCancelled() {
+         return cancelled;
+     }
+diff --git a/src/main/java/org/bukkit/event/vehicle/VehicleDamageEvent.java b/src/main/java/org/bukkit/event/vehicle/VehicleDamageEvent.java
+index c7b9c1a..2296ab4 100644
+--- a/src/main/java/org/bukkit/event/vehicle/VehicleDamageEvent.java
++++ b/src/main/java/org/bukkit/event/vehicle/VehicleDamageEvent.java
+@@ -3,13 +3,14 @@ package org.bukkit.event.vehicle;
+ import org.bukkit.entity.Entity;
+ import org.bukkit.entity.Vehicle;
+ import org.bukkit.event.Cancellable;
++import org.bukkit.event.EntityAction;
+ import org.bukkit.event.HandlerList;
+ import org.bukkit.util.NumberConversions;
+ 
+ /**
+  * Raised when a vehicle receives damage.
+  */
+-public class VehicleDamageEvent extends VehicleEvent implements Cancellable {
++public class VehicleDamageEvent extends VehicleEvent implements Cancellable, EntityAction {
+     private static final HandlerList handlers = new HandlerList();
+     private final Entity attacker;
+     private double damage;
+@@ -35,6 +36,11 @@ public class VehicleDamageEvent extends VehicleEvent implements Cancellable {
+         return attacker;
+     }
+ 
++    @Override
++    public Entity getActor() {
++        return getAttacker();
++    }
++
+     /**
+      * Gets the damage done to the vehicle
+      *
+diff --git a/src/main/java/org/bukkit/event/vehicle/VehicleDestroyEvent.java b/src/main/java/org/bukkit/event/vehicle/VehicleDestroyEvent.java
+index f1176fd..5b0f545 100644
+--- a/src/main/java/org/bukkit/event/vehicle/VehicleDestroyEvent.java
++++ b/src/main/java/org/bukkit/event/vehicle/VehicleDestroyEvent.java
+@@ -3,6 +3,7 @@ package org.bukkit.event.vehicle;
+ import org.bukkit.entity.Entity;
+ import org.bukkit.entity.Vehicle;
+ import org.bukkit.event.Cancellable;
++import org.bukkit.event.EntityAction;
+ import org.bukkit.event.HandlerList;
+ 
+ /**
+@@ -10,7 +11,7 @@ import org.bukkit.event.HandlerList;
+  * player or the environment. This is not raised if the boat is simply
+  * 'removed' due to other means.
+  */
+-public class VehicleDestroyEvent extends VehicleEvent implements Cancellable {
++public class VehicleDestroyEvent extends VehicleEvent implements Cancellable, EntityAction {
+     private static final HandlerList handlers = new HandlerList();
+     private final Entity attacker;
+     private boolean cancelled;
+@@ -29,6 +30,11 @@ public class VehicleDestroyEvent extends VehicleEvent implements Cancellable {
+         return attacker;
+     }
+ 
++    @Override
++    public Entity getActor() {
++        return getAttacker();
++    }
++
+     public boolean isCancelled() {
+         return cancelled;
+     }
+diff --git a/src/main/java/org/bukkit/event/vehicle/VehicleEnterEvent.java b/src/main/java/org/bukkit/event/vehicle/VehicleEnterEvent.java
+index 85c9b21..029a028 100644
+--- a/src/main/java/org/bukkit/event/vehicle/VehicleEnterEvent.java
++++ b/src/main/java/org/bukkit/event/vehicle/VehicleEnterEvent.java
+@@ -3,12 +3,13 @@ package org.bukkit.event.vehicle;
+ import org.bukkit.entity.Entity;
+ import org.bukkit.entity.Vehicle;
+ import org.bukkit.event.Cancellable;
++import org.bukkit.event.EntityAction;
+ import org.bukkit.event.HandlerList;
+ 
+ /**
+  * Raised when an entity enters a vehicle.
+  */
+-public class VehicleEnterEvent extends VehicleEvent implements Cancellable {
++public class VehicleEnterEvent extends VehicleEvent implements Cancellable, EntityAction {
+     private static final HandlerList handlers = new HandlerList();
+     private boolean cancelled;
+     private final Entity entered;
+@@ -27,6 +28,11 @@ public class VehicleEnterEvent extends VehicleEvent implements Cancellable {
+         return entered;
+     }
+ 
++    @Override
++    public Entity getActor() {
++        return getEntered();
++    }
++
+     public boolean isCancelled() {
+         return cancelled;
+     }
+diff --git a/src/main/java/org/bukkit/event/vehicle/VehicleEntityCollisionEvent.java b/src/main/java/org/bukkit/event/vehicle/VehicleEntityCollisionEvent.java
+index 4d4d0e2..caf865d 100644
+--- a/src/main/java/org/bukkit/event/vehicle/VehicleEntityCollisionEvent.java
++++ b/src/main/java/org/bukkit/event/vehicle/VehicleEntityCollisionEvent.java
+@@ -3,12 +3,13 @@ package org.bukkit.event.vehicle;
+ import org.bukkit.entity.Entity;
+ import org.bukkit.entity.Vehicle;
+ import org.bukkit.event.Cancellable;
++import org.bukkit.event.EntityAction;
+ import org.bukkit.event.HandlerList;
+ 
+ /**
+  * Raised when a vehicle collides with an entity.
+  */
+-public class VehicleEntityCollisionEvent extends VehicleCollisionEvent implements Cancellable {
++public class VehicleEntityCollisionEvent extends VehicleCollisionEvent implements Cancellable, EntityAction {
+     private static final HandlerList handlers = new HandlerList();
+     private final Entity entity;
+     private boolean cancelled = false;
+@@ -24,6 +25,11 @@ public class VehicleEntityCollisionEvent extends VehicleCollisionEvent implement
+         return entity;
+     }
+ 
++    @Override
++    public Entity getActor() {
++        return getEntity();
++    }
++
+     public boolean isCancelled() {
+         return cancelled;
+     }
+diff --git a/src/main/java/org/bukkit/event/vehicle/VehicleExitEvent.java b/src/main/java/org/bukkit/event/vehicle/VehicleExitEvent.java
+index 364451b..ab44ac6 100644
+--- a/src/main/java/org/bukkit/event/vehicle/VehicleExitEvent.java
++++ b/src/main/java/org/bukkit/event/vehicle/VehicleExitEvent.java
+@@ -3,12 +3,13 @@ package org.bukkit.event.vehicle;
+ import org.bukkit.entity.LivingEntity;
+ import org.bukkit.entity.Vehicle;
+ import org.bukkit.event.Cancellable;
++import org.bukkit.event.EntityAction;
+ import org.bukkit.event.HandlerList;
+ 
+ /**
+  * Raised when a living entity exits a vehicle.
+  */
+-public class VehicleExitEvent extends VehicleEvent implements Cancellable {
++public class VehicleExitEvent extends VehicleEvent implements Cancellable, EntityAction {
+     private static final HandlerList handlers = new HandlerList();
+     private boolean cancelled;
+     private final LivingEntity exited;
+@@ -27,6 +28,11 @@ public class VehicleExitEvent extends VehicleEvent implements Cancellable {
+         return exited;
+     }
+ 
++    @Override
++    public LivingEntity getActor() {
++        return getExited();
++    }
++
+     public boolean isCancelled() {
+         return cancelled;
+     }
+diff --git a/src/main/java/org/bukkit/event/vehicle/VehicleMoveEvent.java b/src/main/java/org/bukkit/event/vehicle/VehicleMoveEvent.java
+index 9a13e29..ec2f397 100644
+--- a/src/main/java/org/bukkit/event/vehicle/VehicleMoveEvent.java
++++ b/src/main/java/org/bukkit/event/vehicle/VehicleMoveEvent.java
+@@ -2,12 +2,13 @@ package org.bukkit.event.vehicle;
+ 
+ import org.bukkit.Location;
+ import org.bukkit.entity.Vehicle;
++import org.bukkit.event.EntityAction;
+ import org.bukkit.event.HandlerList;
+ 
+ /**
+  * Raised when a vehicle moves.
+  */
+-public class VehicleMoveEvent extends VehicleEvent {
++public class VehicleMoveEvent extends VehicleEvent implements EntityAction {
+     private static final HandlerList handlers = new HandlerList();
+     private final Location from;
+     private final Location to;
+@@ -19,6 +20,11 @@ public class VehicleMoveEvent extends VehicleEvent {
+         this.to = to;
+     }
+ 
++    @Override
++    public Vehicle getActor() {
++        return getVehicle();
++    }
++
+     /**
+      * Get the previous position.
+      *
+diff --git a/src/main/java/org/bukkit/event/weather/LightningStrikeEvent.java b/src/main/java/org/bukkit/event/weather/LightningStrikeEvent.java
+index 66fd763..00b5127 100644
+--- a/src/main/java/org/bukkit/event/weather/LightningStrikeEvent.java
++++ b/src/main/java/org/bukkit/event/weather/LightningStrikeEvent.java
+@@ -3,12 +3,13 @@ package org.bukkit.event.weather;
+ import org.bukkit.World;
+ import org.bukkit.entity.LightningStrike;
+ import org.bukkit.event.Cancellable;
++import org.bukkit.event.EntityAction;
+ import org.bukkit.event.HandlerList;
+ 
+ /**
+  * Stores data for lightning striking
+  */
+-public class LightningStrikeEvent extends WeatherEvent implements Cancellable {
++public class LightningStrikeEvent extends WeatherEvent implements Cancellable, EntityAction {
+     private static final HandlerList handlers = new HandlerList();
+     private boolean canceled;
+     private final LightningStrike bolt;
+@@ -36,6 +37,11 @@ public class LightningStrikeEvent extends WeatherEvent implements Cancellable {
+     }
+ 
+     @Override
++    public LightningStrike getActor() {
++        return getLightning();
++    }
++
++    @Override
+     public HandlerList getHandlers() {
+         return handlers;
+     }
+diff --git a/src/main/java/org/bukkit/event/world/StructureGrowEvent.java b/src/main/java/org/bukkit/event/world/StructureGrowEvent.java
+index 62d300d..5c1f51f 100644
+--- a/src/main/java/org/bukkit/event/world/StructureGrowEvent.java
++++ b/src/main/java/org/bukkit/event/world/StructureGrowEvent.java
+@@ -7,12 +7,13 @@ import org.bukkit.block.BlockState;
+ import org.bukkit.entity.Player;
+ import org.bukkit.event.Cancellable;
+ import org.bukkit.event.HandlerList;
++import org.bukkit.event.PlayerAction;
+ 
+ /**
+  * Event that is called when an organic structure attempts to grow (Sapling {@literal ->}
+  * Tree), (Mushroom {@literal ->} Huge Mushroom), naturally or using bonemeal.
+  */
+-public class StructureGrowEvent extends WorldEvent implements Cancellable {
++public class StructureGrowEvent extends WorldEvent implements Cancellable, PlayerAction {
+     private static final HandlerList handlers = new HandlerList();
+     private boolean cancelled = false;
+     private final Location location;
+@@ -68,6 +69,11 @@ public class StructureGrowEvent extends WorldEvent implements Cancellable {
+         return player;
+     }
+ 
++    @Override
++    public Player getActor() {
++        return getPlayer();
++    }
++
+     /**
+      * Gets an ArrayList of all blocks associated with the structure.
+      *
+diff --git a/src/test/java/org/bukkit/plugin/TimedRegisteredListenerTest.java b/src/test/java/org/bukkit/plugin/TimedRegisteredListenerTest.java
+index b206b1f..ef75e5a 100644
+--- a/src/test/java/org/bukkit/plugin/TimedRegisteredListenerTest.java
++++ b/src/test/java/org/bukkit/plugin/TimedRegisteredListenerTest.java
+@@ -8,6 +8,7 @@ import org.bukkit.event.EventException;
+ import org.bukkit.event.EventPriority;
+ import org.bukkit.event.Listener;
+ import org.bukkit.event.block.BlockBreakEvent;
++import org.bukkit.event.player.PlayerActionBase;
+ import org.bukkit.event.player.PlayerEvent;
+ import org.bukkit.event.player.PlayerInteractEvent;
+ import org.bukkit.event.player.PlayerMoveEvent;
+@@ -37,7 +38,7 @@ public class TimedRegisteredListenerTest {
+         assertThat(trl.getEventClass(), is((Object) PlayerInteractEvent.class));
+         // Ensure that the closest superclass of the two events is chosen
+         trl.callEvent(moveEvent);
+-        assertThat(trl.getEventClass(), is((Object) PlayerEvent.class));
++        assertThat(trl.getEventClass(), is((Object) PlayerActionBase.class));
+         // As above, so below
+         trl.callEvent(breakEvent);
+         assertThat(trl.getEventClass(), is((Object) Event.class));
+-- 
+1.9.0
+

--- a/Bukkit/0049-Logging-improvements.patch
+++ b/Bukkit/0049-Logging-improvements.patch
@@ -1,0 +1,68 @@
+From 04787828aed5ff5d8d7be6790b0025878abd9362 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Fri, 10 Jul 2015 23:07:53 -0400
+Subject: [PATCH] Logging improvements
+
+
+diff --git a/src/main/java/org/bukkit/plugin/PluginLogger.java b/src/main/java/org/bukkit/plugin/PluginLogger.java
+index f43c10b..f409a28 100644
+--- a/src/main/java/org/bukkit/plugin/PluginLogger.java
++++ b/src/main/java/org/bukkit/plugin/PluginLogger.java
+@@ -1,6 +1,7 @@
+ package org.bukkit.plugin;
+ 
+ import java.util.logging.Level;
++import java.util.logging.LogManager;
+ import java.util.logging.LogRecord;
+ import java.util.logging.Logger;
+ 
+@@ -14,6 +15,25 @@ import java.util.logging.Logger;
+ public class PluginLogger extends Logger {
+     private String pluginName;
+ 
++    public static PluginLogger get(Plugin context) {
++        LogManager lm = LogManager.getLogManager();
++        Logger logger = lm.getLogger(context.getClass().getCanonicalName());
++
++        if(logger instanceof PluginLogger) {
++            return (PluginLogger) logger;
++        } else {
++            PluginLogger pluginLogger = new PluginLogger(context);
++
++            // Register the logger under the plugin's name, unless some other logger is already using the name
++            if(logger == null) {
++                lm.addLogger(pluginLogger);
++                pluginLogger.setParent(context.getServer().getLogger()); // addLogger changes this, change it back
++            }
++
++            return pluginLogger;
++        }
++    }
++
+     /**
+      * Creates a new PluginLogger that extracts the name from a plugin.
+      *
+@@ -24,7 +44,6 @@ public class PluginLogger extends Logger {
+         String prefix = context.getDescription().getPrefix();
+         pluginName = prefix != null ? new StringBuilder().append("[").append(prefix).append("] ").toString() : "[" + context.getDescription().getName() + "] ";
+         setParent(context.getServer().getLogger());
+-        setLevel(Level.ALL);
+     }
+ 
+     @Override
+diff --git a/src/main/java/org/bukkit/plugin/java/JavaPlugin.java b/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
+index 273d14b..9da6dc8 100644
+--- a/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
++++ b/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
+@@ -290,7 +290,7 @@ public abstract class JavaPlugin extends PluginBase {
+         this.dataFolder = dataFolder;
+         this.classLoader = classLoader;
+         this.configFile = new File(dataFolder, "config.yml");
+-        this.logger = new PluginLogger(this);
++        this.logger = PluginLogger.get(this);
+ 
+         if (description.isDatabaseEnabled()) {
+             ServerConfig db = new ServerConfig();
+-- 
+1.9.0
+

--- a/Bukkit/0050-Localize-inventory-titles.patch
+++ b/Bukkit/0050-Localize-inventory-titles.patch
@@ -1,0 +1,172 @@
+From f6bf0833d1b3ccba5ab127c90ee736dc7cb42b37 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Sun, 12 Jul 2015 09:58:54 -0400
+Subject: [PATCH] Localize inventory titles
+
+
+diff --git a/src/main/java/org/bukkit/event/inventory/InventoryType.java b/src/main/java/org/bukkit/event/inventory/InventoryType.java
+index 43be533..0532ec1 100644
+--- a/src/main/java/org/bukkit/event/inventory/InventoryType.java
++++ b/src/main/java/org/bukkit/event/inventory/InventoryType.java
+@@ -6,78 +6,80 @@ public enum InventoryType {
+      * A chest inventory, with 0, 9, 18, 27, 36, 45, or 54 slots of type
+      * CONTAINER.
+      */
+-    CHEST(27,"Chest"),
++    CHEST(27, "Chest", "container.chest"),
+     /**
+      * A dispenser inventory, with 9 slots of type CONTAINER.
+      */
+-    DISPENSER(9,"Dispenser"),
++    DISPENSER(9, "Dispenser", "container.dispenser"),
+     /**
+      * A dropper inventory, with 9 slots of type CONTAINER.
+      */
+-    DROPPER(9, "Dropper"),
++    DROPPER(9, "Dropper", "container.dropper"),
+     /**
+      * A furnace inventory, with a RESULT slot, a CRAFTING slot, and a FUEL
+      * slot.
+      */
+-    FURNACE(3,"Furnace"),
++    FURNACE(3, "Furnace", "container.furnace"),
+     /**
+      * A workbench inventory, with 9 CRAFTING slots and a RESULT slot.
+      */
+-    WORKBENCH(10,"Crafting"),
++    WORKBENCH(10, "Crafting", "container.crafting"),
+     /**
+      * A player's crafting inventory, with 4 CRAFTING slots and a RESULT slot.
+      * Also implies that the 4 ARMOR slots are accessible.
+      */
+-    CRAFTING(5,"Crafting"),
++    CRAFTING(5, "Crafting", "container.crafting"),
+     /**
+      * An enchantment table inventory, with two CRAFTING slots and three
+      * enchanting buttons.
+      */
+-    ENCHANTING(2,"Enchanting"),
++    ENCHANTING(2, "Enchanting", "container.enchant"),
+     /**
+      * A brewing stand inventory, with one FUEL slot and three CRAFTING slots.
+      */
+-    BREWING(5,"Brewing"),
++    BREWING(5,"Brewing", "container.brewing"),
+     /**
+      * A player's inventory, with 9 QUICKBAR slots, 27 CONTAINER slots, 4 ARMOR
+      * slots and 1 offhand slot. The ARMOR and offhand slots may not be visible
+      * to the player, though.
+      */
+-    PLAYER(41,"Player"),
++    PLAYER(41,"Player", "container.inventory"),
+     /**
+      * The creative mode inventory, with only 9 QUICKBAR slots and nothing
+      * else. (The actual creative interface with the items is client-side and
+      * cannot be altered by the server.)
+      */
+-    CREATIVE(9,"Creative"),
++    CREATIVE(9, "Creative", "container.creative"),
+     /**
+      * The merchant inventory, with 2 TRADE-IN slots, and 1 RESULT slot.
+      */
+-    MERCHANT(3,"Villager"),
++    MERCHANT(3, "Villager", "entity.Villager.name"),
+     /**
+      * The ender chest inventory, with 27 slots.
+      */
+-    ENDER_CHEST(27,"Ender Chest"),
++    ENDER_CHEST(27, "Ender Chest", "container.enderchest"),
+     /**
+      * An anvil inventory, with 2 CRAFTING slots and 1 RESULT slot
+      */
+-    ANVIL(3, "Repairing"),
++    ANVIL(3, "Repairing", "container.repair"),
+     /**
+      * A beacon inventory, with 1 CRAFTING slot
+      */
+-    BEACON(1, "container.beacon"),
++    BEACON(1, "Beacon", "container.beacon"),
+     /**
+      * A hopper inventory, with 5 slots of type CONTAINER.
+      */
+-    HOPPER(5, "Item Hopper"),
++    HOPPER(5, "Item Hopper", "container.hopper"),
+     ;
+ 
+     private final int size;
+     private final String title;
++    private final String localizedTitle;
+ 
+-    private InventoryType(int defaultSize, String defaultTitle) {
++    private InventoryType(int defaultSize, String defaultTitle, String localizedTitle) {
+         size = defaultSize;
+         title = defaultTitle;
++        this.localizedTitle = localizedTitle;
+     }
+ 
+     public int getDefaultSize() {
+@@ -88,6 +90,10 @@ public enum InventoryType {
+         return title;
+     }
+ 
++    public String getLocalizedTitle() {
++        return localizedTitle;
++    }
++
+     public enum SlotType {
+         /**
+          * A result slot in a furnace or crafting inventory.
+diff --git a/src/main/java/org/bukkit/inventory/Inventory.java b/src/main/java/org/bukkit/inventory/Inventory.java
+index bac683b..7166baa 100644
+--- a/src/main/java/org/bukkit/inventory/Inventory.java
++++ b/src/main/java/org/bukkit/inventory/Inventory.java
+@@ -4,6 +4,7 @@ import java.util.HashMap;
+ import java.util.List;
+ import java.util.ListIterator;
+ 
++import net.md_5.bungee.api.chat.BaseComponent;
+ import org.bukkit.Location;
+ import org.bukkit.Material;
+ import org.bukkit.Physical;
+@@ -49,13 +50,25 @@ public interface Inventory extends Iterable<ItemStack>, Physical {
+     public void setMaxStackSize(int size);
+ 
+     /**
+-     * Returns the name of the inventory
++     * Returns the name of the inventory in the default server locale (US English)
+      *
+      * @return The String with the name of the inventory
++     * @deprecated not localized, use #getLocalizedName instead
+      */
+     public String getName();
+ 
+     /**
++     * @return true if this inventory has been given a custom name
++     *         false if it is using the default (localized) name
++     */
++    boolean hasCustomName();
++
++    /**
++     * @return the name of this inventory.
++     */
++    BaseComponent getLocalizedName();
++
++    /**
+      * Returns the ItemStack found in the slot at the given index
+      *
+      * @param index The index of the Slot's ItemStack to return
+@@ -377,9 +390,10 @@ public interface Inventory extends Iterable<ItemStack>, Physical {
+     public List<HumanEntity> getViewers();
+ 
+     /**
+-     * Returns the title of this inventory.
++     * Returns the title of this inventory in the default server locale (US English)
+      *
+      * @return A String with the title.
++     * @deprecated not localized, use #getLocalizedName instead
+      */
+     public String getTitle();
+ 
+-- 
+1.9.0
+

--- a/Bukkit/0051-Skull-skin-API.patch
+++ b/Bukkit/0051-Skull-skin-API.patch
@@ -1,0 +1,78 @@
+From 5311c0c5425dc8769424172083171eb3e9bc07d9 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Thu, 6 Aug 2015 22:18:43 -0400
+Subject: [PATCH] Skull skin API
+
+
+diff --git a/src/main/java/org/bukkit/block/Skull.java b/src/main/java/org/bukkit/block/Skull.java
+index 7fbbc6b..2117090 100644
+--- a/src/main/java/org/bukkit/block/Skull.java
++++ b/src/main/java/org/bukkit/block/Skull.java
+@@ -2,6 +2,7 @@ package org.bukkit.block;
+ 
+ import java.util.UUID;
+ import org.bukkit.OfflinePlayer;
++import org.bukkit.Skin;
+ import org.bukkit.SkullType;
+ 
+ /**
+@@ -55,6 +56,21 @@ public interface Skull extends BlockState {
+     public void setOwningPlayer(OfflinePlayer player);
+ 
+     /**
++     * Set the owner and appearance of this skull. A skull with this data set
++     * does not need to fetch anything remotely.
++     *
++     * @param name Username of the skull's owner, can be null (appears in item tooltip)
++     * @param uuid UUID of the skull's owner
++     * @param skin Skull owner's skin
++     */
++    void setOwner(String name, UUID uuid, Skin skin);
++
++    /**
++     * Clear any owner data in this skull
++     */
++    void clearOwner();
++
++    /**
+      * Gets the rotation of the skull in the world
+      *
+      * @return the rotation of the skull
+diff --git a/src/main/java/org/bukkit/inventory/meta/SkullMeta.java b/src/main/java/org/bukkit/inventory/meta/SkullMeta.java
+index fab3119..81d0343 100644
+--- a/src/main/java/org/bukkit/inventory/meta/SkullMeta.java
++++ b/src/main/java/org/bukkit/inventory/meta/SkullMeta.java
+@@ -1,6 +1,9 @@
+ package org.bukkit.inventory.meta;
+ 
++import java.util.UUID;
++
+ import org.bukkit.Material;
++import org.bukkit.Skin;
+ 
+ /**
+  * Represents a skull ({@link Material#SKULL_ITEM}) that can have an owner.
+@@ -32,5 +35,20 @@ public interface SkullMeta extends ItemMeta {
+      */
+     boolean setOwner(String owner);
+ 
++    /**
++     * Set the owner and appearance of this skull. A skull with this data set
++     * does not need to fetch anything remotely.
++     *
++     * @param name Username of the skull's owner, can be null (appears in item tooltip)
++     * @param uuid UUID of the skull's owner
++     * @param skin Skull owner's skin
++     */
++    void setOwner(String name, UUID uuid, Skin skin);
++
++    /**
++     * Clear any owner data in this skull
++     */
++    void clearOwner();
++
+     SkullMeta clone();
+ }
+-- 
+1.9.0
+

--- a/Bukkit/0052-Dynamic-port-allocation.patch
+++ b/Bukkit/0052-Dynamic-port-allocation.patch
@@ -1,0 +1,95 @@
+From ec5c9c8beda776abcd240821d066a0c5df71091a Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Tue, 25 Aug 2015 05:22:19 -0400
+Subject: [PATCH] Dynamic port allocation
+
+
+diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
+index 192f52c..e52d0d4 100644
+--- a/src/main/java/org/bukkit/Bukkit.java
++++ b/src/main/java/org/bukkit/Bukkit.java
+@@ -164,13 +164,39 @@ public final class Bukkit {
+      */
+     public static int getMaxPlayers() {
+         return server.getMaxPlayers();
++
++    }
++    /**
++     * Get the port number specified in the server configuration.
++     * If this is 0, the port is dynamically allocated, and can be
++     * retrieved with {@link #getPort()}.
++     *
++     * @return the configured listening port
++     */
++    public static int getConfiguredPort() {
++        return server.getConfiguredPort();
+     }
+ 
+     /**
+-     * Get the game port that the server runs on.
++     * Get the port that the server is currently listening on.
++     * If the port is dynamic, this method can be used to detect the
++     * ephemeral port that was allocated. If the server is not bound
++     * to a port, this will return 0, which should only happen if
++     * binding failed for some reason.
++     *
++     * @return the currently bound listening port
++     */
++    public static int getBoundPort() {
++        return server.getBoundPort();
++    }
++
++    /**
++     * Get the port that the server is currently listening on,
++     * or the configured port if the server is not currently listening.
+      *
+      * @return the port number of this server
+      */
++    @Deprecated
+     public static int getPort() {
+         return server.getPort();
+     }
+diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
+index b74d880..0e1d140 100644
+--- a/src/main/java/org/bukkit/Server.java
++++ b/src/main/java/org/bukkit/Server.java
+@@ -141,10 +141,35 @@ public interface Server extends PluginMessageRecipient {
+     public int getMaxPlayers();
+ 
+     /**
+-     * Get the game port that the server runs on.
++     * Get the port number specified in the server configuration.
++     * If this is 0, the port is dynamically allocated, and can be
++     * retrieved with {@link #getBoundPort()}.
++     *
++     * @return the configured listening port
++     */
++    int getConfiguredPort();
++
++    /**
++     * Get the port that the server is currently listening on.
++     * If the port is dynamic, this method can be used to detect the
++     * ephemeral port that was allocated. If the server is not bound
++     * to a port, this will return 0, which should only happen if
++     * binding failed for some reason.
++     *
++     * @return the currently bound listening port
++     */
++    int getBoundPort();
++
++    /**
++     * Get the port that the server is currently listening on,
++     * or the configured port if the server is not currently listening.
++     *
++     * Deprecated: use either {@link #getConfiguredPort()} or {@link #getBoundPort()},
++     * depending on what, exactly, you want to know.
+      *
+      * @return the port number of this server
+      */
++    @Deprecated
+     public int getPort();
+ 
+     /**
+-- 
+1.9.0
+

--- a/Bukkit/0053-Plugin-isolation.patch
+++ b/Bukkit/0053-Plugin-isolation.patch
@@ -1,0 +1,622 @@
+From 9a39bb87d59050b458e8b45432362416c199f052 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Fri, 29 May 2015 01:08:37 -0400
+Subject: [PATCH] Plugin isolation
+
+
+diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
+index e52d0d4..c8a829e 100644
+--- a/src/main/java/org/bukkit/Bukkit.java
++++ b/src/main/java/org/bukkit/Bukkit.java
+@@ -369,6 +369,13 @@ public final class Bukkit {
+     }
+ 
+     /**
++     * Should plugins be able to access classes from other plugins that are not explicit dependencies?
++     */
++    public static boolean getIsolatePlugins() {
++        return server.getIsolatePlugins();
++    }
++
++    /**
+      * Gets default ticks per animal spawns value.
+      * <p>
+      * <b>Example Usage:</b>
+diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
+index 0e1d140..ba17c11 100644
+--- a/src/main/java/org/bukkit/Server.java
++++ b/src/main/java/org/bukkit/Server.java
+@@ -304,6 +304,11 @@ public interface Server extends PluginMessageRecipient {
+     public boolean getWaterPushesTNT();
+ 
+     /**
++     * Should plugins be able to access classes from other plugins that are not explicit dependencies?
++     */
++    public boolean getIsolatePlugins();
++
++    /**
+      * Gets default ticks per animal spawns value.
+      * <p>
+      * <b>Example Usage:</b>
+diff --git a/src/main/java/org/bukkit/configuration/serialization/ConfigurationSerialization.java b/src/main/java/org/bukkit/configuration/serialization/ConfigurationSerialization.java
+index e5ddef2..9cd15f4 100644
+--- a/src/main/java/org/bukkit/configuration/serialization/ConfigurationSerialization.java
++++ b/src/main/java/org/bukkit/configuration/serialization/ConfigurationSerialization.java
+@@ -5,10 +5,13 @@ import java.lang.reflect.InvocationTargetException;
+ import java.lang.reflect.Method;
+ import java.lang.reflect.Modifier;
+ import java.util.HashMap;
++import java.util.Iterator;
+ import java.util.Map;
+ import java.util.logging.Level;
+ import java.util.logging.Logger;
+ 
++import com.google.common.collect.HashMultimap;
++import com.google.common.collect.SetMultimap;
+ import org.apache.commons.lang.Validate;
+ import org.bukkit.Color;
+ import org.bukkit.FireworkEffect;
+@@ -16,6 +19,8 @@ import org.bukkit.Location;
+ import org.bukkit.block.banner.Pattern;
+ import org.bukkit.configuration.Configuration;
+ import org.bukkit.inventory.ItemStack;
++import org.bukkit.plugin.Plugin;
++import org.bukkit.plugin.java.JavaPlugin;
+ import org.bukkit.potion.PotionEffect;
+ import org.bukkit.util.BlockVector;
+ import org.bukkit.util.Vector;
+@@ -26,7 +31,9 @@ import org.bukkit.util.Vector;
+ public class ConfigurationSerialization {
+     public static final String SERIALIZED_TYPE_KEY = "==";
+     private final Class<? extends ConfigurationSerializable> clazz;
+-    private static Map<String, Class<? extends ConfigurationSerializable>> aliases = new HashMap<String, Class<? extends ConfigurationSerializable>>();
++    private static final Map<String, Class<? extends ConfigurationSerializable>> aliases = new HashMap<String, Class<? extends ConfigurationSerializable>>();
++    private static final SetMultimap<Plugin, String> pluginToAlias = HashMultimap.create();
++    private static final Map<String, Plugin> aliasToPlugin = new HashMap<String, Plugin>();
+ 
+     static {
+         registerClass(Vector.class);
+@@ -205,8 +212,10 @@ public class ConfigurationSerialization {
+         DelegateDeserialization delegate = clazz.getAnnotation(DelegateDeserialization.class);
+ 
+         if (delegate == null) {
+-            registerClass(clazz, getAlias(clazz));
+-            registerClass(clazz, clazz.getName());
++            synchronized(aliases) {
++                registerClass(clazz, getAlias(clazz));
++                registerClass(clazz, clazz.getName());
++            }
+         }
+     }
+ 
+@@ -219,7 +228,27 @@ public class ConfigurationSerialization {
+      * @see SerializableAs
+      */
+     public static void registerClass(Class<? extends ConfigurationSerializable> clazz, String alias) {
+-        aliases.put(alias, clazz);
++        Plugin plugin = JavaPlugin.class.isAssignableFrom(clazz) ? JavaPlugin.getProvidingPlugin(clazz) : null;
++        registerClass(clazz, alias, plugin);
++    }
++
++    /**
++     * Registers the given alias to the specified {@link
++     * ConfigurationSerializable} class
++     *
++     * @param clazz Class to register
++     * @param alias Alias to register as
++     * @param plugin Plugin that will own the registration
++     * @see SerializableAs
++     */
++    public static void registerClass(Class<? extends ConfigurationSerializable> clazz, String alias, Plugin plugin) {
++        synchronized(aliases) {
++            aliases.put(alias, clazz);
++            if(plugin != null) {
++                pluginToAlias.put(plugin, alias);
++                aliasToPlugin.put(alias, plugin);
++            }
++        }
+     }
+ 
+     /**
+@@ -228,7 +257,11 @@ public class ConfigurationSerialization {
+      * @param alias Alias to unregister
+      */
+     public static void unregisterClass(String alias) {
+-        aliases.remove(alias);
++        synchronized(aliases) {
++            aliases.remove(alias);
++            Plugin plugin = aliasToPlugin.remove(alias);
++            if(plugin != null) pluginToAlias.remove(plugin, alias);
++        }
+     }
+ 
+     /**
+@@ -238,8 +271,24 @@ public class ConfigurationSerialization {
+      * @param clazz Class to unregister
+      */
+     public static void unregisterClass(Class<? extends ConfigurationSerializable> clazz) {
+-        while (aliases.values().remove(clazz)) {
+-            ;
++        synchronized(aliases) {
++            for(Iterator<Map.Entry<String, Class<? extends ConfigurationSerializable>>> iterator = aliases.entrySet().iterator(); iterator.hasNext(); ) {
++                Map.Entry<String, Class<? extends ConfigurationSerializable>> entry = iterator.next();
++                if(clazz.equals(entry.getValue())) {
++                    iterator.remove();
++                    Plugin plugin = aliasToPlugin.remove(entry.getKey());
++                    if(plugin != null) pluginToAlias.remove(plugin, entry.getKey());
++                }
++            }
++        }
++    }
++
++    public static void unregisterAll(Plugin plugin) {
++        synchronized(aliases) {
++            for(String alias : pluginToAlias.removeAll(plugin)) {
++                aliases.remove(alias);
++                aliasToPlugin.remove(alias);
++            }
+         }
+     }
+ 
+@@ -251,7 +300,9 @@ public class ConfigurationSerialization {
+      * @return Registered class, or null if not found
+      */
+     public static Class<? extends ConfigurationSerializable> getClassByAlias(String alias) {
+-        return aliases.get(alias);
++        synchronized(aliases) {
++            return aliases.get(alias);
++        }
+     }
+ 
+     /**
+diff --git a/src/main/java/org/bukkit/plugin/SimplePluginManager.java b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
+index dc71961..89b40f2 100644
+--- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
++++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
+@@ -23,6 +23,7 @@ import org.bukkit.Server;
+ import org.bukkit.command.Command;
+ import org.bukkit.command.PluginCommandYamlParser;
+ import org.bukkit.command.SimpleCommandMap;
++import org.bukkit.configuration.serialization.ConfigurationSerialization;
+ import org.bukkit.event.Event;
+ import org.bukkit.event.EventPriority;
+ import org.bukkit.event.HandlerList;
+@@ -461,6 +462,12 @@ public final class SimplePluginManager implements PluginManager {
+             } catch(Throwable ex) {
+                 server.getLogger().log(Level.SEVERE, "Error occurred (in the plugin loader) while unregistering plugin channels for " + plugin.getDescription().getFullName() + " (Is it up to date?)", ex);
+             }
++
++            try {
++                ConfigurationSerialization.unregisterAll(plugin);
++            } catch (Throwable ex) {
++                server.getLogger().log(Level.SEVERE, "Error occurred (in the plugin loader) while unregistering serializables " + plugin.getDescription().getFullName() + " (Is it up to date?)", ex);
++            }
+         }
+     }
+ 
+diff --git a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
+index 885f8ae..6cb69ba 100644
+--- a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
++++ b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
+@@ -9,10 +9,12 @@ import java.lang.reflect.Method;
+ import java.util.Arrays;
+ import java.util.HashMap;
+ import java.util.HashSet;
+-import java.util.List;
++import java.util.LinkedHashMap;
++import java.util.LinkedHashSet;
+ import java.util.Map;
+ import java.util.Set;
+-import java.util.concurrent.CopyOnWriteArrayList;
++import java.util.concurrent.locks.ReadWriteLock;
++import java.util.concurrent.locks.ReentrantReadWriteLock;
+ import java.util.jar.JarEntry;
+ import java.util.jar.JarFile;
+ import java.util.logging.Level;
+@@ -22,8 +24,6 @@ import org.apache.commons.lang.Validate;
+ import org.bukkit.Server;
+ import org.bukkit.Warning;
+ import org.bukkit.Warning.WarningState;
+-import org.bukkit.configuration.serialization.ConfigurationSerializable;
+-import org.bukkit.configuration.serialization.ConfigurationSerialization;
+ import org.bukkit.event.Event;
+ import org.bukkit.event.EventException;
+ import org.bukkit.event.EventHandler;
+@@ -48,8 +48,8 @@ import org.yaml.snakeyaml.error.YAMLException;
+ public final class JavaPluginLoader implements PluginLoader {
+     final Server server;
+     private final Pattern[] fileFilters = new Pattern[] { Pattern.compile("\\.jar$"), };
+-    private final Map<String, Class<?>> classes = new HashMap<String, Class<?>>();
+-    private final List<PluginClassLoader> loaders = new CopyOnWriteArrayList<PluginClassLoader>();
++    final Map<String, PluginClassLoader> loaders = new LinkedHashMap<String, PluginClassLoader>();
++    final ReadWriteLock loaderLock = new ReentrantReadWriteLock();
+ 
+     /**
+      * This class was not meant to be constructed explicitly
+@@ -114,26 +114,50 @@ public final class JavaPluginLoader implements PluginLoader {
+             ));
+         }
+ 
+-        for (final String pluginName : description.getDepend()) {
+-            Plugin current = server.getPluginManager().getPlugin(pluginName);
++        Set<PluginClassLoader> dependencies = new LinkedHashSet<PluginClassLoader>();
++        loaderLock.readLock().lock();
++        try {
++            for (final String pluginName : description.getDepend()) {
++                PluginClassLoader current = loaders.get(pluginName);
++
++                if (current == null) {
++                    throw new UnknownDependencyException(pluginName);
++                }
++                dependencies.add(current);
++            }
+ 
+-            if (current == null) {
+-                throw new UnknownDependencyException(pluginName);
++            for (final String pluginName : description.getSoftDepend()) {
++                PluginClassLoader current = loaders.get(pluginName);
++                if (current != null) {
++                    dependencies.add(current);
++                }
+             }
++        } finally {
++            loaderLock.readLock().unlock();
+         }
+ 
+         final PluginClassLoader loader;
+         try {
+-            loader = new PluginClassLoader(this, getClass().getClassLoader(), description, dataFolder, file);
+-        } catch (InvalidPluginException ex) {
+-            throw ex;
++            loader = new PluginClassLoader(this, getClass().getClassLoader(), dependencies, description, dataFolder, file);
+         } catch (Throwable ex) {
+             throw new InvalidPluginException(ex);
+         }
+ 
+-        loaders.add(loader);
++        loaderLock.writeLock().lock();
++        try {
++            loaders.put(description.getName(), loader);
++        }
++        finally {
++            loaderLock.writeLock().unlock();
++        }
+ 
+-        return loader.plugin;
++        try {
++            return loader.createPlugin();
++        } catch (InvalidPluginException ex) {
++            throw ex;
++        } catch (Throwable ex) {
++            throw new InvalidPluginException(ex);
++        }
+     }
+ 
+     public PluginDescriptionFile getPluginDescription(File file) throws InvalidDescriptionException {
+@@ -178,49 +202,6 @@ public final class JavaPluginLoader implements PluginLoader {
+         return fileFilters.clone();
+     }
+ 
+-    Class<?> getClassByName(final String name) {
+-        Class<?> cachedClass = classes.get(name);
+-
+-        if (cachedClass != null) {
+-            return cachedClass;
+-        } else {
+-            for (PluginClassLoader loader : loaders) {
+-                try {
+-                    cachedClass = loader.findClass(name, false);
+-                } catch (ClassNotFoundException cnfe) {}
+-                if (cachedClass != null) {
+-                    return cachedClass;
+-                }
+-            }
+-        }
+-        return null;
+-    }
+-
+-    void setClass(final String name, final Class<?> clazz) {
+-        if (!classes.containsKey(name)) {
+-            classes.put(name, clazz);
+-
+-            if (ConfigurationSerializable.class.isAssignableFrom(clazz)) {
+-                Class<? extends ConfigurationSerializable> serializable = clazz.asSubclass(ConfigurationSerializable.class);
+-                ConfigurationSerialization.registerClass(serializable);
+-            }
+-        }
+-    }
+-
+-    private void removeClass(String name) {
+-        Class<?> clazz = classes.remove(name);
+-
+-        try {
+-            if ((clazz != null) && (ConfigurationSerializable.class.isAssignableFrom(clazz))) {
+-                Class<? extends ConfigurationSerializable> serializable = clazz.asSubclass(ConfigurationSerializable.class);
+-                ConfigurationSerialization.unregisterClass(serializable);
+-            }
+-        } catch (NullPointerException ex) {
+-            // Boggle!
+-            // (Native methods throwing NPEs is not fun when you can't stop it before-hand)
+-        }
+-    }
+-
+     public Map<Class<? extends Event>, Set<RegisteredListener>> createRegisteredListeners(Listener listener, final Plugin plugin) {
+         Validate.notNull(plugin, "Plugin can not be null");
+         Validate.notNull(listener, "Listener can not be null");
+@@ -318,11 +299,15 @@ public final class JavaPluginLoader implements PluginLoader {
+ 
+             JavaPlugin jPlugin = (JavaPlugin) plugin;
+ 
+-            PluginClassLoader pluginLoader = (PluginClassLoader) jPlugin.getClassLoader();
++            String pluginName = jPlugin.getDescription().getName();
+ 
+-            if (!loaders.contains(pluginLoader)) {
+-                loaders.add(pluginLoader);
+-                server.getLogger().log(Level.WARNING, "Enabled plugin with unregistered PluginClassLoader " + plugin.getDescription().getFullName());
++            loaderLock.writeLock().lock();
++            try {
++                if (!loaders.containsKey(pluginName)) {
++                    loaders.put(pluginName, (PluginClassLoader) jPlugin.getClassLoader());
++                }
++            } finally {
++                loaderLock.writeLock().unlock();
+             }
+ 
+             try {
+@@ -355,14 +340,21 @@ public final class JavaPluginLoader implements PluginLoader {
+                 server.getLogger().log(Level.SEVERE, "Error occurred while disabling " + plugin.getDescription().getFullName() + " (Is it up to date?)", ex);
+             }
+ 
+-            if (cloader instanceof PluginClassLoader) {
+-                PluginClassLoader loader = (PluginClassLoader) cloader;
+-                loaders.remove(loader);
+-
+-                Set<String> names = loader.getClasses();
++            loaderLock.writeLock().lock();
++            try {
++                loaders.remove(jPlugin.getDescription().getName());
++            } finally {
++                loaderLock.writeLock().unlock();
++            }
+ 
+-                for (String name : names) {
+-                    removeClass(name);
++            if (cloader instanceof PluginClassLoader) {
++                loaderLock.readLock().lock();
++                try {
++                    for(PluginClassLoader other : loaders.values()) {
++                        other.removeDependency((PluginClassLoader) cloader);
++                    }
++                } finally {
++                    loaderLock.readLock().unlock();
+                 }
+             }
+         }
+diff --git a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
+index 13f8633..4e94cc8 100644
+--- a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
++++ b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
+@@ -4,11 +4,13 @@ import java.io.File;
+ import java.net.MalformedURLException;
+ import java.net.URL;
+ import java.net.URLClassLoader;
+-import java.util.HashMap;
+-import java.util.Map;
++import java.util.LinkedHashSet;
+ import java.util.Set;
++import java.util.concurrent.locks.ReadWriteLock;
++import java.util.concurrent.locks.ReentrantReadWriteLock;
+ 
+ import org.apache.commons.lang.Validate;
++import org.bukkit.Bukkit;
+ import org.bukkit.plugin.InvalidPluginException;
+ import org.bukkit.plugin.PluginDescriptionFile;
+ 
+@@ -16,28 +18,42 @@ import org.bukkit.plugin.PluginDescriptionFile;
+  * A ClassLoader for plugins, to allow shared classes across multiple plugins
+  */
+ final class PluginClassLoader extends URLClassLoader {
+-    private final JavaPluginLoader loader;
+-    private final Map<String, Class<?>> classes = new HashMap<String, Class<?>>();
++    private final JavaPluginLoader pluginLoader;
++    private final Set<PluginClassLoader> dependencies;
++    private final Set<PluginClassLoader> linearizedDependencies = new LinkedHashSet<PluginClassLoader>();
++    private final ReadWriteLock dependencyLock = new ReentrantReadWriteLock();
+     private final PluginDescriptionFile description;
+     private final File dataFolder;
+     private final File file;
+-    final JavaPlugin plugin;
+-    private JavaPlugin pluginInit;
+-    private IllegalStateException pluginState;
++    private final boolean isolate;
++    JavaPlugin plugin;
+ 
+-    PluginClassLoader(final JavaPluginLoader loader, final ClassLoader parent, final PluginDescriptionFile description, final File dataFolder, final File file) throws InvalidPluginException, MalformedURLException {
++    static {
++        registerAsParallelCapable();
++    }
++
++    PluginClassLoader(final JavaPluginLoader pluginLoader, final ClassLoader parent, final Set<PluginClassLoader> dependencies, final PluginDescriptionFile description, final File dataFolder, final File file) throws MalformedURLException {
+         super(new URL[] {file.toURI().toURL()}, parent);
+-        Validate.notNull(loader, "Loader cannot be null");
++        Validate.notNull(pluginLoader, "Loader cannot be null");
++        Validate.notNull(parent, "Parent loader cannot be null");
+ 
+-        this.loader = loader;
++        this.pluginLoader = pluginLoader;
+         this.description = description;
+         this.dataFolder = dataFolder;
+         this.file = file;
+ 
++        this.dependencies = dependencies;
++        linearizeDependencies();
++
++        this.isolate = Bukkit.getIsolatePlugins();
++    }
++
++    JavaPlugin createPlugin() throws InvalidPluginException {
++        Validate.isTrue(plugin == null, "Plugin already created");
+         try {
+             Class<?> jarClass;
+             try {
+-                jarClass = Class.forName(description.getMain(), true, this);
++                jarClass = loadLocalClass(description.getMain(), true);
+             } catch (ClassNotFoundException ex) {
+                 throw new InvalidPluginException("Cannot find main class `" + description.getMain() + "'", ex);
+             }
+@@ -50,6 +66,7 @@ final class PluginClassLoader extends URLClassLoader {
+             }
+ 
+             plugin = pluginClass.newInstance();
++            return plugin;
+         } catch (IllegalAccessException ex) {
+             throw new InvalidPluginException("No public constructor", ex);
+         } catch (InstantiationException ex) {
+@@ -57,50 +74,118 @@ final class PluginClassLoader extends URLClassLoader {
+         }
+     }
+ 
+-    @Override
+-    protected Class<?> findClass(String name) throws ClassNotFoundException {
+-        return findClass(name, true);
++    /**
++     * Flatten the dependency tree using a depth-first tree walk
++     */
++    private void linearizeDependencies() {
++        linearizedDependencies.clear();
++        linearizedDependencies.add(this);
++        for(PluginClassLoader dependency : dependencies) {
++            linearizedDependencies.addAll(dependency.linearizedDependencies);
++        }
+     }
+ 
+-    Class<?> findClass(String name, boolean checkGlobal) throws ClassNotFoundException {
+-        if (name.startsWith("org.bukkit.") || name.startsWith("net.minecraft.")) {
+-            throw new ClassNotFoundException(name);
++    /**
++     * Similar to the parent method, except it tries to find the class locally
++     * before delegating to the parent loader. The effect is that local classes
++     * are always loaded when available, even if a class with the same name is
++     * already available from the parent loader. This allows multiple plugins to
++     * use different versions of the same class.
++     */
++    @Override
++    protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
++        if(isolate) {
++            // Local, dependencies, Bukkit
++            try {
++                // Search local plugin, followed by dependencies
++                return loadDependencyClass(name, resolve);
++            } catch(ClassNotFoundException e) {
++                // Search non-plugin classes (
++                return loadBukkitClass(name, resolve);
++            }
++        } else {
++            // Bukkit, all plugins in loading order
++            try {
++                return loadBukkitClass(name, resolve);
++            } catch(ClassNotFoundException e) {
++                // Search all plugins in load order
++                return loadPluginClass(name, resolve);
++            }
+         }
+-        Class<?> result = classes.get(name);
++    }
+ 
+-        if (result == null) {
+-            if (checkGlobal) {
+-                result = loader.getClassByName(name);
++    /**
++     * Load a class from the first dependency that provides it
++     */
++    Class<?> loadDependencyClass(String name, boolean resolve) throws ClassNotFoundException {
++        dependencyLock.readLock().lock();
++        try {
++            for(PluginClassLoader dependency : linearizedDependencies) {
++                try {
++                    return dependency.loadLocalClass(name, resolve);
++                } catch(ClassNotFoundException ignored) {}
+             }
++        } finally {
++            dependencyLock.readLock().unlock();
++        }
+ 
+-            if (result == null) {
+-                result = super.findClass(name);
++        throw new ClassNotFoundException(name);
++    }
+ 
+-                if (result != null) {
+-                    loader.setClass(name, result);
+-                }
+-            }
++    /**
++     * Load a class from this plugin
++     */
++    Class<?> loadLocalClass(String name, boolean resolve) throws ClassNotFoundException {
++        synchronized(getClassLoadingLock(name)) {
++            Class<?> cls = findLoadedClass(name);
++            if(cls == null) cls = findClass(name);
++            if(resolve) resolveClass(cls);
++            return cls;
++        }
++    }
+ 
+-            classes.put(name, result);
++    /**
++     * Load a class from the first plugin that provides it (including this plugin), in loading order.
++     */
++    Class<?> loadPluginClass(String name, boolean resolve) throws ClassNotFoundException {
++        pluginLoader.loaderLock.readLock().lock();
++        try {
++            for(PluginClassLoader loader : pluginLoader.loaders.values()) {
++                try {
++                    return loader.loadLocalClass(name, resolve);
++                } catch(ClassNotFoundException ignored) {}
++            }
++        } finally {
++            pluginLoader.loaderLock.readLock().unlock();
+         }
+ 
+-        return result;
++        throw new ClassNotFoundException(name);
+     }
+ 
+-    Set<String> getClasses() {
+-        return classes.keySet();
++    Class<?> loadBukkitClass(String name, boolean resolve) throws ClassNotFoundException {
++        Class<?> cls = getParent().loadClass(name);
++        if(resolve) resolveClass(cls);
++        return cls;
++    }
++
++    void removeDependency(PluginClassLoader dependency) {
++        dependencyLock.writeLock().lock();
++        try {
++            dependencies.remove(dependency);
++            linearizeDependencies();
++        } finally {
++            dependencyLock.writeLock().unlock();
++        }
+     }
+ 
+     synchronized void initialize(JavaPlugin javaPlugin) {
+         Validate.notNull(javaPlugin, "Initializing plugin cannot be null");
+         Validate.isTrue(javaPlugin.getClass().getClassLoader() == this, "Cannot initialize plugin outside of this class loader");
+-        if (this.plugin != null || this.pluginInit != null) {
+-            throw new IllegalArgumentException("Plugin already initialized!", pluginState);
+-        }
+ 
+-        pluginState = new IllegalStateException("Initial initialization");
+-        this.pluginInit = javaPlugin;
++        if (this.plugin != null) {
++            throw new IllegalArgumentException("Plugin already initialized!");
++        }
+ 
+-        javaPlugin.init(loader, loader.server, description, dataFolder, file, this);
++        javaPlugin.init(pluginLoader, pluginLoader.server, description, dataFolder, file, this);
+     }
+ }
+-- 
+1.9.0
+

--- a/Bukkit/0054-Implement-minecraft-api.patch
+++ b/Bukkit/0054-Implement-minecraft-api.patch
@@ -1,0 +1,284 @@
+From 40c557caee9bf04ee9891c0e6962d87c7e1a4684 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Thu, 4 Feb 2016 04:59:45 -0500
+Subject: [PATCH] Implement minecraft-api
+
+
+diff --git a/pom.xml b/pom.xml
+index 91f8160..b790c9c 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -84,10 +84,8 @@
+         </dependency>
+         <dependency>
+             <groupId>tc.oc</groupId>
+-            <artifactId>bungeecord-chat</artifactId>
++            <artifactId>minecraft-api</artifactId>
+             <version>1.11-SNAPSHOT</version>
+-            <type>jar</type>
+-            <scope>compile</scope>
+         </dependency>
+ 
+         <!-- testing -->
+diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
+index ba17c11..f36daaa 100644
+--- a/src/main/java/org/bukkit/Server.java
++++ b/src/main/java/org/bukkit/Server.java
+@@ -52,7 +52,7 @@ import org.bukkit.inventory.meta.ItemMeta;
+ /**
+  * Represents a server implementation.
+  */
+-public interface Server extends PluginMessageRecipient {
++public interface Server extends PluginMessageRecipient, tc.oc.minecraft.api.server.LocalServer {
+ 
+     /**
+      * Used for all administrative messages, such as an operator using a
+diff --git a/src/main/java/org/bukkit/command/CommandSender.java b/src/main/java/org/bukkit/command/CommandSender.java
+index 52c5947..a0fffb2 100644
+--- a/src/main/java/org/bukkit/command/CommandSender.java
++++ b/src/main/java/org/bukkit/command/CommandSender.java
+@@ -3,7 +3,7 @@ package org.bukkit.command;
+ import org.bukkit.Server;
+ import org.bukkit.permissions.Permissible;
+ 
+-public interface CommandSender extends Permissible {
++public interface CommandSender extends Permissible, tc.oc.minecraft.api.command.CommandSender {
+ 
+     /**
+      * Sends this sender a message
+diff --git a/src/main/java/org/bukkit/command/ConsoleCommandSender.java b/src/main/java/org/bukkit/command/ConsoleCommandSender.java
+index f309c2e..a460d33 100644
+--- a/src/main/java/org/bukkit/command/ConsoleCommandSender.java
++++ b/src/main/java/org/bukkit/command/ConsoleCommandSender.java
+@@ -2,5 +2,5 @@ package org.bukkit.command;
+ 
+ import org.bukkit.conversations.Conversable;
+ 
+-public interface ConsoleCommandSender extends CommandSender, Conversable {
++public interface ConsoleCommandSender extends CommandSender, Conversable, tc.oc.minecraft.api.command.ConsoleCommandSender {
+ }
+diff --git a/src/main/java/org/bukkit/configuration/Configuration.java b/src/main/java/org/bukkit/configuration/Configuration.java
+index 52e3ac4..5d9636d 100644
+--- a/src/main/java/org/bukkit/configuration/Configuration.java
++++ b/src/main/java/org/bukkit/configuration/Configuration.java
+@@ -5,7 +5,7 @@ import java.util.Map;
+ /**
+  * Represents a source of configurable options and settings
+  */
+-public interface Configuration extends ConfigurationSection {
++public interface Configuration extends ConfigurationSection, tc.oc.minecraft.api.configuration.Configuration {
+     /**
+      * Sets the default value of the given path as provided.
+      * <p>
+diff --git a/src/main/java/org/bukkit/configuration/ConfigurationSection.java b/src/main/java/org/bukkit/configuration/ConfigurationSection.java
+index 166f2a6..40fcb0f 100644
+--- a/src/main/java/org/bukkit/configuration/ConfigurationSection.java
++++ b/src/main/java/org/bukkit/configuration/ConfigurationSection.java
+@@ -12,7 +12,7 @@ import org.bukkit.inventory.ItemStack;
+ /**
+  * Represents a section of a {@link Configuration}
+  */
+-public interface ConfigurationSection {
++public interface ConfigurationSection extends tc.oc.minecraft.api.configuration.ConfigurationSection {
+     /**
+      * Gets a set containing all keys in this section.
+      * <p>
+@@ -767,6 +767,8 @@ public interface ConfigurationSection {
+      */
+     public boolean isColor(String path);
+ 
++    ConfigurationSection getSection(String path);
++
+     /**
+      * Gets the requested ConfigurationSection by path.
+      * <p>
+@@ -825,4 +827,6 @@ public interface ConfigurationSection {
+      * @throws IllegalArgumentException Thrown if path is null.
+      */
+     public void addDefault(String path, Object value);
++
++    ConfigurationSection needSection(String path) throws tc.oc.minecraft.api.configuration.InvalidConfigurationException;
+ }
+diff --git a/src/main/java/org/bukkit/configuration/InvalidConfigurationException.java b/src/main/java/org/bukkit/configuration/InvalidConfigurationException.java
+index d23480e..8944900 100644
+--- a/src/main/java/org/bukkit/configuration/InvalidConfigurationException.java
++++ b/src/main/java/org/bukkit/configuration/InvalidConfigurationException.java
+@@ -4,7 +4,7 @@ package org.bukkit.configuration;
+  * Exception thrown when attempting to load an invalid {@link Configuration}
+  */
+ @SuppressWarnings("serial")
+-public class InvalidConfigurationException extends Exception {
++public class InvalidConfigurationException extends tc.oc.minecraft.api.configuration.InvalidConfigurationException {
+ 
+     /**
+      * Creates a new instance of InvalidConfigurationException without a
+diff --git a/src/main/java/org/bukkit/configuration/MemorySection.java b/src/main/java/org/bukkit/configuration/MemorySection.java
+index 1f4c8ce..f032374 100644
+--- a/src/main/java/org/bukkit/configuration/MemorySection.java
++++ b/src/main/java/org/bukkit/configuration/MemorySection.java
+@@ -14,11 +14,12 @@ import org.bukkit.Color;
+ import org.bukkit.OfflinePlayer;
+ import org.bukkit.inventory.ItemStack;
+ import org.bukkit.util.Vector;
++import tc.oc.minecraft.api.configuration.AbstractConfigurationSection;
+ 
+ /**
+  * A type of {@link ConfigurationSection} that is stored in memory.
+  */
+-public class MemorySection implements ConfigurationSection {
++public class MemorySection extends AbstractConfigurationSection implements ConfigurationSection {
+     protected final Map<String, Object> map = new LinkedHashMap<String, Object>();
+     private final Configuration root;
+     private final ConfigurationSection parent;
+@@ -68,6 +69,11 @@ public class MemorySection implements ConfigurationSection {
+         this.fullPath = createPath(parent, path);
+     }
+ 
++    @Override
++    public java.util.Collection<String> getKeys() {
++        return getKeys(false);
++    }
++
+     public Set<String> getKeys(boolean deep) {
+         Set<String> result = new LinkedHashSet<String>();
+ 
+@@ -683,6 +689,17 @@ public class MemorySection implements ConfigurationSection {
+         return val instanceof Color;
+     }
+ 
++    @Override
++    public ConfigurationSection getSection(String path) {
++        final ConfigurationSection section = getConfigurationSection(path);
++        return section != null ? section : createSection(path);
++    }
++
++    @Override
++    public ConfigurationSection needSection(String path) throws tc.oc.minecraft.api.configuration.InvalidConfigurationException {
++        return needType(path, ConfigurationSection.class);
++    }
++
+     public ConfigurationSection getConfigurationSection(String path) {
+         Object val = get(path, null);
+         if (val != null) {
+diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
+index 41a4bd5..72cf253 100644
+--- a/src/main/java/org/bukkit/entity/Player.java
++++ b/src/main/java/org/bukkit/entity/Player.java
+@@ -29,7 +29,7 @@ import org.bukkit.util.RayBlockIntersection;
+ /**
+  * Represents a player, connected or not
+  */
+-public interface Player extends HumanEntity, Conversable, CommandSender, OfflinePlayer, PluginMessageRecipient {
++public interface Player extends HumanEntity, Conversable, CommandSender, OfflinePlayer, PluginMessageRecipient, tc.oc.minecraft.api.entity.Player {
+ 
+     /**
+      * Set a fake name for this player when viewed by the given player.
+diff --git a/src/main/java/org/bukkit/event/Listener.java b/src/main/java/org/bukkit/event/Listener.java
+index ff083e6..2dbb6ad 100644
+--- a/src/main/java/org/bukkit/event/Listener.java
++++ b/src/main/java/org/bukkit/event/Listener.java
+@@ -3,4 +3,4 @@ package org.bukkit.event;
+ /**
+  * Simple interface for tagging all EventListeners
+  */
+-public interface Listener {}
++public interface Listener extends tc.oc.minecraft.api.event.Listener {}
+diff --git a/src/main/java/org/bukkit/permissions/Permissible.java b/src/main/java/org/bukkit/permissions/Permissible.java
+index a7c0ef5..bebbcb7 100644
+--- a/src/main/java/org/bukkit/permissions/Permissible.java
++++ b/src/main/java/org/bukkit/permissions/Permissible.java
+@@ -7,7 +7,7 @@ import org.bukkit.plugin.Plugin;
+ /**
+  * Represents an object that may be assigned permissions
+  */
+-public interface Permissible extends ServerOperator {
++public interface Permissible extends ServerOperator, tc.oc.minecraft.api.permissions.Permissible {
+ 
+     /**
+      * Checks if this object contains an override for the specified
+diff --git a/src/main/java/org/bukkit/plugin/Plugin.java b/src/main/java/org/bukkit/plugin/Plugin.java
+index 7bdc809..0d21654 100644
+--- a/src/main/java/org/bukkit/plugin/Plugin.java
++++ b/src/main/java/org/bukkit/plugin/Plugin.java
+@@ -16,7 +16,7 @@ import com.avaje.ebean.EbeanServer;
+  * <p>
+  * The use of {@link PluginBase} is recommended for actual Implementation
+  */
+-public interface Plugin extends TabExecutor {
++public interface Plugin extends TabExecutor, tc.oc.minecraft.api.plugin.Plugin, tc.oc.minecraft.api.configuration.Configurable {
+     /**
+      * Returns the folder that the plugin data's files are located in. The
+      * folder may not yet exist.
+diff --git a/src/main/java/org/bukkit/plugin/PluginDescriptionFile.java b/src/main/java/org/bukkit/plugin/PluginDescriptionFile.java
+index b93569f..e4eddfb 100644
+--- a/src/main/java/org/bukkit/plugin/PluginDescriptionFile.java
++++ b/src/main/java/org/bukkit/plugin/PluginDescriptionFile.java
+@@ -174,7 +174,7 @@ import com.google.common.collect.ImmutableSet;
+  *      inferno.burningdeaths: true
+  *</pre></blockquote>
+  */
+-public final class PluginDescriptionFile {
++public final class PluginDescriptionFile implements tc.oc.minecraft.api.plugin.PluginDescription {
+     private static final ThreadLocal<Yaml> YAML = new ThreadLocal<Yaml>() {
+         @Override
+         protected Yaml initialValue() {
+diff --git a/src/main/java/org/bukkit/plugin/PluginManager.java b/src/main/java/org/bukkit/plugin/PluginManager.java
+index e5638d5..15f6218 100644
+--- a/src/main/java/org/bukkit/plugin/PluginManager.java
++++ b/src/main/java/org/bukkit/plugin/PluginManager.java
+@@ -8,11 +8,13 @@ import org.bukkit.event.EventPriority;
+ import org.bukkit.event.Listener;
+ import org.bukkit.permissions.Permissible;
+ import org.bukkit.permissions.Permission;
++import tc.oc.minecraft.api.event.EventBus;
++import tc.oc.minecraft.api.plugin.PluginFinder;
+ 
+ /**
+  * Handles all plugin management from the Server
+  */
+-public interface PluginManager {
++public interface PluginManager extends PluginFinder, EventBus {
+ 
+     /**
+      * Registers the specified plugin loader
+diff --git a/src/main/java/org/bukkit/plugin/SimplePluginManager.java b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
+index 89b40f2..c4adbd8 100644
+--- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
++++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
+@@ -365,6 +365,11 @@ public final class SimplePluginManager implements PluginManager {
+         return plugins.toArray(new Plugin[0]);
+     }
+ 
++    @Override
++    public Collection<? extends Plugin> getAllPlugins() {
++        return java.util.Arrays.asList(getPlugins());
++    }
++
+     /**
+      * Checks if the given plugin is enabled or not
+      * <p>
+@@ -537,6 +542,21 @@ public final class SimplePluginManager implements PluginManager {
+         }
+     }
+ 
++    @Override
++    public void registerListener(tc.oc.minecraft.api.plugin.Plugin plugin, tc.oc.minecraft.api.event.Listener listener) {
++        registerEvents((Listener) listener, (Plugin) plugin);
++    }
++
++    @Override
++    public void unregisterListener(tc.oc.minecraft.api.event.Listener listener) {
++        HandlerList.unregisterAll((Listener) listener);
++    }
++
++    @Override
++    public void unregisterListeners(tc.oc.minecraft.api.plugin.Plugin plugin) {
++        HandlerList.unregisterAll((Plugin) plugin);
++    }
++
+     public void registerEvents(Listener listener, Plugin plugin) {
+         if (!plugin.isEnabled()) {
+             throw new IllegalPluginAccessException("Plugin attempted to register " + listener + " while not enabled");
+-- 
+1.9.0
+

--- a/Bukkit/0055-Arrow-pickup-rule-API.patch
+++ b/Bukkit/0055-Arrow-pickup-rule-API.patch
@@ -1,0 +1,34 @@
+From 82a7792559ad0f30176df3d406fc23030d6fa8bb Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Fri, 4 Mar 2016 03:13:18 -0500
+Subject: [PATCH] Arrow pickup rule API
+
+
+diff --git a/src/main/java/org/bukkit/entity/Arrow.java b/src/main/java/org/bukkit/entity/Arrow.java
+index e49eef0..819d3fb 100644
+--- a/src/main/java/org/bukkit/entity/Arrow.java
++++ b/src/main/java/org/bukkit/entity/Arrow.java
+@@ -39,4 +39,20 @@ public interface Arrow extends Projectile {
+      * @param critical whether or not it should be critical
+      */
+     public void setCritical(boolean critical);
++
++    /**
++     * Which players can pickup this arrow as an item?
++     *
++     * This is generally true only if the arrow was NOT fired from a bow with the infinity enchantment.
++     */
++    PickupRule getPickupRule();
++
++    /**
++     * Set the rule for which players can pickup this arrow as an item.
++     */
++    void setPickupRule(PickupRule rule);
++
++    enum PickupRule {
++        DISALLOWED, ALLOWED, CREATIVE_ONLY
++    }
+ }
+-- 
+1.9.0
+

--- a/Bukkit/0056-Multi-trade-API.patch
+++ b/Bukkit/0056-Multi-trade-API.patch
@@ -1,0 +1,28 @@
+From 237d6b047c474c0b58a0debbac2cff7c92549e57 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Fri, 4 Mar 2016 04:18:12 -0500
+Subject: [PATCH] Multi-trade API
+
+
+diff --git a/src/main/java/org/bukkit/entity/HumanEntity.java b/src/main/java/org/bukkit/entity/HumanEntity.java
+index ede84ef..e001b14 100644
+--- a/src/main/java/org/bukkit/entity/HumanEntity.java
++++ b/src/main/java/org/bukkit/entity/HumanEntity.java
+@@ -119,6 +119,14 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, Permissible, Inv
+     public InventoryView openMerchant(Villager trader, boolean force);
+ 
+     /**
++     * Makes a copy of the given villager's current trading offers and opens
++     * a trading window for this player, allowing them to interact with those
++     * offers, without affecting the villager's state, or any other players who
++     * might be trading with the villager.
++     */
++    public InventoryView openMerchantCopy(Villager trader);
++
++    /**
+      * Starts a trade between the player and the merchant.
+      *
+      * Note that only one player may trade with a merchant at once. You must use
+-- 
+1.9.0
+

--- a/Bukkit/0057-Arrow-damage-API.patch
+++ b/Bukkit/0057-Arrow-damage-API.patch
@@ -1,0 +1,41 @@
+From a52ba8184dba04f8ca5018eb0d091d52f7600eee Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Fri, 4 Mar 2016 04:36:30 -0500
+Subject: [PATCH] Arrow damage API
+
+
+diff --git a/src/main/java/org/bukkit/entity/Arrow.java b/src/main/java/org/bukkit/entity/Arrow.java
+index 819d3fb..7963208 100644
+--- a/src/main/java/org/bukkit/entity/Arrow.java
++++ b/src/main/java/org/bukkit/entity/Arrow.java
+@@ -6,6 +6,27 @@ package org.bukkit.entity;
+ public interface Arrow extends Projectile {
+ 
+     /**
++     * Get the base damage value for this arrow. This value is affected
++     * by the power enchantment of the bow that fired the arrow. Normal
++     * arrows fired by a player from an unenchanted bow have a damage
++     * value of 2.
++     *
++     * The actual damage delivered is derived from this value, but also
++     * depends on the velocity of the arrow at the moment of impact,
++     * and whether or not the arrow is critical.
++     *
++     * @see #setDamage(double)
++     */
++    double getDamage();
++
++    /**
++     * Set the base damage value for this arrow.
++     *
++     * @see #getDamage()
++     */
++    void setDamage(double damage);
++
++    /**
+      * Gets the knockback strength for an arrow, which is the
+      * {@link org.bukkit.enchantments.Enchantment#KNOCKBACK KnockBack} level
+      * of the bow that shot it.
+-- 
+1.9.0
+

--- a/Bukkit/0058-Absorption-API.patch
+++ b/Bukkit/0058-Absorption-API.patch
@@ -1,0 +1,30 @@
+From 7ffe87eb319156ef6e15d90b7d84d4841d4af44c Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Fri, 4 Mar 2016 05:57:57 -0500
+Subject: [PATCH] Absorption API
+
+
+diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
+index 183134e..3a9f98d 100644
+--- a/src/main/java/org/bukkit/entity/LivingEntity.java
++++ b/src/main/java/org/bukkit/entity/LivingEntity.java
+@@ -227,6 +227,16 @@ public interface LivingEntity extends Attributable, Entity, Damageable, Projecti
+     public void setNoDamageTicks(int ticks);
+ 
+     /**
++     * Get the amount of absorption this entity currently has, in half-hearts.
++     */
++    float getAbsorption();
++
++    /**
++     * Set the amount of absorption this entity currently has, in half-hearts.
++     */
++    void setAbsorption(float absorption);
++
++    /**
+      * Gets the player identified as the killer of the living entity.
+      * <p>
+      * May be null.
+-- 
+1.9.0
+

--- a/Bukkit/0059-Enhanced-boss-bar-API.patch
+++ b/Bukkit/0059-Enhanced-boss-bar-API.patch
@@ -1,0 +1,91 @@
+From d1e419d75770f71c625438ad312121c42e67e377 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Sat, 5 Mar 2016 01:41:34 -0500
+Subject: [PATCH] Enhanced boss bar API
+
+
+diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
+index c8a829e..f1be862 100644
+--- a/src/main/java/org/bukkit/Bukkit.java
++++ b/src/main/java/org/bukkit/Bukkit.java
+@@ -1228,7 +1228,7 @@ public final class Bukkit {
+      * @param flags an optional list of flags to set on the boss bar
+      * @return the created boss bar
+      */
+-    public static BossBar createBossBar(String title, BarColor color, BarStyle style, BarFlag... flags) {
++    public static BossBar createBossBar(net.md_5.bungee.api.chat.BaseComponent title, BarColor color, BarStyle style, BarFlag... flags) {
+         return server.createBossBar(title, color, style, flags);
+     }
+ 
+diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
+index f36daaa..0d8192d 100644
+--- a/src/main/java/org/bukkit/Server.java
++++ b/src/main/java/org/bukkit/Server.java
+@@ -1024,7 +1024,7 @@ public interface Server extends PluginMessageRecipient, tc.oc.minecraft.api.serv
+      * @param flags an optional list of flags to set on the boss bar
+      * @return the created boss bar
+      */
+-    BossBar createBossBar(String title, BarColor color, BarStyle style, BarFlag ...flags);
++    BossBar createBossBar(net.md_5.bungee.api.chat.BaseComponent title, BarColor color, BarStyle style, BarFlag ...flags);
+ 
+     /**
+      * @see UnsafeValues
+diff --git a/src/main/java/org/bukkit/boss/BossBar.java b/src/main/java/org/bukkit/boss/BossBar.java
+index effc329..1a7ca56 100644
+--- a/src/main/java/org/bukkit/boss/BossBar.java
++++ b/src/main/java/org/bukkit/boss/BossBar.java
+@@ -1,8 +1,10 @@
+ package org.bukkit.boss;
+ 
++import net.md_5.bungee.api.chat.BaseComponent;
+ import org.bukkit.entity.Player;
+ 
+ import java.util.List;
++import java.util.Set;
+ 
+ public interface BossBar {
+ 
+@@ -11,14 +13,14 @@ public interface BossBar {
+      *
+      * @return the title of the bar
+      */
+-    String getTitle();
++    BaseComponent getTitle();
+ 
+     /**
+      * Sets the title of this boss bar
+      *
+      * @param title the title of the bar
+      */
+-    void setTitle(String title);
++    void setTitle(BaseComponent title);
+ 
+     /**
+      * Returns the color of this boss bar
+@@ -49,6 +51,11 @@ public interface BossBar {
+     void setStyle(BarStyle style);
+ 
+     /**
++     * Replace the entire set of flags for this boss bar
++     */
++    void setFlags(Set<BarFlag> flags);
++
++    /**
+      * Remove an existing flag on this boss bar
+      *
+      * @param flag the existing flag to remove
+@@ -141,4 +148,11 @@ public interface BossBar {
+      */
+     @Deprecated
+     void hide();
++
++    /**
++     * Set all properties of this boss bar at once. This will send no more than a single packet to
++     * each client. It will be the smallest packet that can carry all the properties that actually
++     * changed. If no properties change, then no packet will be sent at all.
++     */
++    void update(BaseComponent title, double progress, BarColor color, BarStyle style, Set<BarFlag> flags);
+ }
+-- 
+1.9.0
+

--- a/Bukkit/0060-Empty-chunk-API.patch
+++ b/Bukkit/0060-Empty-chunk-API.patch
@@ -1,0 +1,25 @@
+From 157dfc9b6360f384d85e831461dc920b75f595a6 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Sun, 6 Mar 2016 03:43:13 -0500
+Subject: [PATCH] Empty chunk API
+
+
+diff --git a/src/main/java/org/bukkit/Chunk.java b/src/main/java/org/bukkit/Chunk.java
+index 7ee47f4..1d6126d 100644
+--- a/src/main/java/org/bukkit/Chunk.java
++++ b/src/main/java/org/bukkit/Chunk.java
+@@ -52,6 +52,11 @@ public interface Chunk extends Physical {
+     Set<Block> getBlocks(Material material);
+ 
+     /**
++     * Is this chunk entirely filled with air blocks?
++     */
++    boolean isEmpty();
++
++    /**
+      * Capture thread-safe read-only snapshot of chunk data
+      *
+      * @return ChunkSnapshot
+-- 
+1.9.0
+

--- a/Bukkit/0061-Registration-API.patch
+++ b/Bukkit/0061-Registration-API.patch
@@ -1,0 +1,192 @@
+From 4bec3348c8fde5a383ce74b49912ddb27c89b337 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Thu, 10 Mar 2016 15:07:43 -0500
+Subject: [PATCH] Registration API
+
+
+diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
+index f1be862..3a92082 100644
+--- a/src/main/java/org/bukkit/Bukkit.java
++++ b/src/main/java/org/bukkit/Bukkit.java
+@@ -37,6 +37,7 @@ import org.bukkit.permissions.Permissible;
+ import org.bukkit.plugin.PluginManager;
+ import org.bukkit.plugin.ServicesManager;
+ import org.bukkit.plugin.messaging.Messenger;
++import org.bukkit.registry.Key;
+ import org.bukkit.scheduler.BukkitScheduler;
+ import org.bukkit.scoreboard.ScoreboardManager;
+ import org.bukkit.util.CachedServerIcon;
+@@ -52,6 +53,7 @@ import org.bukkit.inventory.meta.ItemMeta;
+  * Represents the Bukkit core, for version and Server singleton handling
+  */
+ public final class Bukkit {
++    private static BukkitRuntime runtime;
+     private static Server server;
+ 
+     /**
+@@ -59,6 +61,24 @@ public final class Bukkit {
+      */
+     private Bukkit() {}
+ 
++    public static BukkitRuntime runtime() {
++        if(runtime == null) {
++            throw new IllegalStateException("No Bukkit runtime defined");
++        }
++        return runtime;
++    }
++
++    public static BukkitRuntime getRuntime() {
++        return runtime;
++    }
++
++    public static void setRuntime(BukkitRuntime runtime) {
++        if(runtime != null && Bukkit.runtime != null) {
++            throw new UnsupportedOperationException("Cannot redefine Bukkit runtime");
++        }
++        Bukkit.runtime = runtime;
++    }
++
+     /**
+      * Gets the current {@link Server} singleton
+      *
+@@ -79,7 +99,7 @@ public final class Bukkit {
+         if (Bukkit.server != null) {
+             throw new UnsupportedOperationException("Cannot redefine singleton Server");
+         }
+-
++        setRuntime(server);
+         Bukkit.server = server;
+         server.getLogger().info("This server is running " + getName() + " version " + getVersion() + " (Implementing API version " + getBukkitVersion() + ")");
+     }
+@@ -1117,7 +1137,7 @@ public final class Bukkit {
+      * @see ItemFactory
+      */
+     public static ItemFactory getItemFactory() {
+-        return server.getItemFactory();
++        return runtime().getItemFactory();
+     }
+ 
+     /**
+@@ -1207,12 +1227,12 @@ public final class Bukkit {
+ 
+     /**
+      * Create a ChunkData for use in a generator.
+-     * 
++     *
+      * See {@link ChunkGenerator#generateChunkData(org.bukkit.World, java.util.Random, int, int, org.bukkit.generator.ChunkGenerator.BiomeGrid)}
+-     * 
++     *
+      * @param world the world to create the ChunkData for
+      * @return a new ChunkData for the world
+-     * 
++     *
+      */
+     public static ChunkGenerator.ChunkData createChunkData(World world) {
+         return server.createChunkData(world);
+@@ -1258,4 +1278,12 @@ public final class Bukkit {
+     public static void broadcast(net.md_5.bungee.api.chat.BaseComponent... components) {
+         server.broadcast(components);
+     }
++
++    public static Key key(String prefix, String id) {
++        return runtime().key(prefix, id);
++    }
++
++    public static Key key(String id) {
++        return runtime().key(id);
++    }
+ }
+diff --git a/src/main/java/org/bukkit/BukkitRuntime.java b/src/main/java/org/bukkit/BukkitRuntime.java
+new file mode 100644
+index 0000000..1ed31cb
+--- /dev/null
++++ b/src/main/java/org/bukkit/BukkitRuntime.java
+@@ -0,0 +1,20 @@
++package org.bukkit;
++
++import org.bukkit.inventory.ItemFactory;
++import org.bukkit.inventory.meta.ItemMeta;
++import org.bukkit.registry.Key;
++
++public interface BukkitRuntime {
++
++    Key key(String prefix, String id);
++
++    Key key(String key);
++
++    /**
++     * Gets the instance of the item factory (for {@link ItemMeta}).
++     *
++     * @return the item factory
++     * @see ItemFactory
++     */
++    ItemFactory getItemFactory();
++}
+diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
+index 0d8192d..d165beb 100644
+--- a/src/main/java/org/bukkit/Server.java
++++ b/src/main/java/org/bukkit/Server.java
+@@ -52,7 +52,7 @@ import org.bukkit.inventory.meta.ItemMeta;
+ /**
+  * Represents a server implementation.
+  */
+-public interface Server extends PluginMessageRecipient, tc.oc.minecraft.api.server.LocalServer {
++public interface Server extends PluginMessageRecipient, BukkitRuntime, tc.oc.minecraft.api.server.LocalServer {
+ 
+     /**
+      * Used for all administrative messages, such as an operator using a
+diff --git a/src/main/java/org/bukkit/registry/Key.java b/src/main/java/org/bukkit/registry/Key.java
+new file mode 100644
+index 0000000..b8ce9e4
+--- /dev/null
++++ b/src/main/java/org/bukkit/registry/Key.java
+@@ -0,0 +1,6 @@
++package org.bukkit.registry;
++
++public interface Key {
++    String prefix();
++    String id();
++}
+diff --git a/src/main/java/org/bukkit/registry/Registerable.java b/src/main/java/org/bukkit/registry/Registerable.java
+new file mode 100644
+index 0000000..4c22aea
+--- /dev/null
++++ b/src/main/java/org/bukkit/registry/Registerable.java
+@@ -0,0 +1,5 @@
++package org.bukkit.registry;
++
++public interface Registerable {
++    Key key();
++}
+diff --git a/src/main/java/org/bukkit/registry/Registry.java b/src/main/java/org/bukkit/registry/Registry.java
+new file mode 100644
+index 0000000..d7c6368
+--- /dev/null
++++ b/src/main/java/org/bukkit/registry/Registry.java
+@@ -0,0 +1,23 @@
++package org.bukkit.registry;
++
++import java.util.NoSuchElementException;
++import java.util.Set;
++
++public interface Registry<V extends Registerable> extends Iterable<V> {
++
++    V get(Key key);
++
++    V need(Key key) throws NoSuchElementException;
++
++    boolean containsKey(Key key);
++
++    Set<Key> keySet();
++
++    /**
++     * Return an "empty" or "default" value of this registry's type, or null if there is no such value.
++     *
++     * The exact nature of this value depends on the registry type, but it can generally be used
++     * as a fallback where a specific value is unavailable.
++     */
++    V getFallback();
++}
+-- 
+1.9.0
+

--- a/Bukkit/0062-Modernize-potion-API.patch
+++ b/Bukkit/0062-Modernize-potion-API.patch
@@ -1,0 +1,589 @@
+From fbe87fd1dc2f789e8b40e3afebc156d3ff8d14bd Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Thu, 10 Mar 2016 15:08:23 -0500
+Subject: [PATCH] Modernize potion API
+
+
+diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
+index 3a92082..3f99983 100644
+--- a/src/main/java/org/bukkit/Bukkit.java
++++ b/src/main/java/org/bukkit/Bukkit.java
+@@ -37,6 +37,8 @@ import org.bukkit.permissions.Permissible;
+ import org.bukkit.plugin.PluginManager;
+ import org.bukkit.plugin.ServicesManager;
+ import org.bukkit.plugin.messaging.Messenger;
++import org.bukkit.potion.PotionEffectRegistry;
++import org.bukkit.potion.PotionBrewRegistry;
+ import org.bukkit.registry.Key;
+ import org.bukkit.scheduler.BukkitScheduler;
+ import org.bukkit.scoreboard.ScoreboardManager;
+@@ -1286,4 +1288,12 @@ public final class Bukkit {
+     public static Key key(String id) {
+         return runtime().key(id);
+     }
++
++    public static PotionBrewRegistry potionRegistry() {
++        return runtime().potionRegistry();
++    }
++
++    public static PotionEffectRegistry potionEffectRegistry() {
++        return runtime().potionEffectRegistry();
++    }
+ }
+diff --git a/src/main/java/org/bukkit/BukkitRuntime.java b/src/main/java/org/bukkit/BukkitRuntime.java
+index 1ed31cb..b452cd3 100644
+--- a/src/main/java/org/bukkit/BukkitRuntime.java
++++ b/src/main/java/org/bukkit/BukkitRuntime.java
+@@ -2,6 +2,8 @@ package org.bukkit;
+ 
+ import org.bukkit.inventory.ItemFactory;
+ import org.bukkit.inventory.meta.ItemMeta;
++import org.bukkit.potion.PotionEffectRegistry;
++import org.bukkit.potion.PotionBrewRegistry;
+ import org.bukkit.registry.Key;
+ 
+ public interface BukkitRuntime {
+@@ -17,4 +19,8 @@ public interface BukkitRuntime {
+      * @see ItemFactory
+      */
+     ItemFactory getItemFactory();
++
++    PotionBrewRegistry potionRegistry();
++
++    PotionEffectRegistry potionEffectRegistry();
+ }
+diff --git a/src/main/java/org/bukkit/inventory/meta/PotionMeta.java b/src/main/java/org/bukkit/inventory/meta/PotionMeta.java
+index d915125..2160d64 100644
+--- a/src/main/java/org/bukkit/inventory/meta/PotionMeta.java
++++ b/src/main/java/org/bukkit/inventory/meta/PotionMeta.java
+@@ -1,6 +1,7 @@
+ package org.bukkit.inventory.meta;
+ 
+ import org.bukkit.Color;
++import org.bukkit.potion.PotionBrew;
+ import org.bukkit.potion.PotionEffect;
+ import org.bukkit.potion.PotionEffectType;
+ import org.bukkit.potion.PotionData;
+@@ -27,6 +28,10 @@ public interface PotionMeta extends ItemMeta {
+      */
+     PotionData getBasePotionData();
+ 
++    void setPotionBrew(PotionBrew brew);
++
++    PotionBrew getPotionBrew();
++
+     /**
+      * Checks for the presence of custom potion effects.
+      *
+diff --git a/src/main/java/org/bukkit/potion/PotionBrew.java b/src/main/java/org/bukkit/potion/PotionBrew.java
+new file mode 100644
+index 0000000..f5fcc3a
+--- /dev/null
++++ b/src/main/java/org/bukkit/potion/PotionBrew.java
+@@ -0,0 +1,9 @@
++package org.bukkit.potion;
++
++import java.util.List;
++
++import org.bukkit.registry.Registerable;
++
++public interface PotionBrew extends Registerable {
++    List<PotionEffect> effects();
++}
+diff --git a/src/main/java/org/bukkit/potion/PotionBrewRegistry.java b/src/main/java/org/bukkit/potion/PotionBrewRegistry.java
+new file mode 100644
+index 0000000..11ae697
+--- /dev/null
++++ b/src/main/java/org/bukkit/potion/PotionBrewRegistry.java
+@@ -0,0 +1,5 @@
++package org.bukkit.potion;
++
++import org.bukkit.registry.Registry;
++
++public interface PotionBrewRegistry extends Registry<PotionBrew> {}
+diff --git a/src/main/java/org/bukkit/potion/PotionEffectRegistry.java b/src/main/java/org/bukkit/potion/PotionEffectRegistry.java
+new file mode 100644
+index 0000000..724b62f
+--- /dev/null
++++ b/src/main/java/org/bukkit/potion/PotionEffectRegistry.java
+@@ -0,0 +1,11 @@
++package org.bukkit.potion;
++
++import org.bukkit.registry.Registry;
++
++public interface PotionEffectRegistry extends Registry<PotionEffectType> {
++    @Deprecated
++    PotionEffectType forLegacyId(int legacyId);
++
++    @Deprecated
++    PotionEffectType forLegacyName(String legacyName);
++}
+diff --git a/src/main/java/org/bukkit/potion/PotionEffectType.java b/src/main/java/org/bukkit/potion/PotionEffectType.java
+index 27c1f47..8bea2a9 100644
+--- a/src/main/java/org/bukkit/potion/PotionEffectType.java
++++ b/src/main/java/org/bukkit/potion/PotionEffectType.java
+@@ -1,162 +1,157 @@
+ package org.bukkit.potion;
+ 
+-import java.util.HashMap;
+-import java.util.Map;
++import java.util.ArrayList;
++import java.util.List;
+ 
+-import org.apache.commons.lang.Validate;
++import org.bukkit.Bukkit;
++import org.bukkit.registry.Key;
++import org.bukkit.registry.Registerable;
+ 
+ /**
+  * Represents a type of potion and its effect on an entity.
+  */
+-public abstract class PotionEffectType {
++public abstract class PotionEffectType implements Registerable {
+     /**
+      * Increases movement speed.
+      */
+-    public static final PotionEffectType SPEED = new PotionEffectTypeWrapper(1);
++    public static final PotionEffectType SPEED = new PotionEffectTypeWrapper("speed");
+ 
+     /**
+      * Decreases movement speed.
+      */
+-    public static final PotionEffectType SLOW = new PotionEffectTypeWrapper(2);
++    public static final PotionEffectType SLOW = new PotionEffectTypeWrapper("slowness");
+ 
+     /**
+      * Increases dig speed.
+      */
+-    public static final PotionEffectType FAST_DIGGING = new PotionEffectTypeWrapper(3);
++    public static final PotionEffectType FAST_DIGGING = new PotionEffectTypeWrapper("haste");
+ 
+     /**
+      * Decreases dig speed.
+      */
+-    public static final PotionEffectType SLOW_DIGGING = new PotionEffectTypeWrapper(4);
++    public static final PotionEffectType SLOW_DIGGING = new PotionEffectTypeWrapper("mining_fatigue");
+ 
+     /**
+      * Increases damage dealt.
+      */
+-    public static final PotionEffectType INCREASE_DAMAGE = new PotionEffectTypeWrapper(5);
++    public static final PotionEffectType INCREASE_DAMAGE = new PotionEffectTypeWrapper("strength");
+ 
+     /**
+      * Heals an entity.
+      */
+-    public static final PotionEffectType HEAL = new PotionEffectTypeWrapper(6);
++    public static final PotionEffectType HEAL = new PotionEffectTypeWrapper("instant_health");
+ 
+     /**
+      * Hurts an entity.
+      */
+-    public static final PotionEffectType HARM = new PotionEffectTypeWrapper(7);
++    public static final PotionEffectType HARM = new PotionEffectTypeWrapper("instant_damage");
+ 
+     /**
+      * Increases jump height.
+      */
+-    public static final PotionEffectType JUMP = new PotionEffectTypeWrapper(8);
++    public static final PotionEffectType JUMP = new PotionEffectTypeWrapper("jump_boost");
+ 
+     /**
+      * Warps vision on the client.
+      */
+-    public static final PotionEffectType CONFUSION = new PotionEffectTypeWrapper(9);
++    public static final PotionEffectType CONFUSION = new PotionEffectTypeWrapper("nausea");
+ 
+     /**
+      * Regenerates health.
+      */
+-    public static final PotionEffectType REGENERATION = new PotionEffectTypeWrapper(10);
++    public static final PotionEffectType REGENERATION = new PotionEffectTypeWrapper("regeneration");
+ 
+     /**
+      * Decreases damage dealt to an entity.
+      */
+-    public static final PotionEffectType DAMAGE_RESISTANCE = new PotionEffectTypeWrapper(11);
++    public static final PotionEffectType DAMAGE_RESISTANCE = new PotionEffectTypeWrapper("resistance");
+ 
+     /**
+      * Stops fire damage.
+      */
+-    public static final PotionEffectType FIRE_RESISTANCE = new PotionEffectTypeWrapper(12);
++    public static final PotionEffectType FIRE_RESISTANCE = new PotionEffectTypeWrapper("fire_resistance");
+ 
+     /**
+      * Allows breathing underwater.
+      */
+-    public static final PotionEffectType WATER_BREATHING = new PotionEffectTypeWrapper(13);
++    public static final PotionEffectType WATER_BREATHING = new PotionEffectTypeWrapper("water_breathing");
+ 
+     /**
+      * Grants invisibility.
+      */
+-    public static final PotionEffectType INVISIBILITY = new PotionEffectTypeWrapper(14);
++    public static final PotionEffectType INVISIBILITY = new PotionEffectTypeWrapper("invisibility");
+ 
+     /**
+      * Blinds an entity.
+      */
+-    public static final PotionEffectType BLINDNESS = new PotionEffectTypeWrapper(15);
++    public static final PotionEffectType BLINDNESS = new PotionEffectTypeWrapper("blindness");
+ 
+     /**
+      * Allows an entity to see in the dark.
+      */
+-    public static final PotionEffectType NIGHT_VISION = new PotionEffectTypeWrapper(16);
++    public static final PotionEffectType NIGHT_VISION = new PotionEffectTypeWrapper("night_vision");
+ 
+     /**
+      * Increases hunger.
+      */
+-    public static final PotionEffectType HUNGER = new PotionEffectTypeWrapper(17);
++    public static final PotionEffectType HUNGER = new PotionEffectTypeWrapper("hunger");
+ 
+     /**
+      * Decreases damage dealt by an entity.
+      */
+-    public static final PotionEffectType WEAKNESS = new PotionEffectTypeWrapper(18);
++    public static final PotionEffectType WEAKNESS = new PotionEffectTypeWrapper("weakness");
+ 
+     /**
+      * Deals damage to an entity over time.
+      */
+-    public static final PotionEffectType POISON = new PotionEffectTypeWrapper(19);
++    public static final PotionEffectType POISON = new PotionEffectTypeWrapper("poison");
+ 
+     /**
+      * Deals damage to an entity over time and gives the health to the
+      * shooter.
+      */
+-    public static final PotionEffectType WITHER = new PotionEffectTypeWrapper(20);
++    public static final PotionEffectType WITHER = new PotionEffectTypeWrapper("wither");
+ 
+     /**
+      * Increases the maximum health of an entity.
+      */
+-    public static final PotionEffectType HEALTH_BOOST = new PotionEffectTypeWrapper(21);
++    public static final PotionEffectType HEALTH_BOOST = new PotionEffectTypeWrapper("health_boost");
+ 
+     /**
+      * Increases the maximum health of an entity with health that cannot be
+      * regenerated, but is refilled every 30 seconds.
+      */
+-    public static final PotionEffectType ABSORPTION = new PotionEffectTypeWrapper(22);
++    public static final PotionEffectType ABSORPTION = new PotionEffectTypeWrapper("absorption");
+ 
+     /**
+      * Increases the food level of an entity each tick.
+      */
+-    public static final PotionEffectType SATURATION = new PotionEffectTypeWrapper(23);
++    public static final PotionEffectType SATURATION = new PotionEffectTypeWrapper("saturation");
+ 
+     /**
+      * Outlines the entity so that it can be seen from afar.
+      */
+-    public static final PotionEffectType GLOWING = new PotionEffectTypeWrapper(24);
++    public static final PotionEffectType GLOWING = new PotionEffectTypeWrapper("glowing");
+ 
+     /**
+      * Causes the entity to float into the air.
+      */
+-    public static final PotionEffectType LEVITATION = new PotionEffectTypeWrapper(25);
++    public static final PotionEffectType LEVITATION = new PotionEffectTypeWrapper("levitation");
+ 
+     /**
+      * Loot table luck.
+      */
+-    public static final PotionEffectType LUCK = new PotionEffectTypeWrapper(26);
++    public static final PotionEffectType LUCK = new PotionEffectTypeWrapper("luck");
+ 
+     /**
+      * Loot table unluck.
+      */
+-    public static final PotionEffectType UNLUCK = new PotionEffectTypeWrapper(27);
+-
+-    private final int id;
+-
+-    protected PotionEffectType(int id) {
+-        this.id = id;
+-    }
++    public static final PotionEffectType UNLUCK = new PotionEffectTypeWrapper("unluck");
+ 
+     /**
+      * Creates a PotionEffect from this PotionEffectType, applying duration
+      * modifiers and checks.
+      *
+-     * @see PotionBrewer#createEffect(PotionEffectType, int, int)
+      * @param duration time in ticks
+      * @param amplifier the effect's amplifier
+      * @return a resulting potion effect
+@@ -179,15 +174,15 @@ public abstract class PotionEffectType {
+      * @deprecated Magic value
+      */
+     @Deprecated
+-    public int getId() {
+-        return id;
+-    }
++    public abstract int getId();
+ 
+     /**
+-     * Returns the name of this effect type.
++     * Returns the legacy Bukkit name of this effect type.
+      *
+      * @return The name of this effect type
++     * @deprecated Use {@link #key()}
+      */
++    @Deprecated
+     public abstract String getName();
+ 
+     /**
+@@ -199,34 +194,22 @@ public abstract class PotionEffectType {
+ 
+     @Override
+     public boolean equals(Object obj) {
+-        if (obj == null) {
+-            return false;
+-        }
+-        if (!(obj instanceof PotionEffectType)) {
+-            return false;
+-        }
+-        final PotionEffectType other = (PotionEffectType) obj;
+-        if (this.id != other.id) {
+-            return false;
+-        }
+-        return true;
++        return this == obj || (
++            obj instanceof PotionEffectType &&
++            key().equals(((PotionEffectType) obj).key())
++        );
+     }
+ 
+     @Override
+     public int hashCode() {
+-        return id;
++        return key().hashCode();
+     }
+ 
+     @Override
+     public String toString() {
+-        return "PotionEffectType[" + id + ", " + getName() + "]";
++        return "PotionEffectType[" + key() + ", " + getName() + "]";
+     }
+ 
+-    private static final PotionEffectType[] byId = new PotionEffectType[28];
+-    private static final Map<String, PotionEffectType> byName = new HashMap<String, PotionEffectType>();
+-    // will break on updates.
+-    private static boolean acceptingNew = true;
+-
+     /**
+      * Gets the effect type specified by the unique id.
+      *
+@@ -236,46 +219,33 @@ public abstract class PotionEffectType {
+      */
+     @Deprecated
+     public static PotionEffectType getById(int id) {
+-        if (id >= byId.length || id < 0)
+-            return null;
+-        return byId[id];
++        return Bukkit.potionEffectRegistry().forLegacyId(id);
+     }
+ 
+     /**
+-     * Gets the effect type specified by the given name.
++     * Gets the effect type specified by the given legacy Bukkit name.
+      *
+      * @param name Name of PotionEffectType to fetch
+      * @return Resulting PotionEffectType, or null if not found.
++     * @deprecated Use {@link PotionEffectRegistry#get(Key)}
+      */
+     public static PotionEffectType getByName(String name) {
+-        Validate.notNull(name, "name cannot be null");
+-        return byName.get(name.toLowerCase(java.util.Locale.ENGLISH));
++        return Bukkit.potionEffectRegistry().forLegacyName(name);
+     }
+ 
+     /**
+-     * Registers an effect type with the given object.
+-     * <p>
+-     * Generally not to be used from within a plugin.
+-     *
+-     * @param type PotionType to register
++     * Legacy method, not to be called under any circumstances
+      */
++    @Deprecated
+     public static void registerPotionEffectType(PotionEffectType type) {
+-        if (byId[type.id] != null || byName.containsKey(type.getName().toLowerCase(java.util.Locale.ENGLISH))) {
+-            throw new IllegalArgumentException("Cannot set already-set type");
+-        } else if (!acceptingNew) {
+-            throw new IllegalStateException(
+-                    "No longer accepting new potion effect types (can only be done by the server implementation)");
+-        }
+-
+-        byId[type.id] = type;
+-        byName.put(type.getName().toLowerCase(java.util.Locale.ENGLISH), type);
++        throw new UnsupportedOperationException();
+     }
+ 
+     /**
+-     * Stops accepting any effect type registrations.
++     * Legacy method, not to be called under any circumstances
+      */
++    @Deprecated
+     public static void stopAcceptingRegistrations() {
+-        acceptingNew = false;
+     }
+ 
+     /**
+@@ -283,8 +253,14 @@ public abstract class PotionEffectType {
+      * This array is not necessarily in any particular order and may contain null.
+      *
+      * @return Array of types.
++     * @deprecated Use {@link PotionEffectRegistry#iterator()}
+      */
++    @Deprecated
+     public static PotionEffectType[] values() {
+-        return byId.clone();
++        final List<PotionEffectType> list = new ArrayList<PotionEffectType>();
++        for(PotionEffectType type : Bukkit.potionEffectRegistry()) {
++            list.add(type);
++        }
++        return list.toArray(new PotionEffectType[list.size()]);
+     }
+ }
+diff --git a/src/main/java/org/bukkit/potion/PotionEffectTypeWrapper.java b/src/main/java/org/bukkit/potion/PotionEffectTypeWrapper.java
+index 5db1ce8..2e4bf99 100644
+--- a/src/main/java/org/bukkit/potion/PotionEffectTypeWrapper.java
++++ b/src/main/java/org/bukkit/potion/PotionEffectTypeWrapper.java
+@@ -1,8 +1,14 @@
+ package org.bukkit.potion;
+ 
++import org.bukkit.Bukkit;
++import org.bukkit.registry.Key;
++
+ public class PotionEffectTypeWrapper extends PotionEffectType {
+-    protected PotionEffectTypeWrapper(int id) {
+-        super(id);
++
++    private final String id;
++
++    protected PotionEffectTypeWrapper(String id) {
++        this.id = id;
+     }
+ 
+     @Override
+@@ -11,6 +17,16 @@ public class PotionEffectTypeWrapper extends PotionEffectType {
+     }
+ 
+     @Override
++    public Key key() {
++        return Bukkit.key(id);
++    }
++
++    @Override
++    public int getId() {
++        return getType().getId();
++    }
++
++    @Override
+     public String getName() {
+         return getType().getName();
+     }
+@@ -21,7 +37,7 @@ public class PotionEffectTypeWrapper extends PotionEffectType {
+      * @return The potion effect type
+      */
+     public PotionEffectType getType() {
+-        return PotionEffectType.getById(getId());
++        return Bukkit.potionEffectRegistry().get(key());
+     }
+ 
+     @Override
+diff --git a/src/main/java/org/bukkit/potion/PotionType.java b/src/main/java/org/bukkit/potion/PotionType.java
+index 60470b8..f68c127 100644
+--- a/src/main/java/org/bukkit/potion/PotionType.java
++++ b/src/main/java/org/bukkit/potion/PotionType.java
+@@ -1,41 +1,60 @@
+ package org.bukkit.potion;
+ 
++import org.bukkit.Bukkit;
++import org.bukkit.registry.Key;
++
+ /**
+  * This enum reflects and matches each potion state that can be obtained from
+  * the Creative mode inventory
+  */
+ public enum PotionType {
+-    UNCRAFTABLE(null, false, false),
+-    WATER(null, false, false),
+-    MUNDANE(null, false, false),
+-    THICK(null, false, false),
+-    AWKWARD(null, false, false),
+-    NIGHT_VISION(PotionEffectType.NIGHT_VISION, false, true),
+-    INVISIBILITY(PotionEffectType.INVISIBILITY, false, true),
+-    JUMP(PotionEffectType.JUMP, true, true),
+-    FIRE_RESISTANCE(PotionEffectType.FIRE_RESISTANCE, false, true),
+-    SPEED(PotionEffectType.SPEED, true, true),
+-    SLOWNESS(PotionEffectType.SLOW, false, true),
+-    WATER_BREATHING(PotionEffectType.WATER_BREATHING, false, true),
+-    INSTANT_HEAL(PotionEffectType.HEAL, true, false),
+-    INSTANT_DAMAGE(PotionEffectType.HARM, true, false),
+-    POISON(PotionEffectType.POISON, true, true),
+-    REGEN(PotionEffectType.REGENERATION, true, true),
+-    STRENGTH(PotionEffectType.INCREASE_DAMAGE, true, true),
+-    WEAKNESS(PotionEffectType.WEAKNESS, false, true),
+-    LUCK(PotionEffectType.LUCK, false, false);
+-    ;
++    UNCRAFTABLE("empty", null, false, false),
++    WATER("water", null, false, false),
++    MUNDANE("mundane", null, false, false),
++    THICK("thick", null, false, false),
++    AWKWARD("awkward", null, false, false),
++    NIGHT_VISION("night_vision", PotionEffectType.NIGHT_VISION, false, true),
++    INVISIBILITY("invisibility", PotionEffectType.INVISIBILITY, false, true),
++    JUMP("leaping", PotionEffectType.JUMP, true, true),
++    FIRE_RESISTANCE("fire_resistance", PotionEffectType.FIRE_RESISTANCE, false, true),
++    SPEED("swiftness", PotionEffectType.SPEED, true, true),
++    SLOWNESS("slowness", PotionEffectType.SLOW, false, true),
++    WATER_BREATHING("water_breathing", PotionEffectType.WATER_BREATHING, false, true),
++    INSTANT_HEAL("healing", PotionEffectType.HEAL, true, false),
++    INSTANT_DAMAGE("harming", PotionEffectType.HARM, true, false),
++    POISON("poison", PotionEffectType.POISON, true, true),
++    REGEN("regeneration", PotionEffectType.REGENERATION, true, true),
++    STRENGTH("strength", PotionEffectType.INCREASE_DAMAGE, true, true),
++    WEAKNESS("weakness", PotionEffectType.WEAKNESS, false, true),
++    LUCK("luck", PotionEffectType.LUCK, false, false);
++
++    private static final String LONG_PREFIX = "long_";
++    private static final String STRONG_PREFIX = "strong_";
+ 
+     private final PotionEffectType effect;
+     private final boolean upgradeable;
+     private final boolean extendable;
++    private final String id;
+ 
+-    PotionType(PotionEffectType effect, boolean upgradeable, boolean extendable) {
++    PotionType(String id, PotionEffectType effect, boolean upgradeable, boolean extendable) {
++        this.id = id;
+         this.effect = effect;
+         this.upgradeable = upgradeable;
+         this.extendable = extendable;
+     }
+ 
++    public Key baseKey() {
++        return Bukkit.key(id);
++    }
++
++    public Key longKey() {
++        return Bukkit.key(LONG_PREFIX + id);
++    }
++
++    public Key strongKey() {
++        return Bukkit.key(STRONG_PREFIX + id);
++    }
++
+     public PotionEffectType getEffectType() {
+         return effect;
+     }
+-- 
+1.9.0
+

--- a/Bukkit/0063-Legacy-potion-support.patch
+++ b/Bukkit/0063-Legacy-potion-support.patch
@@ -1,0 +1,104 @@
+From 189f6b2876acba47d5601ce085a8d3069981874f Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Sat, 19 Mar 2016 00:45:13 -0400
+Subject: [PATCH] Legacy potion support
+
+
+diff --git a/src/main/java/org/bukkit/potion/Potion.java b/src/main/java/org/bukkit/potion/Potion.java
+index 7aa5a2d..ffe7630 100644
+--- a/src/main/java/org/bukkit/potion/Potion.java
++++ b/src/main/java/org/bukkit/potion/Potion.java
+@@ -6,6 +6,7 @@ import org.apache.commons.lang.Validate;
+ import org.bukkit.Material;
+ import org.bukkit.entity.LivingEntity;
+ import org.bukkit.inventory.ItemStack;
++import org.bukkit.inventory.meta.ItemMeta;
+ import org.bukkit.inventory.meta.PotionMeta;
+ 
+ /**
+@@ -271,7 +272,7 @@ public class Potion {
+         }
+         ItemStack itemStack = new ItemStack(material, amount);
+         PotionMeta meta = (PotionMeta) itemStack.getItemMeta();
+-        meta.setBasePotionData(new PotionData(type, level == 2, extended));
++        meta.setBasePotionData(new PotionData(type, extended, level == 2));
+         itemStack.setItemMeta(meta);
+         return itemStack;
+     }
+@@ -283,6 +284,7 @@ public class Potion {
+     private static final int SPLASH_BIT = 0x4000;
+     private static final int TIER_BIT = 0x20;
+     private static final int TIER_SHIFT = 5;
++    private static final int NAME_MASK = 0x10;
+ 
+     /**
+      *
+@@ -290,10 +292,22 @@ public class Potion {
+      * @return the produced potion
+      */
+     public static Potion fromDamage(int damage) {
++        final int level = ((damage & TIER_BIT) >> TIER_SHIFT) + 1;
++
+         PotionType type;
+         switch (damage & POTION_BIT) {
+             case 0:
+-                type = PotionType.WATER;
++                switch(damage & NAME_MASK) {
++                    default:
++                        type = damage == 0 ? PotionType.WATER : PotionType.MUNDANE;
++                        break;
++                    case 16:
++                        type = PotionType.AWKWARD;
++                        break;
++                    case 32:
++                        type = PotionType.THICK;
++                        break;
++                }
+                 break;
+             case 1:
+                 type = PotionType.REGEN;
+@@ -337,28 +351,29 @@ public class Potion {
+             default:
+                 type = PotionType.WATER;
+         }
+-        Potion potion;
+-        if (type == null || type == PotionType.WATER) {
+-            potion = new Potion(PotionType.WATER);
+-        } else {
+-            int level = (damage & TIER_BIT) >> TIER_SHIFT;
+-            level++;
+-            potion = new Potion(type, level);
+-        }
++
++        Potion potion = new Potion(type, type.isUpgradeable() ? level : 1);
++
+         if ((damage & SPLASH_BIT) > 0) {
+             potion = potion.splash();
+         }
+-        if ((damage & EXTENDED_BIT) > 0) {
++        if ((damage & EXTENDED_BIT) > 0 && type.isExtendable()) {
+             potion = potion.extend();
+         }
+         return potion;
+     }
+ 
++    @Deprecated
+     public static Potion fromItemStack(ItemStack item) {
+         Validate.notNull(item, "item cannot be null");
+-        if (item.getType() != Material.POTION)
+-            throw new IllegalArgumentException("item is not a potion");
+-        return fromDamage(item.getDurability());
++        if(item.getType() != Material.POTION && item.getType() != Material.SPLASH_POTION) {
++            throw new IllegalArgumentException("item cannot be converted to a legacy potion");
++        }
++
++        final PotionData potionData = ((PotionMeta) item.getItemMeta()).getBasePotionData();
++        final Potion potion = new Potion(potionData.getType(), potionData.isUpgraded() ? 2 : 1, potionData.isExtended());
++        if(item.getType() == Material.SPLASH_POTION) potion.splash();
++        return potion;
+     }
+ 
+     /**
+-- 
+1.9.0
+

--- a/Bukkit/0064-Affects-spawning-API.patch
+++ b/Bukkit/0064-Affects-spawning-API.patch
@@ -1,0 +1,31 @@
+From 04fa2fcb6167685bc45bbe67baff2dcfe556413b Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Thu, 2 Aug 2012 17:12:10 -0700
+Subject: [PATCH] Affects spawning API
+
+
+diff --git a/src/main/java/org/bukkit/entity/HumanEntity.java b/src/main/java/org/bukkit/entity/HumanEntity.java
+index e001b14..4757478 100644
+--- a/src/main/java/org/bukkit/entity/HumanEntity.java
++++ b/src/main/java/org/bukkit/entity/HumanEntity.java
+@@ -231,4 +231,17 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, Permissible, Inv
+      * @return Experience required to level up
+      */
+     public int getExpToLevel();
++
++    /**
++     * Setting this to false prevents players from activating mob spawners and
++     * allows mobs to randomly spawn and despawn near them (which normally can't happen).
++     * @param yes true to prevent this player from affecting mob spawning
++     */
++    public void setAffectsSpawning(boolean yes);
++
++    /**
++     * @return whether this player can activate mob spawners and prevent
++     *         random spawning and despawning near them.
++     */
++    public boolean getAffectsSpawning();
+ }
+-- 
+1.9.0
+

--- a/Bukkit/0065-Entity-collision-API.patch
+++ b/Bukkit/0065-Entity-collision-API.patch
@@ -1,0 +1,32 @@
+From 52b4ca6fb1f958172b40530b624b6c74074e3d32 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Sat, 28 Apr 2012 01:39:04 -0400
+Subject: [PATCH] Entity collision API
+
+
+diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
+index 72cf253..807d28d 100644
+--- a/src/main/java/org/bukkit/entity/Player.java
++++ b/src/main/java/org/bukkit/entity/Player.java
+@@ -1073,6 +1073,18 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
+     public void setFlying(boolean value);
+ 
+     /**
++     * Change whether this player can push other entities
++     * @param yes true to push other entities, which is the default
++     */
++    public void setCollidesWithEntities(boolean yes);
++
++    /**
++     * Whether this player can push other entities
++     * @return true if the player can push other entities
++     */
++    public boolean getCollidesWithEntities();
++
++    /**
+      * Sets the speed at which a client will fly. Negative values indicate
+      * reverse directions.
+      *
+-- 
+1.9.0
+

--- a/Bukkit/0066-Geometry-API.patch
+++ b/Bukkit/0066-Geometry-API.patch
@@ -1,0 +1,6558 @@
+From cc822f10da2100767814e5e356b3c79367fbc164 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Fri, 18 Nov 2016 04:34:11 -0500
+Subject: [PATCH] Geometry API
+
+
+diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
+index 3f99983..1519aae 100644
+--- a/src/main/java/org/bukkit/Bukkit.java
++++ b/src/main/java/org/bukkit/Bukkit.java
+@@ -50,6 +50,7 @@ import org.bukkit.generator.ChunkGenerator;
+ 
+ import org.bukkit.inventory.ItemFactory;
+ import org.bukkit.inventory.meta.ItemMeta;
++import org.bukkit.geometry.VectorFactory;
+ 
+ /**
+  * Represents the Bukkit core, for version and Server singleton handling
+@@ -1289,6 +1290,8 @@ public final class Bukkit {
+         return runtime().key(id);
+     }
+ 
++    public static VectorFactory vectors() { return runtime().vectors(); }
++
+     public static PotionBrewRegistry potionRegistry() {
+         return runtime().potionRegistry();
+     }
+diff --git a/src/main/java/org/bukkit/BukkitRuntime.java b/src/main/java/org/bukkit/BukkitRuntime.java
+index b452cd3..837b2dd 100644
+--- a/src/main/java/org/bukkit/BukkitRuntime.java
++++ b/src/main/java/org/bukkit/BukkitRuntime.java
+@@ -5,6 +5,7 @@ import org.bukkit.inventory.meta.ItemMeta;
+ import org.bukkit.potion.PotionEffectRegistry;
+ import org.bukkit.potion.PotionBrewRegistry;
+ import org.bukkit.registry.Key;
++import org.bukkit.geometry.VectorFactory;
+ 
+ public interface BukkitRuntime {
+ 
+@@ -12,6 +13,8 @@ public interface BukkitRuntime {
+ 
+     Key key(String key);
+ 
++    VectorFactory vectors();
++
+     /**
+      * Gets the instance of the item factory (for {@link ItemMeta}).
+      *
+diff --git a/src/main/java/org/bukkit/Location.java b/src/main/java/org/bukkit/Location.java
+index cd7ac2f..0d2cca2 100644
+--- a/src/main/java/org/bukkit/Location.java
++++ b/src/main/java/org/bukkit/Location.java
+@@ -2,24 +2,45 @@ package org.bukkit;
+ 
+ import java.util.HashMap;
+ import java.util.Map;
++import java.util.Objects;
+ 
+ import org.bukkit.block.Block;
+ import org.bukkit.configuration.serialization.ConfigurationSerializable;
++import org.bukkit.geometry.Direction;
++import org.bukkit.geometry.Ray;
++import org.bukkit.util.BlockVector;
+ import org.bukkit.util.NumberConversions;
+-import static org.bukkit.util.NumberConversions.checkFinite;
++
++import org.bukkit.geometry.Vec3;
+ import org.bukkit.util.Vector;
+ 
+ /**
+  * Represents a 3-dimensional position in a world
+  */
+ public class Location implements Cloneable, ConfigurationSerializable, Physical {
++
+     private World world;
+-    private double x;
+-    private double y;
+-    private double z;
++    private final Vector position;
+     private float pitch;
+     private float yaw;
+ 
++    public Location(final World world, Vec3 position) {
++        this(world, position, 0, 0);
++    }
++
++    public Location(final World world, Vec3 position, float yaw, float pitch) {
++        this(world, position.fineX(), position.fineY(), position.fineZ(), yaw, pitch);
++    }
++
++    public Location(final World world, Vec3 position, Direction direction) {
++        this(world, position.fineX(), position.fineY(), position.fineZ(), direction.yawDegrees(), direction.pitchDegrees());
++    }
++
++    public Location(final World world, Ray ray) {
++        this(world, ray.origin().fineX(), ray.origin().fineY(), ray.origin().fineZ(),
++             ray.direction().yawDegrees(), ray.direction().pitchDegrees());
++    }
++
+     /**
+      * Constructs a new Location with the given coordinates
+      *
+@@ -44,9 +65,7 @@ public class Location implements Cloneable, ConfigurationSerializable, Physical
+      */
+     public Location(final World world, final double x, final double y, final double z, final float yaw, final float pitch) {
+         this.world = world;
+-        this.x = x;
+-        this.y = y;
+-        this.z = z;
++        this.position = new Vector(x, y, z);
+         this.pitch = pitch;
+         this.yaw = yaw;
+     }
+@@ -87,13 +106,25 @@ public class Location implements Cloneable, ConfigurationSerializable, Physical
+         return world.getBlockAt(this);
+     }
+ 
++    public Vector position() {
++        return position;
++    }
++
++    public void setPosition(Vec3 pos) {
++        position.set(pos);
++    }
++
++    public void setPosition(double x, double y, double z) {
++        position.set(x, y, z);
++    }
++
+     /**
+      * Sets the x-coordinate of this location
+      *
+      * @param x X-coordinate
+      */
+     public void setX(double x) {
+-        this.x = x;
++        position.setX(x);
+     }
+ 
+     /**
+@@ -102,7 +133,7 @@ public class Location implements Cloneable, ConfigurationSerializable, Physical
+      * @return x-coordinate
+      */
+     public double getX() {
+-        return x;
++        return position.fineX();
+     }
+ 
+     /**
+@@ -112,7 +143,7 @@ public class Location implements Cloneable, ConfigurationSerializable, Physical
+      * @return block X
+      */
+     public int getBlockX() {
+-        return locToBlock(x);
++        return position.coarseX();
+     }
+ 
+     /**
+@@ -121,7 +152,7 @@ public class Location implements Cloneable, ConfigurationSerializable, Physical
+      * @param y y-coordinate
+      */
+     public void setY(double y) {
+-        this.y = y;
++        position.setY(y);
+     }
+ 
+     /**
+@@ -130,7 +161,7 @@ public class Location implements Cloneable, ConfigurationSerializable, Physical
+      * @return y-coordinate
+      */
+     public double getY() {
+-        return y;
++        return position.fineY();
+     }
+ 
+     /**
+@@ -140,7 +171,7 @@ public class Location implements Cloneable, ConfigurationSerializable, Physical
+      * @return block y
+      */
+     public int getBlockY() {
+-        return locToBlock(y);
++        return position.coarseY();
+     }
+ 
+     /**
+@@ -149,7 +180,7 @@ public class Location implements Cloneable, ConfigurationSerializable, Physical
+      * @param z z-coordinate
+      */
+     public void setZ(double z) {
+-        this.z = z;
++        position.setZ(z);
+     }
+ 
+     /**
+@@ -158,7 +189,7 @@ public class Location implements Cloneable, ConfigurationSerializable, Physical
+      * @return z-coordinate
+      */
+     public double getZ() {
+-        return z;
++        return position.fineZ();
+     }
+ 
+     /**
+@@ -168,7 +199,7 @@ public class Location implements Cloneable, ConfigurationSerializable, Physical
+      * @return block z
+      */
+     public int getBlockZ() {
+-        return locToBlock(z);
++        return position.coarseZ();
+     }
+ 
+     /**
+@@ -239,6 +270,14 @@ public class Location implements Cloneable, ConfigurationSerializable, Physical
+         return pitch;
+     }
+ 
++    public Direction direction() {
++        return Direction.ofDegrees(yaw, pitch);
++    }
++
++    public Ray ray() {
++        return Ray.fromLocation(this);
++    }
++
+     /**
+      * Gets a unit-vector pointing in the direction that this Location is
+      * facing.
+@@ -310,11 +349,7 @@ public class Location implements Cloneable, ConfigurationSerializable, Physical
+         if (vec == null || vec.getWorld() != getWorld()) {
+             throw new IllegalArgumentException("Cannot add Locations of differing worlds");
+         }
+-
+-        x += vec.x;
+-        y += vec.y;
+-        z += vec.z;
+-        return this;
++        return add(vec.position());
+     }
+ 
+     /**
+@@ -325,9 +360,7 @@ public class Location implements Cloneable, ConfigurationSerializable, Physical
+      * @return the same location
+      */
+     public Location add(Vector vec) {
+-        this.x += vec.getX();
+-        this.y += vec.getY();
+-        this.z += vec.getZ();
++        position.add(vec);
+         return this;
+     }
+ 
+@@ -341,9 +374,7 @@ public class Location implements Cloneable, ConfigurationSerializable, Physical
+      * @return the same location
+      */
+     public Location add(double x, double y, double z) {
+-        this.x += x;
+-        this.y += y;
+-        this.z += z;
++        position.add(x, y, z);
+         return this;
+     }
+ 
+@@ -359,11 +390,7 @@ public class Location implements Cloneable, ConfigurationSerializable, Physical
+         if (vec == null || vec.getWorld() != getWorld()) {
+             throw new IllegalArgumentException("Cannot add Locations of differing worlds");
+         }
+-
+-        x -= vec.x;
+-        y -= vec.y;
+-        z -= vec.z;
+-        return this;
++        return subtract(vec.position());
+     }
+ 
+     /**
+@@ -374,9 +401,7 @@ public class Location implements Cloneable, ConfigurationSerializable, Physical
+      * @return the same location
+      */
+     public Location subtract(Vector vec) {
+-        this.x -= vec.getX();
+-        this.y -= vec.getY();
+-        this.z -= vec.getZ();
++        position.subtract(vec);
+         return this;
+     }
+ 
+@@ -391,9 +416,7 @@ public class Location implements Cloneable, ConfigurationSerializable, Physical
+      * @return the same location
+      */
+     public Location subtract(double x, double y, double z) {
+-        this.x -= x;
+-        this.y -= y;
+-        this.z -= z;
++        position.subtract(x, y, z);
+         return this;
+     }
+ 
+@@ -409,7 +432,7 @@ public class Location implements Cloneable, ConfigurationSerializable, Physical
+      * @return the magnitude
+      */
+     public double length() {
+-        return Math.sqrt(NumberConversions.square(x) + NumberConversions.square(y) + NumberConversions.square(z));
++        return position.length();
+     }
+ 
+     /**
+@@ -420,7 +443,7 @@ public class Location implements Cloneable, ConfigurationSerializable, Physical
+      * @return the magnitude
+      */
+     public double lengthSquared() {
+-        return NumberConversions.square(x) + NumberConversions.square(y) + NumberConversions.square(z);
++        return position.lengthSquared();
+     }
+ 
+     /**
+@@ -455,8 +478,7 @@ public class Location implements Cloneable, ConfigurationSerializable, Physical
+         } else if (o.getWorld() != getWorld()) {
+             throw new IllegalArgumentException("Cannot measure distance between " + getWorld().getName() + " and " + o.getWorld().getName());
+         }
+-
+-        return NumberConversions.square(x - o.x) + NumberConversions.square(y - o.y) + NumberConversions.square(z - o.z);
++        return position.distanceSquared(o.position());
+     }
+ 
+     /**
+@@ -468,72 +490,59 @@ public class Location implements Cloneable, ConfigurationSerializable, Physical
+      * @return the same location
+      */
+     public Location multiply(double m) {
+-        x *= m;
+-        y *= m;
+-        z *= m;
++        position.multiply(m);
++        return this;
++    }
++
++    /**
++     * Copy yaw and pitch from the given {@link Location} to this one.
++     * @return this object
++     */
++    public Location copyAngles(Location loc) {
++        this.yaw = loc.getYaw();
++        this.pitch = loc.getPitch();
+         return this;
+     }
+ 
+     /**
++     * Copy position and angles from the given {@link Location} to this one.
++     * @return this object
++     */
++    public Location copyLocation(Location loc) {
++        position.set(loc.position());
++        return copyAngles(loc);
++    }
++
++    /**
+      * Zero this location's components. Not world-aware.
+      *
+      * @see Vector
+      * @return the same location
+      */
+     public Location zero() {
+-        x = 0;
+-        y = 0;
+-        z = 0;
++        position.setZero();
+         return this;
+     }
+ 
+     @Override
+     public boolean equals(Object obj) {
+-        if (obj == null) {
+-            return false;
+-        }
+-        if (getClass() != obj.getClass()) {
+-            return false;
+-        }
+-        final Location other = (Location) obj;
+-
+-        if (this.world != other.world && (this.world == null || !this.world.equals(other.world))) {
+-            return false;
+-        }
+-        if (Double.doubleToLongBits(this.x) != Double.doubleToLongBits(other.x)) {
+-            return false;
+-        }
+-        if (Double.doubleToLongBits(this.y) != Double.doubleToLongBits(other.y)) {
+-            return false;
+-        }
+-        if (Double.doubleToLongBits(this.z) != Double.doubleToLongBits(other.z)) {
+-            return false;
+-        }
+-        if (Float.floatToIntBits(this.pitch) != Float.floatToIntBits(other.pitch)) {
+-            return false;
+-        }
+-        if (Float.floatToIntBits(this.yaw) != Float.floatToIntBits(other.yaw)) {
+-            return false;
+-        }
+-        return true;
++        if(this == obj) return true;
++        if(!(obj instanceof Location)) return false;
++        final Location that = (Location) obj;
++        return Objects.equals(world, that.getWorld()) &&
++               Objects.equals(position, that.position()) &&
++               yaw == that.getYaw() &&
++               pitch == that.getPitch();
+     }
+ 
+     @Override
+     public int hashCode() {
+-        int hash = 3;
+-
+-        hash = 19 * hash + (this.world != null ? this.world.hashCode() : 0);
+-        hash = 19 * hash + (int) (Double.doubleToLongBits(this.x) ^ (Double.doubleToLongBits(this.x) >>> 32));
+-        hash = 19 * hash + (int) (Double.doubleToLongBits(this.y) ^ (Double.doubleToLongBits(this.y) >>> 32));
+-        hash = 19 * hash + (int) (Double.doubleToLongBits(this.z) ^ (Double.doubleToLongBits(this.z) >>> 32));
+-        hash = 19 * hash + Float.floatToIntBits(this.pitch);
+-        hash = 19 * hash + Float.floatToIntBits(this.yaw);
+-        return hash;
++        return Objects.hash(world, position, yaw, pitch);
+     }
+ 
+     @Override
+     public String toString() {
+-        return "Location{" + "world=" + world + ",x=" + x + ",y=" + y + ",z=" + z + ",pitch=" + pitch + ",yaw=" + yaw + '}';
++        return "Location{" + "world=" + world + ",pos=" + position + ",pitch=" + pitch + ",yaw=" + yaw + '}';
+     }
+ 
+     /**
+@@ -543,37 +552,26 @@ public class Location implements Cloneable, ConfigurationSerializable, Physical
+      *     Location
+      */
+     public Vector toVector() {
+-        return new Vector(x, y, z);
++        return position.mutableCopy();
+     }
+ 
+-    @Override
+-    public Location clone() {
+-        try {
+-            return (Location) super.clone();
+-        } catch (CloneNotSupportedException e) {
+-            throw new Error(e);
+-        }
++    public BlockVector toBlockVector() {
++        return position.toBlockVector();
+     }
+ 
+-    /**
+-     * Safely converts a double (location coordinate) to an int (block
+-     * coordinate)
+-     *
+-     * @param loc Precise coordinate
+-     * @return Block coordinate
+-     */
+-    public static int locToBlock(double loc) {
+-        return NumberConversions.floor(loc);
++    @Override
++    public Location clone() {
++        return new Location(world, position, yaw, pitch);
+     }
+ 
+-	@Utility
++    @Utility
+ 	public Map<String, Object> serialize() {
+ 		Map<String, Object> data = new HashMap<String, Object>();
+ 		data.put("world", this.world.getName());
+ 
+-		data.put("x", this.x);
+-		data.put("y", this.y);
+-		data.put("z", this.z);
++		data.put("x", position.fineX());
++		data.put("y", position.fineY());
++		data.put("z", position.fineZ());
+ 
+ 		data.put("yaw", this.yaw);
+ 		data.put("pitch", this.pitch);
+diff --git a/src/main/java/org/bukkit/block/BlockFace.java b/src/main/java/org/bukkit/block/BlockFace.java
+index 58fb195..fe704f1 100644
+--- a/src/main/java/org/bukkit/block/BlockFace.java
++++ b/src/main/java/org/bukkit/block/BlockFace.java
+@@ -1,43 +1,79 @@
+ package org.bukkit.block;
+ 
++import java.util.Arrays;
++import java.util.List;
++
++import org.bukkit.geometry.MutableVec3;
++import org.bukkit.geometry.Vec3;
++import org.bukkit.geometry.Vec3Coarse;
++import org.bukkit.util.ImVector;
++import org.bukkit.util.NumberConversions;
++
+ /**
+  * Represents the face of a block
+  */
+-public enum BlockFace {
+-    NORTH(0, 0, -1),
+-    EAST(1, 0, 0),
+-    SOUTH(0, 0, 1),
+-    WEST(-1, 0, 0),
+-    UP(0, 1, 0),
+-    DOWN(0, -1, 0),
+-    NORTH_EAST(NORTH, EAST),
+-    NORTH_WEST(NORTH, WEST),
+-    SOUTH_EAST(SOUTH, EAST),
+-    SOUTH_WEST(SOUTH, WEST),
+-    WEST_NORTH_WEST(WEST, NORTH_WEST),
+-    NORTH_NORTH_WEST(NORTH, NORTH_WEST),
+-    NORTH_NORTH_EAST(NORTH, NORTH_EAST),
+-    EAST_NORTH_EAST(EAST, NORTH_EAST),
+-    EAST_SOUTH_EAST(EAST, SOUTH_EAST),
+-    SOUTH_SOUTH_EAST(SOUTH, SOUTH_EAST),
+-    SOUTH_SOUTH_WEST(SOUTH, SOUTH_WEST),
+-    WEST_SOUTH_WEST(WEST, SOUTH_WEST),
+-    SELF(0, 0, 0);
+-
+-    private final int modX;
+-    private final int modY;
+-    private final int modZ;
+-
+-    private BlockFace(final int modX, final int modY, final int modZ) {
+-        this.modX = modX;
+-        this.modY = modY;
+-        this.modZ = modZ;
+-    }
+-
+-    private BlockFace(final BlockFace face1, final BlockFace face2) {
+-        this.modX = face1.getModX() + face2.getModX();
+-        this.modY = face1.getModY() + face2.getModY();
+-        this.modZ = face1.getModZ() + face2.getModZ();
++public enum BlockFace implements Vec3Coarse<Vec3> {
++    NORTH(8, 0, 0, -1),
++    EAST(12, 1, 0, 0),
++    SOUTH(0, 0, 0, 1),
++    WEST(4, -1, 0, 0),
++    UP(-1, 0, 1, 0),
++    DOWN(-1, 0, -1, 0),
++    NORTH_EAST(10, NORTH, EAST),
++    NORTH_WEST(6, NORTH, WEST),
++    SOUTH_EAST(14, SOUTH, EAST),
++    SOUTH_WEST(2, SOUTH, WEST),
++    WEST_NORTH_WEST(5, WEST, NORTH_WEST),
++    NORTH_NORTH_WEST(7, NORTH, NORTH_WEST),
++    NORTH_NORTH_EAST(9, NORTH, NORTH_EAST),
++    EAST_NORTH_EAST(11, EAST, NORTH_EAST),
++    EAST_SOUTH_EAST(13, EAST, SOUTH_EAST),
++    SOUTH_SOUTH_EAST(15, SOUTH, SOUTH_EAST),
++    SOUTH_SOUTH_WEST(1, SOUTH, SOUTH_WEST),
++    WEST_SOUTH_WEST(3, WEST, SOUTH_WEST),
++    SELF(-1, 0, 0, 0);
++
++    private final int blockYaw; // -1 for undefined
++    private final Vec3 direction;
++
++    BlockFace(final int blockYaw, final int modX, final int modY, final int modZ) {
++        this.blockYaw = blockYaw;
++        this.direction = ImVector.of(modX, modY, modZ);
++    }
++
++    BlockFace(final int blockYaw, final BlockFace face1, final BlockFace face2) {
++        this.blockYaw = blockYaw;
++        this.direction = face1.normal().plus(face2.normal());
++    }
++
++    public boolean isHorizontal() {
++        return blockYaw >= 0;
++    }
++
++    /**
++     * A number from 0 to 15 representing the yaw of this face.
++     *
++     * The number increases in the clockwise direction looking down,
++     * and 0 is due {@link #SOUTH}.
++     *
++     * @throws UnsupportedOperationException if this face is not oriented horizontally
++     */
++    public int blockYaw() {
++        if(blockYaw < 0) {
++            throw new UnsupportedOperationException("Face " + this + " is not a horizontal direction");
++        }
++        return blockYaw;
++    }
++
++    /**
++     * The yaw of this face in degrees, between -180 and +180
++     */
++    public float yaw() {
++        return (blockYaw() + 8) * (360F / 16F) - 180F;
++    }
++
++    public Vec3 normal() {
++        return direction;
+     }
+ 
+     /**
+@@ -46,7 +82,7 @@ public enum BlockFace {
+      * @return Amount of X-coordinates to modify
+      */
+     public int getModX() {
+-        return modX;
++        return direction.coarseX();
+     }
+ 
+     /**
+@@ -55,7 +91,7 @@ public enum BlockFace {
+      * @return Amount of Y-coordinates to modify
+      */
+     public int getModY() {
+-        return modY;
++        return direction.coarseY();
+     }
+ 
+     /**
+@@ -64,7 +100,7 @@ public enum BlockFace {
+      * @return Amount of Z-coordinates to modify
+      */
+     public int getModZ() {
+-        return modZ;
++        return direction.coarseZ();
+     }
+ 
+     public BlockFace getOppositeFace() {
+@@ -129,4 +165,154 @@ public enum BlockFace {
+ 
+         return BlockFace.SELF;
+     }
++
++    private static final List<BlockFace> HORIZONTAL;
++
++    static {
++        final BlockFace[] array = new BlockFace[16];
++        for(BlockFace face : values()) {
++            if(face.isHorizontal()) {
++                array[face.blockYaw()] = face;
++            }
++        }
++        HORIZONTAL = Arrays.asList(array);
++    }
++
++    private static final BlockFace[] DIAGONAL = new BlockFace[] {
++        SOUTH_EAST,
++        SOUTH_WEST,
++        NORTH_EAST,
++        NORTH_WEST,
++    };
++
++    private static final BlockFace[] DIAGONAL_Z = new BlockFace[] {
++        SOUTH_SOUTH_EAST,
++        SOUTH_SOUTH_WEST,
++        NORTH_NORTH_EAST,
++        NORTH_NORTH_WEST,
++    };
++
++    private static final BlockFace[] DIAGONAL_X = new BlockFace[] {
++        EAST_SOUTH_EAST,
++        WEST_SOUTH_WEST,
++        EAST_NORTH_EAST,
++        WEST_NORTH_WEST,
++    };
++
++    /**
++     * All horizontally oriented faces, starting with {@link #SOUTH}
++     * and increasing clockwise looking down.
++     */
++    public static List<BlockFace> horizontal() {
++        return HORIZONTAL;
++    }
++
++    /**
++     * The horizontal face representing the given yaw direction.
++     *
++     * The yaw is wrapped to fit in the range 0 to 15.
++     */
++    public static BlockFace byBlockYaw(int yaw) {
++        return HORIZONTAL.get(NumberConversions.mod(yaw, 16));
++    }
++
++    /**
++     * Return the horizontal face that is closest to the given yaw in degrees.
++     */
++    public static BlockFace byYaw(float degrees) {
++        return byBlockYaw(Math.round(degrees * (16F / 360F)));
++    }
++
++    public static BlockFace byDirection(Vec3 direction) {
++        if(direction instanceof BlockFace) return (BlockFace) direction;
++        return byDirection(direction.fineX(),
++                           direction.fineY(),
++                           direction.fineZ());
++    }
++
++    public static BlockFace byDirection(double x, double y, double z) {
++        if(y != 0) {
++            // vertical
++            if(x != 0 || z != 0) {
++                throw new IllegalArgumentException("No " + BlockFace.class.getSimpleName() +
++                                                   " for direction " + x + ", " + y + ", " + z);
++            }
++            return y > 0 ? UP : DOWN;
++        } else if(z == 0) {
++            // on X axis (including origin)
++            return x > 0 ? EAST : x < 0 ? WEST : SELF;
++        } else if(x == 0) {
++            // on Z axis
++            return z > 0 ? SOUTH : NORTH;
++        } else {
++            // diagonal
++            int quadrant = 0;
++            if(z < 0) quadrant += 2;
++            if(x < 0) quadrant += 1;
++
++            final double ax = Math.abs(x);
++            final double az = Math.abs(z);
++
++            if(ax > az) {
++                // X major
++                return DIAGONAL_X[quadrant];
++            } else if(ax < az) {
++                // Z major
++                return DIAGONAL_Z[quadrant];
++            } else {
++                // 45 degrees
++                return DIAGONAL[quadrant];
++            }
++        }
++    }
++
++    @Override
++    public int coarseX() {
++        return direction.coarseX();
++    }
++
++    @Override
++    public int coarseY() {
++        return direction.coarseY();
++    }
++
++    @Override
++    public int coarseZ() {
++        return direction.coarseZ();
++    }
++
++    @Override
++    public BlockFace copy() {
++        return this;
++    }
++
++    @Override
++    public MutableVec3 mutableCopy() {
++        return direction.mutableCopy();
++    }
++
++    @Override
++    public Vec3 fineCopy() {
++        return direction.fineCopy();
++    }
++
++    @Override
++    public Vec3 fineOf(double x, double y, double z) {
++        return direction.fineOf(x, y, z);
++    }
++
++    @Override
++    public Vec3 fineZero() {
++        return direction.fineZero();
++    }
++
++    @Override
++    public Vec3 coarseOf(int x, int y, int z) {
++        return direction.coarseOf(x, y, z);
++    }
++
++    @Override
++    public Vec3 coarseZero() {
++        return direction.coarseZero();
++    }
+ }
+diff --git a/src/main/java/org/bukkit/geometry/Axis.java b/src/main/java/org/bukkit/geometry/Axis.java
+new file mode 100644
+index 0000000..d0122e6
+--- /dev/null
++++ b/src/main/java/org/bukkit/geometry/Axis.java
+@@ -0,0 +1,63 @@
++package org.bukkit.geometry;
++
++import org.bukkit.block.BlockFace;
++import org.bukkit.util.ImVector;
++
++/**
++ * Represents one of the three spatial axes
++ */
++public enum Axis {
++
++    X(ImVector.of(1, 0, 0)),
++    Y(ImVector.of(0, 1, 0)),
++    Z(ImVector.of(0, 0, 1));
++
++    public static final Axis EAST_WEST = X;
++    public static final Axis UP_DOWN = Y;
++    public static final Axis NORTH_SOUTH = Z;
++
++    private final Vec3 positive, negative;
++    private final BlockFace positiveFace, negativeFace;
++
++    Axis(Vec3 positive) {
++        this.positive = positive;
++        this.negative = positive.negate();
++        this.positiveFace = BlockFace.byDirection(this.positive);
++        this.negativeFace = BlockFace.byDirection(this.negative);
++    }
++
++    /**
++     * Is this axis horizontally oriented?
++     */
++    boolean isHorizontal() {
++        return this != Y;
++    }
++
++    /**
++     * Return a unit vector pointing in the positive direction along this axis
++     */
++    public Vec3 positive() {
++        return positive;
++    }
++
++    /**
++     * Return a unit vector pointing in the negative direction along this axis
++     */
++    public Vec3 negative() {
++        return negative;
++    }
++
++    /**
++     * Return the {@link BlockFace} facing in the positive direction along this axis
++     */
++    public BlockFace positiveFace() {
++        return positiveFace;
++    }
++
++    /**
++     * Return the {@link BlockFace} facing in the negative direction along this axis
++     */
++    public BlockFace negativeFace() {
++        return negativeFace;
++    }
++}
+diff --git a/src/main/java/org/bukkit/geometry/BlockReflection.java b/src/main/java/org/bukkit/geometry/BlockReflection.java
+new file mode 100644
+index 0000000..04d175c
+--- /dev/null
++++ b/src/main/java/org/bukkit/geometry/BlockReflection.java
+@@ -0,0 +1,56 @@
++package org.bukkit.geometry;
++
++/**
++ * A reflection transform that can be applied to blocks,
++ * i.e. reflection in either the X or Z axes, or no reflection at all.
++ */
++public enum BlockReflection {
++
++    NONE(IdentityTransform.INSTANCE),
++
++    LEFT_RIGHT(new BlockTransform(
++        1, 0,
++        0, -1,
++        0, 0, 0
++    )),
++
++    FRONT_BACK(new BlockTransform(
++        -1, 0,
++        0, 1,
++        0, 0, 0
++    ));
++
++    public static final BlockReflection X = FRONT_BACK;
++    public static final BlockReflection Z = LEFT_RIGHT;
++
++    public static final BlockReflection EAST_WEST = FRONT_BACK;
++    public static final BlockReflection NORTH_SOUTH = LEFT_RIGHT;
++
++    /**
++     * Return the reflection along the given {@link Axis}, which must be X or Z.
++     */
++    public static BlockReflection inAxis(Axis axis) {
++        switch(axis) {
++            case X: return FRONT_BACK;
++            case Z: return LEFT_RIGHT;
++        }
++        throw new IllegalArgumentException("Cannot reflect blocks in the " + axis + " axis");
++    }
++
++    private final CoarseTransform transform;
++
++    BlockReflection(CoarseTransform transform) {
++        this.transform = transform;
++    }
++
++    public boolean isIdentity() {
++        return this == NONE;
++    }
++
++    /**
++     * Return a {@link CoarseTransform} equivalent to this reflection.
++     */
++    public CoarseTransform transform() {
++        return transform;
++    }
++}
+diff --git a/src/main/java/org/bukkit/geometry/BlockRotation.java b/src/main/java/org/bukkit/geometry/BlockRotation.java
+new file mode 100644
+index 0000000..5e1bb1a
+--- /dev/null
++++ b/src/main/java/org/bukkit/geometry/BlockRotation.java
+@@ -0,0 +1,94 @@
++package org.bukkit.geometry;
++
++import org.bukkit.util.NumberConversions;
++
++/**
++ * A rotation transform that can be applied to blocks,
++ * i.e. a rotation around the Y axis in units of 90 degrees.
++ *
++ * Wherever rotations are represented as a number of turns,
++ * these turns are always clockwise looking down.
++ */
++public enum BlockRotation {
++
++    NONE(IdentityTransform.INSTANCE),
++    CLOCKWISE_90(makeTransform(1)),
++    CLOCKWISE_180(makeTransform(2)),
++    COUNTERCLOCKWISE_90(makeTransform(3));
++
++    public static final BlockRotation CLOCKWISE_270 = COUNTERCLOCKWISE_90;
++    public static final BlockRotation COUNTERCLOCKWISE_180 = CLOCKWISE_180;
++    public static final BlockRotation COUNTERCLOCKWISE_270 = CLOCKWISE_90;
++
++    private static int sin(int turns) {
++        switch(turns) {
++            default: return 0;
++            case 1: return 1;
++            case 3: return -1;
++        }
++    }
++
++    private static int cos(int turns) {
++        switch(turns) {
++            default: return 0;
++            case 0: return 1;
++            case 2: return -1;
++        }
++    }
++
++    private static CoarseTransform makeTransform(int turns) {
++        return new BlockTransform(
++            cos(turns), -sin(turns),
++            sin(turns), cos(turns),
++            0, 0, 0
++        );
++    }
++
++    /**
++     * Return the rotation for the given number of 90 degree clockwise turns.
++     *
++     * The number can be any positive or negative amount.
++     */
++    public static BlockRotation turns(int turns) {
++        return values()[NumberConversions.mod(turns, 4)];
++    }
++
++    private final CoarseTransform transform;
++
++    BlockRotation(CoarseTransform transform) {
++        this.transform = transform;
++    }
++
++    public boolean isIdentity() {
++        return this == NONE;
++    }
++
++    /**
++     * Return a {@link CoarseTransform} equivalent to this rotation.
++     */
++    public CoarseTransform transform() {
++        return transform;
++    }
++
++    /**
++     * Return the number of 90-degree clockwise turns for this rotation.
++     *
++     * This is always in the range 0 to 3 inclusive.
++     */
++    public int turns() {
++        return ordinal();
++    }
++
++    /**
++     * Apply this rotation to the given {@link Axis}
++     */
++    public Axis apply(Axis axis) {
++        if(turns() % 2 == 1) {
++            switch(axis) {
++                case X: return Axis.Z;
++                case Z: return Axis.X;
++            }
++        }
++        return axis;
++    }
++}
+diff --git a/src/main/java/org/bukkit/geometry/BlockRotoflection.java b/src/main/java/org/bukkit/geometry/BlockRotoflection.java
+new file mode 100644
+index 0000000..46e8655
+--- /dev/null
++++ b/src/main/java/org/bukkit/geometry/BlockRotoflection.java
+@@ -0,0 +1,149 @@
++package org.bukkit.geometry;
++
++import org.bukkit.util.NumberConversions;
++
++/**
++ * A combined reflection and rotation transform that can be applied to blocks.
++ *
++ * This class can represent any of the 8 transforms that affect only the state of a block (and not its position).
++ *
++ * The transform is always normalized to an optional reflection in the X axis,
++ * followed by a rotation of 0 to 3 clockwise right turns, around the Y axis, looking down.
++ */
++public class BlockRotoflection {
++
++    private static final BlockRotoflection[] NORMAL = new BlockRotoflection[] {
++        new BlockRotoflection(false, 0),
++        new BlockRotoflection(false, 1),
++        new BlockRotoflection(false, 2),
++        new BlockRotoflection(false, 3)
++    };
++
++    private static final BlockRotoflection[] INVERTED = new BlockRotoflection[] {
++        new BlockRotoflection(true, 0),
++        new BlockRotoflection(true, 1),
++        new BlockRotoflection(true, 2),
++        new BlockRotoflection(true, 3)
++    };
++
++    public static BlockRotoflection identity() {
++        return NORMAL[0];
++    }
++
++    /**
++     * Return the transform equivalent to the given operations
++     *
++     * @param reflect    Reflect in X axis
++     * @param turns      Number of clockwise right turns, around Y axis, facing down
++     */
++    public static BlockRotoflection of(boolean reflect, int turns) {
++        turns = NumberConversions.mod(turns, 4);
++        return reflect ? INVERTED[turns] : NORMAL[turns];
++    }
++
++    /**
++     * Return the transform equivalent to the given operations
++     */
++    public static BlockRotoflection of(BlockReflection reflection, BlockRotation rotation) {
++        if(reflection == BlockReflection.Z) {
++            // Normalize reflection axis to X
++            return of(true, rotation.turns() + 2);
++        } else {
++            return of(reflection == BlockReflection.X, rotation.turns());
++        }
++    }
++
++    /**
++     * Return the transform equivalent to the given reflection alone
++     */
++    public static BlockRotoflection of(BlockReflection reflection) {
++        return of(reflection, BlockRotation.NONE);
++    }
++
++    /**
++     * Return the transform equivalent to the given rotation alone
++     */
++    public static BlockRotoflection of(BlockRotation rotation) {
++        return of(false, rotation.turns());
++    }
++
++    private final BlockReflection reflection;
++    private final BlockRotation rotation;
++    private final CoarseTransform transform;
++
++    private BlockRotoflection(boolean reflect, int turns) {
++        this.reflection = reflect ? BlockReflection.X : BlockReflection.NONE;
++        this.rotation = BlockRotation.turns(turns);
++        this.transform = reflection.transform().andThen(rotation.transform());
++    }
++
++    public boolean isIdentity() {
++        return reflection.isIdentity() && rotation.isIdentity();
++    }
++
++    /**
++     * Return the reflection component of this transform,
++     * which is either {@link BlockReflection#NONE} or {@link BlockReflection#X}.
++     */
++    public BlockReflection reflection() {
++        return reflection;
++    }
++
++    /**
++     * Does this transform include a reflection?
++     */
++    boolean isReflected() {
++        return reflection != BlockReflection.NONE;
++    }
++
++    /**
++     * Return the rotation component of this transform
++     */
++    public BlockRotation rotation() {
++        return rotation;
++    }
++
++    /**
++     * Return the rotation component of this transform,
++     * as a count of clockwise right turns.
++     */
++    int turns() {
++        return rotation.turns();
++    }
++
++    /**
++     * Return a {@link CoarseTransform} equivalent to this transform
++     */
++    public CoarseTransform transform() {
++        return transform;
++    }
++
++    /**
++     * Apply this transform to the given {@link Axis}
++     */
++    public Axis apply(Axis axis) {
++        return rotation.apply(axis);
++    }
++
++    @Override
++    public int hashCode() {
++        return reflection.ordinal() * 4 +
++               rotation.ordinal();
++    }
++
++    @Override
++    public boolean equals(Object that) {
++        return this == that || (
++            that instanceof BlockRotoflection &&
++            this.reflection.equals(((BlockRotoflection) that).reflection) &&
++            this.rotation.equals(((BlockRotoflection) that).rotation)
++        );
++    }
++
++    @Override
++    public String toString() {
++        return getClass().getSimpleName() +
++               "{reflection=" + reflection +
++               " rotation=" + rotation + "}";
++    }
++}
+diff --git a/src/main/java/org/bukkit/geometry/BlockTransform.java b/src/main/java/org/bukkit/geometry/BlockTransform.java
+new file mode 100644
+index 0000000..ddd24cd
+--- /dev/null
++++ b/src/main/java/org/bukkit/geometry/BlockTransform.java
+@@ -0,0 +1,237 @@
++package org.bukkit.geometry;
++
++import java.util.Arrays;
++
++import org.bukkit.Bukkit;
++
++/**
++ * Represents by a 4x4 matrix of the form:
++ *
++ *     [ xx  0   xz  xt ]
++ *     [ 0   1   0   yt ]
++ *     [ zx  0   zz  zt ]
++ *     [ 0   0   0   1  ]
++ *
++ * Where
++ *
++ *     xt, yt, zt are integers
++ *
++ * and
++ *
++ *     |  xx  xz  |
++ *     |          | = -1 or 1
++ *     |  zx  zz  |
++ *
++ * i.e. the determinant of the x-z minor 2x2 matrix is -1 or 1,
++ * which ensures that area is preserved in the x-z plane,
++ * though orientation may be inverted.
++ */
++class BlockTransform implements CoarseTransform {
++
++    private final int xx, xz,
++                      zx, zz;
++    private final int xt, yt, zt;
++
++    // The x-z determinant, might come in handy
++    private final int determinant;
++
++    // Cached inverse
++    private BlockTransform inverse;
++
++    BlockTransform(int xx, int xz, int zx, int zz, int xt, int yt, int zt) {
++        this(null, xx, xz, zx, zz, xt, yt, zt);
++    }
++
++    BlockTransform(BlockTransform inverse, int xx, int xz, int zx, int zz, int xt, int yt, int zt) {
++        this.determinant = xx * zz - xz * zx;
++
++        if(determinant != -1 && determinant != 1) {
++            throw new IllegalArgumentException(
++                "Invalid block transform - coefficients do not preserve area: [ " + xx + " " + xz + " ], [ " + zx + " " + zz + " ]"
++            );
++        }
++
++        this.inverse = inverse;
++
++        this.xx = xx; this.xz = xz;
++        this.zx = zx; this.zz = zz;
++
++        this.xt = xt; this.yt = yt; this.zt = zt;
++    }
++
++    @Override
++    public boolean isIdentity() {
++        return xx == 1 && xz == 0 &&
++               zx == 0 && zz == 1 &&
++               xt == 0 && yt == 0 && zt == 0;
++    }
++
++    @Override
++    public Vec3 apply(Vec3 v) {
++        if(v.isFine()) {
++            final double x = v.fineX();
++            final double y = v.fineY();
++            final double z = v.fineZ();
++
++            return Bukkit.vectors().fine(
++                x * xx + z * xz + xt,
++                y + yt,
++                x * zx + z * zz + zt
++            );
++        } else {
++            final int x = v.coarseX();
++            final int y = v.coarseY();
++            final int z = v.coarseZ();
++
++            return Bukkit.vectors().coarse(
++                x * xx + z * xz + xt,
++                y + yt,
++                x * zx + z * zz + zt
++            );
++        }
++    }
++
++    @Override
++    public void applyInPlace(MutableVec3 v) {
++        if(v.isFine()) {
++            final double x = v.fineX();
++            final double y = v.fineY();
++            final double z = v.fineZ();
++
++            v.set(
++                x * xx + z * xz + xt,
++                y + yt,
++                x * zx + z * zz + zt
++            );
++        } else {
++            final int x = v.coarseX();
++            final int y = v.coarseY();
++            final int z = v.coarseZ();
++
++            v.set(
++                x * xx + z * xz + xt,
++                y + yt,
++                x * zx + z * zz + zt
++            );
++        }
++    }
++
++    @Override
++    public CoarseTransform inverse() {
++        if(inverse == null) {
++            inverse = new BlockTransform(
++                this,
++                xx, zx,
++                xz, zz,
++                - xx * xt - zx * zt,
++                - yt,
++                - xz * xt - zz * zt
++            );
++        }
++        return inverse;
++    }
++
++    @Override
++    public CoarseTransform compose(CoarseTransform before) {
++        if(before instanceof BlockTransform) {
++            final BlockTransform that = (BlockTransform) before;
++            return new BlockTransform(
++                this.xx * that.xx + this.xz * that.zx, this.xx * that.xz + this.xz * that.zz,
++                this.zx * that.xx + this.zz * that.zx, this.zx * that.xz + this.zz * that.zz,
++                this.xx * that.xt + this.xz * that.zt + this.xt,
++                this.yt + that.yt,
++                this.zx * that.xt + this.zz * that.zt + this.zt
++            );
++        }
++
++        return before.andThen(this);
++    }
++
++    @Override
++    public Transform compose(Transform before) {
++        if(before instanceof CoarseTransform) {
++            return compose((CoarseTransform) before);
++        }
++
++        return before.andThen(this);
++    }
++
++    @Override
++    public CoarseTransform andThen(CoarseTransform after) {
++        return after.compose(this);
++    }
++
++    @Override
++    public Transform andThen(Transform after) {
++        return after.compose(this);
++    }
++
++    @Override
++    public BlockRotoflection orientation() {
++        /*
++
++        + 0     0 -     - 0     0 +
++        0 +     + 0     0 -     - 0
++
++        - 0     0 -     + 0     0 +
++        0 +     - 0     0 -     + 0
++
++         */
++        if(xx < 0) {
++            if(zz < 0) {
++                return BlockRotoflection.of(false, 2);
++            } else {
++                return BlockRotoflection.of(true, 0);
++            }
++        } else if(xx > 0) {
++            if(zz < 0) {
++                return BlockRotoflection.of(true, 2);
++            } else {
++                return BlockRotoflection.of(false, 0);
++            }
++        } else if(xz < 0) {
++            if(zx < 0) {
++                return BlockRotoflection.of(true, 1);
++            } else {
++                return BlockRotoflection.of(false, 1);
++            }
++        } else {
++            if(zx < 0) {
++                return BlockRotoflection.of(false, 3);
++            } else {
++                return BlockRotoflection.of(true, 3);
++            }
++        }
++    }
++
++    @Override
++    public int hashCode() {
++        // Identity transform is always 0
++        return isIdentity() ? 0 : Arrays.hashCode(new int[]{xx, xz, zx, zz, xt, yt, zt});
++    }
++
++    @Override
++    public boolean equals(Object obj) {
++        if(this == obj) return true;
++
++        if(obj instanceof BlockTransform) {
++            final BlockTransform that = (BlockTransform) obj;
++            return this.xx == that.xx &&
++                   this.xz == that.xz &&
++                   this.zx == that.zx &&
++                   this.zz == that.zz &&
++                   this.xt == that.xt &&
++                   this.yt == that.yt &&
++                   this.zt == that.zt;
++        }
++
++        return obj.equals(this);
++    }
++
++    @Override
++    public String toString() {
++        return Transform.class.getSimpleName() +
++               "{orientation=" + orientation() +
++               " translation=(" + xt + ", " + yt + ", " + zt + ")}";
++    }
++}
+diff --git a/src/main/java/org/bukkit/geometry/CoarseTransform.java b/src/main/java/org/bukkit/geometry/CoarseTransform.java
+new file mode 100644
+index 0000000..ef931bc
+--- /dev/null
++++ b/src/main/java/org/bukkit/geometry/CoarseTransform.java
+@@ -0,0 +1,59 @@
++package org.bukkit.geometry;
++
++/**
++ * A transform that can be applied to blocks, i.e. any combination
++ * of reflection along horizontal axes, right-angle rotation, and
++ * translation by integer offsets.
++ */
++public interface CoarseTransform extends Transform {
++
++    BlockRotoflection orientation();
++
++    @Override
++    CoarseTransform inverse();
++
++    CoarseTransform compose(CoarseTransform before);
++
++    CoarseTransform andThen(CoarseTransform after);
++
++    @Override
++    default CoarseTransform translate(int x, int y, int z) {
++        return andThen(translation(x, y, z));
++    }
++
++    @Override
++    default CoarseTransform translate(Vec3 offset) {
++        return andThen(translation(offset));
++    }
++
++    @Override
++    default CoarseTransform reflect(Axis axis) {
++        return andThen(reflection(axis));
++    }
++
++    @Override
++    default CoarseTransform rotate(int turns) {
++        return andThen(rotation(turns));
++    }
++
++    static CoarseTransform translation(int x, int y, int z) {
++        if(x == 0 && y == 0 && z == 0) return Transform.identity();
++        return new BlockTransform(
++            1, 0,
++            0, 1,
++            x, y, z
++        );
++    }
++
++    static CoarseTransform translation(Vec3 offset) {
++        return translation(offset.coarseX(), offset.coarseY(), offset.coarseZ());
++    }
++
++    static CoarseTransform reflection(Axis axis) {
++        return BlockReflection.inAxis(axis).transform();
++    }
++
++    static CoarseTransform rotation(int turns) {
++        return BlockRotation.turns(turns).transform();
++    }
++}
+diff --git a/src/main/java/org/bukkit/geometry/Cuboid.java b/src/main/java/org/bukkit/geometry/Cuboid.java
+new file mode 100644
+index 0000000..ba64e92
+--- /dev/null
++++ b/src/main/java/org/bukkit/geometry/Cuboid.java
+@@ -0,0 +1,589 @@
++package org.bukkit.geometry;
++
++import java.util.Objects;
++import java.util.Random;
++
++import org.bukkit.Bukkit;
++import org.bukkit.region.BlockRegion;
++import org.bukkit.region.CuboidBlockRegion;
++import org.bukkit.util.ImVector;
++import org.bukkit.util.NumberConversions;
++import org.bukkit.util.Vector;
++
++/**
++ * Represents an axis-aligned cuboid (box) in fine (real-valued) coordinates
++ *
++ * In fine-space, all boundaries of the cuboid are closed. That is, points on
++ * any boundary are considered inside the cuboid. Blocks are considered inside
++ * the cuboid if and only if their center points are inside.
++ *
++ * Cuboids can be unbounded in any combination of the 6 directions, in which case
++ * the respective coordinate will be +/- Infinity.
++ *
++ * Cuboids can have zero length on any combination of axes, in which case the
++ * minimum and maximum coordinates on those axes will be equal. If any axis has
++ * zero length, then the cuboid has zero volume, but may still contain points
++ * that lie on the degenerate boundary.
++ *
++ * There is a single "empty cuboid" which has the following properties:
++ *
++ *      - It is equal only to itself.
++ *      - It contains no points or other spatial objects, except for itself.
++ *      - It is contained by all other cuboids.
++ *      - It's minimum and maximum points are the NaN vector, as are any other points
++ *        in space that are generated from the cuboid.
++ *      - Attempts to generate any coarse points will throw an {@link ArithmeticException}.
++ *      - Any relative measurements of the cuboid (such as size or volume) are zero.
++ *
++ * The empty cuboid is returned in these cases:
++ *
++ *      - Calling {@link #empty()}
++ *      - Trying to construct a cuboid with any NaN values
++ *      - Trying to construct a cuboid with negative length in any axis
++ *      - Trying to construct a cuboid enclosing an empty set of points
++ */
++public abstract class Cuboid implements Region {
++
++    protected final ImVector min;
++    protected final ImVector max;
++
++    Cuboid(Vec3 min, Vec3 max) {
++        this.min = ImVector.copyOf(min);
++        this.max = ImVector.copyOf(max);
++    }
++
++    /**
++     * Create a minimal cuboid enclosing the given pair of points
++     *
++     * The relative order of the points on any axis does not matter.
++     */
++    public static Cuboid between(Vec3 a, Vec3 b) {
++        if(a.anyNaN() || b.anyNaN()) return empty();
++        return new NonEmptyCuboid(a.minimum(b), a.maximum(b));
++    }
++
++    /**
++     * Create a cuboid with the given minimum corner and size
++     */
++    public static Cuboid fromMinAndSize(Vec3 min, Vec3 size) {
++        if(min.anyNaN() || size.anyNaN() ||
++           size.fineX() < 0 || size.fineY() < 0 || size.fineZ() < 0) return empty();
++        return new NonEmptyCuboid(min, min.plus(size));
++    }
++
++    /**
++     * Create a minimal bounding box containing all of the given points
++     */
++    public static Cuboid enclosing(Vec3... points) {
++        if(points.length == 0) return empty();
++
++        final Vector min = new Vector(Double.POSITIVE_INFINITY);
++        final Vector max = new Vector(Double.NEGATIVE_INFINITY);
++
++        for(Vec3 p : points) {
++            if(p.anyNaN()) return empty();
++            min.minimize(p);
++            max.maximize(p);
++        }
++
++        return between(min, max);
++    }
++
++    /**
++     * Return the cuboid that is unbounded in all directions
++     */
++    public static Cuboid unbounded() {
++        return NonEmptyCuboid.UNBOUNDED;
++    }
++
++    /**
++     * Return the inverse of the {@link #unbounded()} cuboid
++     */
++    public static Cuboid empty() {
++        return EmptyCuboid.INSTANCE;
++    }
++
++    /**
++     * Return the largest cuboid contained entirely within both of the given cuboids
++     */
++    public static Cuboid intersect(Cuboid a, Cuboid b) {
++        if(a.contains(b)) {
++            return b;
++        } else if(b.contains(a)) {
++            return a;
++        } else {
++            return between(a.min.maximum(b.min),
++                           a.max.minimum(b.max));
++        }
++    }
++
++    /**
++     * Return the smallest cuboid containing both of the given cuboids
++     */
++    public static Cuboid union(Cuboid a, Cuboid b) {
++        if(a.contains(b)) {
++            return a;
++        } else if(b.contains(a)) {
++            return b;
++        } else {
++            return between(a.min.minimum(b.min),
++                           a.max.maximum(b.max));
++        }
++    }
++
++    /**
++     * Return the smallest cuboid containing the given original cuboid, after subtracting the other given cuboid.
++     */
++    public static Cuboid complement(Cuboid original, Cuboid subtracted) {
++        // The booleans reflect if the subtracted set contains the
++        // original set on each axis. The final bounds for each axis
++        // are then the minimum of the two sets, if the other two axes
++        // are containing, otherwise the bounds of the original set.
++        boolean cx = subtracted.min.fineX() < original.min.fineX() && subtracted.max.fineX() > original.max.fineX();
++        boolean cy = subtracted.min.fineY() < original.min.fineY() && subtracted.max.fineY() > original.max.fineY();
++        boolean cz = subtracted.min.fineZ() < original.min.fineZ() && subtracted.max.fineZ() > original.max.fineZ();
++        return between(ImVector.of(cy && cz ? Math.max(original.min.fineX(), subtracted.min.fineX()) : original.min.fineX(),
++                                   cz && cx ? Math.max(original.min.fineY(), subtracted.min.fineY()) : original.min.fineY(),
++                                   cx && cy ? Math.max(original.min.fineZ(), subtracted.min.fineZ()) : original.min.fineZ()),
++                       ImVector.of(cy && cz ? Math.min(original.max.fineX(), subtracted.max.fineX()) : original.max.fineX(),
++                                   cz && cx ? Math.min(original.max.fineY(), subtracted.max.fineY()) : original.max.fineY(),
++                                   cx && cy ? Math.min(original.max.fineZ(), subtracted.max.fineZ()) : original.max.fineZ()));
++    }
++
++    @Override
++    public Cuboid bounds() {
++        return this;
++    }
++
++    /**
++     * Return the distance from the origin of the given ray to the point
++     * where it first intersects this cuboid. If the ray originates inside
++     * the cuboid, zero is returned.
++     *
++     * If the ray does not intersect the cuboid, but the line of the ray does
++     * intersect (behind the ray's origin), then a negative distance is returned.
++     *
++     * In any other case, NaN is returned.
++     */
++    public abstract double intersectionDistance(Ray ray);
++
++    /**
++     * Return the point at which the given ray enters this cuboid,
++     * or null if the ray does not intersect the cuboid. If the ray
++     * originates inside the cuboid, the ray's origin point is returned.
++     */
++    public abstract ImVector intersect(Ray ray);
++
++
++    /**
++     * Construct a cuboid by translating this cuboid by the given offset
++     */
++    public abstract Cuboid translate(Vec3 offset);
++
++    public abstract Cuboid transform(Transform transform);
++
++    /**
++     * Does this cuboid fully enclose the given cuboid?
++     */
++    public abstract boolean contains(Cuboid cuboid);
++
++    /**
++     * Return the minimum corner of this cuboid
++     */
++    public ImVector minimum() {
++        return min;
++    }
++
++    /**
++     * Return the maximum corner of this cuboid
++     */
++    public ImVector maximum() {
++        return max;
++    }
++
++    /**
++     * Return the dimensions of this cuboid
++     */
++    public ImVector size() {
++        return max.minus(min);
++    }
++
++    public double volume() {
++        final ImVector size = size();
++        return size.fineX() * size.fineY() * size.fineZ();
++    }
++
++    /**
++     * Return the center point of this cuboid
++     */
++    public ImVector center() {
++        return ImVector.copyOf(min.midway(max));
++    }
++
++    /**
++     * Return the eight corner points of this cuboid
++     */
++    public ImVector[] vertices() {
++        return new ImVector[] {
++            min,
++            ImVector.of(min.fineX(), min.fineY(), max.fineZ()),
++            ImVector.of(min.fineX(), max.fineY(), min.fineZ()),
++            ImVector.of(min.fineX(), max.fineY(), max.fineZ()),
++            ImVector.of(max.fineX(), min.fineY(), min.fineZ()),
++            ImVector.of(max.fineX(), min.fineY(), max.fineZ()),
++            ImVector.of(max.fineX(), max.fineY(), min.fineZ()),
++            max
++        };
++    }
++
++    /**
++     * Generate an evenly distributed random point inside this cuboid,
++     * using the given source of random numbers.
++     *
++     * {@link Random#nextDouble()} is used to choose the individual
++     * components, so the range of possible coordinates includes the
++     * lower bounds of the cuboid, but not the upper bounds.
++     *
++     * @throws ArithmeticException if the cuboid is unbounded
++     */
++    public abstract ImVector randomPointInside(Random random);
++
++    /**
++     * Return the lowest block with a center point inside this cuboid
++     */
++    public abstract Vec3 minimumBlockInside();
++
++    /**
++     * Return the highest block with a center point inside this cuboid
++     */
++    public abstract Vec3 maximumBlockInside();
++
++    /**
++     * Return the lowest block with a center point that is greater,
++     * on all axes, than any point in the cuboid.
++     *
++     * This block will have coordinates one greater than {@link #maximumBlockInside()}.
++     */
++    public abstract Vec3 minimumBlockOutside();
++
++    /**
++     * Return number of blocks on each axis with center points inside this cuboid.
++     */
++    public abstract Vec3 blockSize();
++}
++
++class NonEmptyCuboid extends Cuboid {
++
++    static final Cuboid UNBOUNDED = new NonEmptyCuboid(ImVector.of(Double.NEGATIVE_INFINITY),
++                                                       ImVector.of(Double.POSITIVE_INFINITY));
++
++    public NonEmptyCuboid(Vec3 min, Vec3 max) {
++        super(min, max);
++    }
++
++    @Override
++    public String toString() {
++        return getClass().getSimpleName() + "{min=[" + min.toString() + "],max=[" + max.toString() + "]}";
++    }
++
++    @Override
++    public int hashCode() {
++        return Objects.hash(min, max);
++    }
++
++    @Override
++    public boolean equals(Object obj) {
++        if(this == obj) return true;
++        if(!(obj instanceof Cuboid)) return false;
++        final Cuboid that = (Cuboid) obj;
++        return min.equals(that.minimum()) && max.equals(that.max);
++    }
++
++    /**
++     * Return the distance from the origin of the given ray to the point
++     * where it first intersects this cuboid. If the ray originates inside
++     * the cuboid, zero is returned.
++     *
++     * If the ray does not intersect the cuboid, but the line of the ray does
++     * intersect (behind the ray's origin), then a negative distance is returned.
++     *
++     * In any other case, NaN is returned.
++     */
++    public double intersectionDistance(Ray ray) {
++        // Find the distances to both boundaries on each axis
++        final ImVector d1 = min.minus(ray.origin()).over(ray.normal());
++        final ImVector d2 = max.minus(ray.origin()).over(ray.normal());
++
++        // Sort the distances into near and far for each axis
++        final ImVector near = d1.minimum(d2);
++        final ImVector far = d1.maximum(d2);
++
++        // Last near point enters the cuboid
++        // First far point exits the cuboid
++        final double enter = NumberConversions.max(near.fineX(), near.fineY(), near.fineZ());
++        final double exit = NumberConversions.min(far.fineX(), far.fineY(), far.fineZ());
++
++        // If the ray enters the cuboid before it exits, then it intersects
++        return enter <= exit ? enter : Double.NaN;
++    }
++
++    /**
++     * Return the point at which the given ray enters this cuboid,
++     * or null if the ray does not intersect the cuboid. If the ray
++     * originates inside the cuboid, the ray's origin point is returned.
++     */
++    public ImVector intersect(Ray ray) {
++        final double distance = intersectionDistance(ray);
++        if(distance == 0) {
++            return ray.origin();
++        } else if(distance > 0) {
++            return ray.origin().plus(ray.normal().times(distance));
++        } else {
++            return null;
++        }
++    }
++
++    /**
++     * Construct a cuboid by translating this cuboid by the given offset
++     */
++    public Cuboid translate(Vec3 offset) {
++        return offset.isZero() ? this : new NonEmptyCuboid(min.plus(offset), max.plus(offset));
++    }
++
++    public Cuboid transform(Transform transform) {
++        return transform.isIdentity() ? this : new NonEmptyCuboid(transform.apply(min), transform.apply(max));
++    }
++
++    public boolean isFinite() {
++        return !(Double.isInfinite(min.fineX()) || Double.isInfinite(max.fineX()) ||
++                 Double.isInfinite(min.fineY()) || Double.isInfinite(max.fineY()) ||
++                 Double.isInfinite(min.fineZ()) || Double.isInfinite(max.fineZ()));
++    }
++
++    public boolean isBlockFinite() {
++        return !(Double.isInfinite(min.fineX()) || Double.isInfinite(max.fineX()) ||
++                 Double.isInfinite(min.fineZ()) || Double.isInfinite(max.fineZ()));
++    }
++
++    public boolean isEmpty() {
++        return false;
++    }
++
++    public boolean contains(Vec3 point) {
++        return min.fineLessOrEqual(point) && max.fineGreaterOrEqual(point);
++    }
++
++    /**
++     * Does this cuboid fully enclose the given cuboid?
++     */
++    public boolean contains(Cuboid cuboid) {
++        return cuboid.isEmpty() || (contains(cuboid.minimum()) && cuboid.contains(minimum()));
++    }
++
++    /**
++     * Generate an evenly distributed random point inside this cuboid,
++     * using the given source of random numbers.
++     *
++     * {@link Random#nextDouble()} is used to choose the individual
++     * components, so the range of possible coordinates includes the
++     * lower bounds of the cuboid, but not the upper bounds.
++     *
++     * @throws ArithmeticException if the cuboid is unbounded
++     */
++    public ImVector randomPointInside(Random random) {
++        assertFinite();
++        final ImVector size = size();
++        return min.plus(size.fineX() * random.nextDouble(),
++                        size.fineY() * random.nextDouble(),
++                        size.fineZ() * random.nextDouble());
++    }
++
++    /**
++     * Return the lowest block with a center point inside this cuboid
++     */
++    public Vec3 minimumBlockInside() {
++        assertBlockFinite();
++        return Bukkit.vectors().coarse(min.fineX() + 0.5d,
++                                       NumberConversions.clamp(min.fineY(), 0, 256) + 0.5d,
++                                       min.fineZ() + 0.5d);
++    }
++
++    /**
++     * Return the highest block with a center point inside this cuboid
++     */
++    public Vec3 maximumBlockInside() {
++        assertBlockFinite();
++        return Bukkit.vectors().coarse(max.fineX() - 0.5d,
++                                       NumberConversions.clamp(max.fineY(), 0, 256) - 0.5d,
++                                       max.fineZ() - 0.5d);
++    }
++
++    /**
++     * Return the lowest block with a center point that is greater,
++     * on all axes, than any point in the cuboid.
++     *
++     * This block will have coordinates one greater than {@link #maximumBlockInside()}.
++     */
++    public Vec3 minimumBlockOutside() {
++        assertBlockFinite();
++        return Bukkit.vectors().coarse(max.fineX() + 0.5d,
++                                       NumberConversions.clamp(max.fineY(), 0, 256) + 0.5d,
++                                       max.fineZ() + 0.5d);
++    }
++
++    public boolean containsBlock(Vec3 v) {
++        return v.coarseGreaterOrEqual(minimumBlockInside()) &&
++               v.coarseLess(minimumBlockOutside());
++    }
++
++    /**
++     * Return number of blocks on each axis with center points inside this cuboid.
++     */
++    public Vec3 blockSize() {
++        return minimumBlockOutside().minus(minimumBlockInside());
++    }
++
++    public int blockVolume() {
++        final Vec3 size = blockSize();
++        if(size.coarseX() <= 0 || size.coarseY() <= 0 || size.coarseZ() <= 0) return 0;
++        return size.coarseX() * size.coarseY() * size.coarseZ();
++    }
++
++    public boolean isBlockEmpty() {
++        return blockVolume() <= 0;
++    }
++
++    public Vec3 randomBlockInside(Random random) {
++        final Vec3 size = blockSize();
++        if(size.coarseX() <= 0 || size.coarseY() <= 0 || size.coarseZ() <= 0) {
++            throw new ArithmeticException("Cuboid contains no blocks");
++        }
++
++        return minimumBlockInside().plus(random.nextInt(size.coarseX()),
++                                         random.nextInt(size.coarseY()),
++                                         random.nextInt(size.coarseZ()));
++    }
++
++    public BlockRegion blockRegion() {
++        return CuboidBlockRegion.fromMinAndSize(minimumBlockInside(), blockSize());
++    }
++}
++
++class EmptyCuboid extends Cuboid implements EmptyRegion {
++
++    static final EmptyCuboid INSTANCE = new EmptyCuboid();
++
++    private EmptyCuboid() {
++        super(ImVector.ofNaN(), ImVector.ofNaN());
++    }
++
++    @Override
++    public int hashCode() {
++        return 0;
++    }
++
++    @Override
++    public boolean equals(Object obj) {
++        return obj instanceof Region && ((Region) obj).isEmpty();
++    }
++
++    @Override
++    public double intersectionDistance(Ray ray) {
++        return Double.NaN;
++    }
++
++    @Override
++    public ImVector intersect(Ray ray) {
++        return null;
++    }
++
++    @Override
++    public Cuboid translate(Vec3 offset) {
++        return this;
++    }
++
++    @Override
++    public Cuboid transform(Transform transform) {
++        return this;
++    }
++
++    @Override
++    public boolean isFinite() {
++        return true;
++    }
++
++    @Override
++    public boolean isBlockFinite() {
++        return true;
++    }
++
++    @Override
++    public boolean isEmpty() {
++        return true;
++    }
++
++    @Override
++    public boolean isBlockEmpty() {
++        return true;
++    }
++
++    @Override
++    public boolean contains(Vec3 point) {
++        return false;
++    }
++
++    @Override
++    public boolean contains(Cuboid cuboid) {
++        return cuboid.isEmpty();
++    }
++
++    @Override
++    public ImVector size() {
++        return ImVector.ofZero();
++    }
++
++    @Override
++    public double volume() {
++        return 0;
++    }
++
++    @Override
++    public ImVector randomPointInside(Random random) {
++        return ImVector.ofNaN();
++    }
++
++    @Override
++    public boolean containsBlock(Vec3 v) {
++        return false;
++    }
++
++    @Override
++    public Vec3 blockSize() {
++        return ImVector.ofZero();
++    }
++
++    @Override
++    public int blockVolume() {
++        return 0;
++    }
++
++    @Override
++    public BlockRegion blockRegion() {
++        return BlockRegion.empty();
++    }
++
++    @Override
++    public Vec3 minimumBlockInside() {
++        throw new ArithmeticException("Region is empty");
++    }
++
++    @Override
++    public Vec3 maximumBlockInside() {
++        throw new ArithmeticException("Region is empty");
++    }
++
++    @Override
++    public Vec3 minimumBlockOutside() {
++        throw new ArithmeticException("Region is empty");
++    }
++}
+\ No newline at end of file
+diff --git a/src/main/java/org/bukkit/geometry/Direction.java b/src/main/java/org/bukkit/geometry/Direction.java
+new file mode 100644
+index 0000000..4b193c1
+--- /dev/null
++++ b/src/main/java/org/bukkit/geometry/Direction.java
+@@ -0,0 +1,79 @@
++package org.bukkit.geometry;
++
++import org.bukkit.Bukkit;
++
++public class Direction {
++
++    private static final double TWO_PI = Math.PI * 2, HALF_PI = Math.PI / 2;
++
++    private final double yaw, pitch;
++
++    private Direction(double yaw, double pitch) {
++        this.yaw = yaw;
++        this.pitch = pitch;
++    }
++
++    public double yaw() {
++        return yaw;
++    }
++
++    public double pitch() {
++        return pitch;
++    }
++
++    public float yawDegrees() {
++        return (float) Math.toDegrees(yaw);
++    }
++
++    public float pitchDegrees() {
++        return (float) Math.toDegrees(pitch);
++    }
++
++    public Vec3 toVector() {
++        final double cos = Math.cos(pitch);
++        return Bukkit.vectors().fine(
++            -cos * Math.sin(yaw),
++            -Math.sin(pitch),
++            cos * Math.cos(yaw)
++        );
++    }
++
++    public static Direction of(double yaw, double pitch) {
++        return new Direction((yaw + TWO_PI) % TWO_PI, pitch);
++    }
++
++    public static Direction ofDegrees(double yaw, double pitch) {
++        return of(Math.toRadians(yaw), Math.toRadians(pitch));
++    }
++
++    public static Direction fromVector(double x, double y, double z) {
++        if (x == 0 && z == 0) {
++            return new Direction(0, y > 0 ? -HALF_PI : HALF_PI);
++        }
++
++        final double xz = Math.sqrt(x * x + z * z);
++        return of(Math.atan2(-x, z), Math.atan(-y / xz));
++    }
++
++    @Override
++    public int hashCode() {
++        return Double.hashCode(yaw) * 31 + Double.hashCode(pitch);
++    }
++
++    @Override
++    public boolean equals(Object obj) {
++        if(this == obj) return true;
++        if(!(obj instanceof Direction)) return false;
++        final Direction that = (Direction) obj;
++        return this.yaw == that.yaw() &&
++               this.pitch == that.pitch();
++    }
++
++    @Override
++    public String toString() {
++        return getClass().getSimpleName() +
++               "{yaw=" + yaw +
++               " pitch=" + pitch +
++               "}";
++    }
++}
+diff --git a/src/main/java/org/bukkit/geometry/EmptyRegion.java b/src/main/java/org/bukkit/geometry/EmptyRegion.java
+new file mode 100644
+index 0000000..578e718
+--- /dev/null
++++ b/src/main/java/org/bukkit/geometry/EmptyRegion.java
+@@ -0,0 +1,82 @@
++package org.bukkit.geometry;
++
++import java.util.Random;
++
++import org.bukkit.region.BlockRegion;
++import org.bukkit.util.ImVector;
++
++public interface EmptyRegion extends Region {
++
++    default int standardHashCode() {
++        return 0;
++    }
++
++    default boolean standardEquals(Object obj) {
++        return obj instanceof Region && ((Region) obj).isEmpty();
++    }
++
++    @Override
++    default boolean isEmpty() {
++        return true;
++    }
++
++    @Override
++    default boolean isBlockEmpty() {
++        return true;
++    }
++
++    @Override
++    default boolean isFinite() {
++        return true;
++    }
++
++    @Override
++    default boolean isBlockFinite() {
++        return true;
++    }
++
++    @Override
++    default double volume() {
++        return 0;
++    }
++
++    @Override
++    default int blockVolume() {
++        return 0;
++    }
++
++    @Override
++    default boolean contains(Vec3 point) {
++        return false;
++    }
++
++    @Override
++    default boolean containsBlock(Vec3 v) {
++        return false;
++    }
++
++    @Override
++    default Vec3 randomPointInside(Random random) {
++        return ImVector.ofNaN();
++    }
++
++    @Override
++    default Vec3 randomBlockInside(Random random) {
++        throw new ArithmeticException("Region is empty");
++    }
++
++    @Override
++    default Cuboid bounds() {
++        return Cuboid.empty();
++    }
++
++    @Override
++    default BlockRegion blockRegion() {
++        return BlockRegion.empty();
++    }
++
++    @Override
++    default Region transform(Transform transform) {
++        return this;
++    }
++}
+diff --git a/src/main/java/org/bukkit/geometry/Everywhere.java b/src/main/java/org/bukkit/geometry/Everywhere.java
+new file mode 100644
+index 0000000..1c535db
+--- /dev/null
++++ b/src/main/java/org/bukkit/geometry/Everywhere.java
+@@ -0,0 +1,81 @@
++package org.bukkit.geometry;
++
++import java.util.Random;
++
++import org.bukkit.region.BlockRegion;
++
++class Everywhere implements Region {
++
++    static final Everywhere INSTANCE = new Everywhere();
++
++    private Everywhere() {}
++
++    @Override
++    public boolean isEmpty() {
++        return false;
++    }
++
++    @Override
++    public boolean isBlockEmpty() {
++        return false;
++    }
++
++    @Override
++    public boolean isFinite() {
++        return false;
++    }
++
++    @Override
++    public boolean isBlockFinite() {
++        return false;
++    }
++
++    @Override
++    public double volume() {
++        return Double.POSITIVE_INFINITY;
++    }
++
++    @Override
++    public int blockVolume() throws ArithmeticException {
++        assertBlockFinite();
++        return 0;
++    }
++
++    @Override
++    public boolean contains(Vec3 point) {
++        return true;
++    }
++
++    @Override
++    public boolean containsBlock(Vec3 v) {
++        return true;
++    }
++
++    @Override
++    public Vec3 randomPointInside(Random random) throws ArithmeticException {
++        assertFinite();
++        return null;
++    }
++
++    @Override
++    public Vec3 randomBlockInside(Random random) throws ArithmeticException {
++        assertBlockFinite();
++        return null;
++    }
++
++    @Override
++    public Cuboid bounds() {
++        return Cuboid.unbounded();
++    }
++
++    @Override
++    public BlockRegion blockRegion() throws ArithmeticException {
++        assertBlockFinite();
++        return null;
++    }
++
++    @Override
++    public Region transform(Transform transform) {
++        return this;
++    }
++}
+diff --git a/src/main/java/org/bukkit/geometry/IdentityTransform.java b/src/main/java/org/bukkit/geometry/IdentityTransform.java
+new file mode 100644
+index 0000000..827316c
+--- /dev/null
++++ b/src/main/java/org/bukkit/geometry/IdentityTransform.java
+@@ -0,0 +1,75 @@
++package org.bukkit.geometry;
++
++import org.bukkit.block.BlockFace;
++
++class IdentityTransform implements CoarseTransform {
++
++    static final IdentityTransform INSTANCE = new IdentityTransform();
++
++    private IdentityTransform() {}
++
++    @Override
++    public boolean isIdentity() {
++        return true;
++    }
++
++    @Override
++    public CoarseTransform inverse() {
++        return this;
++    }
++
++    @Override
++    public Vec3 apply(Vec3 v) {
++        return v.copy();
++    }
++
++    @Override
++    public void applyInPlace(MutableVec3 v) {
++    }
++
++    @Override
++    public BlockFace apply(BlockFace face) {
++        return face;
++    }
++
++    @Override
++    public CoarseTransform compose(CoarseTransform before) {
++        return before;
++    }
++
++    @Override
++    public CoarseTransform andThen(CoarseTransform after) {
++        return after;
++    }
++
++    @Override
++    public Transform compose(Transform before) {
++        return before;
++    }
++
++    @Override
++    public Transform andThen(Transform after) {
++        return after;
++    }
++
++    @Override
++    public BlockRotoflection orientation() {
++        return BlockRotoflection.identity();
++    }
++
++    @Override
++    public int hashCode() {
++        return 0;
++    }
++
++    @Override
++    public boolean equals(Object that) {
++        return that instanceof Transform &&
++               ((Transform) that).isIdentity();
++    }
++
++    @Override
++    public String toString() {
++        return Transform.class.getSimpleName() + "{identity}";
++    }
++}
+diff --git a/src/main/java/org/bukkit/geometry/MutableVec3.java b/src/main/java/org/bukkit/geometry/MutableVec3.java
+new file mode 100644
+index 0000000..f2b8525
+--- /dev/null
++++ b/src/main/java/org/bukkit/geometry/MutableVec3.java
+@@ -0,0 +1,123 @@
++package org.bukkit.geometry;
++
++import java.util.function.DoubleBinaryOperator;
++import java.util.function.DoubleUnaryOperator;
++import java.util.function.IntBinaryOperator;
++import java.util.function.IntUnaryOperator;
++
++/**
++ * Extends {@link Vec3} with mutating methods.
++ *
++ * All mutating methods return the vector they are called on.
++ *
++ * Due to the sordid history of Bukkit vector types, some implementors
++ * of this interface are NOT, in fact, mutable. However, all vectors that
++ * are mutable do implement this interface.
++ *
++ * @see MutableVec3Coarse
++ * @see MutableVec3Fine
++ */
++public interface MutableVec3 extends Vec3 {
++
++    /**
++     * Return an unmodifiable view of this vector
++     */
++    Vec3 unmodifiable();
++
++    MutableVec3 setX(double x);
++    MutableVec3 setY(double y);
++    MutableVec3 setZ(double z);
++
++    MutableVec3 setX(int x);
++    MutableVec3 setY(int y);
++    MutableVec3 setZ(int z);
++
++    MutableVec3 set(int x, int y, int z);
++    MutableVec3 set(double x, double y, double z);
++    MutableVec3 set(Vec3 v);
++
++    MutableVec3 setZero();
++
++    MutableVec3 modify(IntUnaryOperator op);
++    MutableVec3 modify(DoubleUnaryOperator op);
++    MutableVec3 modify(Vec3 v, IntBinaryOperator op);
++    MutableVec3 modify(Vec3 v, DoubleBinaryOperator op);
++
++    MutableVec3 add(int x, int y, int z);
++    MutableVec3 add(double x, double y, double z);
++    MutableVec3 add(Vec3 v);
++
++    MutableVec3 subtract(int x, int y, int z);
++    MutableVec3 subtract(double x, double y, double z);
++    MutableVec3 subtract(Vec3 v);
++
++    MutableVec3 multiply(int x, int y, int z);
++    MutableVec3 multiply(double x, double y, double z);
++    MutableVec3 multiply(Vec3 v);
++
++    MutableVec3 divide(int x, int y, int z);
++    MutableVec3 divide(double x, double y, double z);
++    MutableVec3 divide(Vec3 v);
++
++    MutableVec3 minimize(Vec3 v);
++    MutableVec3 maximize(Vec3 v);
++    MutableVec3 clamp(Vec3 min, Vec3 max);
++
++    default MutableVec3 set(Axis axis, double n) {
++        switch(axis) {
++            case X: return setX(n);
++            case Y: return setY(n);
++            case Z: return setZ(n);
++        }
++        throw new IllegalStateException();
++    }
++
++    default MutableVec3 set(Axis axis, int n) {
++        switch(axis) {
++            case X: return setX(n);
++            case Y: return setY(n);
++            case Z: return setZ(n);
++        }
++        throw new IllegalStateException();
++    }
++
++    default MutableVec3 set(int xyz) {
++        return set(xyz, xyz, xyz);
++    }
++
++    default MutableVec3 set(double xyz) {
++        return set(xyz, xyz, xyz);
++    }
++
++    default MutableVec3 add(int xyz) {
++        return add(xyz, xyz, xyz);
++    }
++
++    default MutableVec3 add(double xyz) {
++        return add(xyz, xyz, xyz);
++    }
++
++    default MutableVec3 subtract(int xyz) {
++        return subtract(xyz, xyz, xyz);
++    }
++
++    default MutableVec3 subtract(double xyz) {
++        return subtract(xyz, xyz, xyz);
++    }
++
++    default MutableVec3 multiply(int n) {
++        return multiply(n, n, n);
++    }
++
++    default MutableVec3 multiply(double n) {
++        return multiply(n, n, n);
++    }
++
++    default MutableVec3 divide(int n) {
++        return divide(n, n, n);
++    }
++
++    default MutableVec3 divide(double n) {
++        return divide(n, n, n);
++    }
++}
+diff --git a/src/main/java/org/bukkit/geometry/MutableVec3Coarse.java b/src/main/java/org/bukkit/geometry/MutableVec3Coarse.java
+new file mode 100644
+index 0000000..4dc203e
+--- /dev/null
++++ b/src/main/java/org/bukkit/geometry/MutableVec3Coarse.java
+@@ -0,0 +1,189 @@
++package org.bukkit.geometry;
++
++import java.util.function.DoubleBinaryOperator;
++import java.util.function.DoubleUnaryOperator;
++import java.util.function.IntBinaryOperator;
++import java.util.function.IntUnaryOperator;
++
++import com.google.common.base.Preconditions;
++import org.bukkit.util.NumberConversions;
++
++/**
++ * Base implementation for mutable coarse vectors.
++ *
++ * This interface is intended to help with implementation of the API.
++ * It should NOT be used by consumers of the API.
++ *
++ * @see MutableVec3Fine
++ */
++public interface MutableVec3Coarse<V extends Vec3, M extends MutableVec3Coarse<V, M>> extends MutableVec3, Vec3Coarse<V> {
++
++    @Override M setX(int x);
++    @Override M setY(int y);
++    @Override M setZ(int z);
++
++    @Override
++    M set(int x, int y, int z);
++
++    @Override
++    default boolean isMutable() {
++        return true;
++    }
++
++    @Override
++    default V copy() {
++        return coarseOf(coarseX(), coarseY(), coarseZ());
++    }
++
++    @Override
++    default M setX(double x) {
++        return setX(NumberConversions.floor(x));
++    }
++
++    @Override
++    default M setY(double y) {
++        return setY(NumberConversions.floor(y));
++    }
++
++    @Override
++    default M setZ(double z) {
++        return setZ(NumberConversions.floor(z));
++    }
++
++    @Override
++    default M setZero() {
++        return set(0, 0, 0);
++    }
++
++    @Override
++    default M set(double x, double y, double z) {
++        return set(NumberConversions.floor(x),
++                   NumberConversions.floor(y),
++                   NumberConversions.floor(z));
++    }
++
++    @Override
++    default M set(Vec3 v) {
++        return set(v.coarseX(),
++                   v.coarseY(),
++                   v.coarseZ());
++    }
++
++    @Override
++    default M modify(IntUnaryOperator op) {
++        return set(op.applyAsInt(coarseX()),
++                   op.applyAsInt(coarseY()),
++                   op.applyAsInt(coarseZ()));
++    }
++
++    @Override
++    default M modify(DoubleUnaryOperator op) {
++        return set(op.applyAsDouble(fineX()),
++                   op.applyAsDouble(fineY()),
++                   op.applyAsDouble(fineZ()));
++    }
++
++    @Override
++    default M modify(Vec3 v, IntBinaryOperator op) {
++        return set(op.applyAsInt(coarseX(), v.coarseX()),
++                   op.applyAsInt(coarseY(), v.coarseY()),
++                   op.applyAsInt(coarseZ(), v.coarseZ()));
++    }
++
++    @Override
++    default M modify(Vec3 v, DoubleBinaryOperator op) {
++        return set(op.applyAsDouble(fineX(), v.fineX()),
++                   op.applyAsDouble(fineY(), v.fineY()),
++                   op.applyAsDouble(fineZ(), v.fineZ()));
++    }
++
++    @Override
++    default M minimize(Vec3 v) {
++        return modify(v, (IntBinaryOperator) Math::min);
++    }
++
++    @Override
++    default M maximize(Vec3 v) {
++        return modify(v, (IntBinaryOperator) Math::max);
++    }
++
++    @Override
++    default M clamp(Vec3 min, Vec3 max) {
++        Preconditions.checkArgument(min.coarseLessOrEqual(max));
++        return set(NumberConversions.clamp(coarseX(), min.coarseX(), max.coarseX()),
++                   NumberConversions.clamp(coarseY(), min.coarseY(), max.coarseY()),
++                   NumberConversions.clamp(coarseZ(), min.coarseZ(), max.coarseZ()));
++    }
++
++    @Override
++    default M add(int x, int y, int z) {
++        return set(coarseX() + x,
++                   coarseY() + y,
++                   coarseZ() + z);
++    }
++
++    @Override
++    default M add(double x, double y, double z) {
++        return add(NumberConversions.floor(x),
++                   NumberConversions.floor(y),
++                   NumberConversions.floor(z));
++    }
++
++    @Override
++    default M add(Vec3 v) {
++        return add(v.coarseX(),
++                   v.coarseY(),
++                   v.coarseZ());
++    }
++
++    @Override
++    default M subtract(double x, double y, double z) {
++        // Be careful to floor AFTER negating
++        return add(-x, -y, -z);
++    }
++
++    @Override
++    default M subtract(int x, int y, int z) {
++        return set(coarseX() - x,
++                   coarseY() - y,
++                   coarseZ() - z);
++    }
++
++    @Override
++    default M subtract(Vec3 v) {
++        return v.isFine() ? subtract(v.fineX(), v.fineY(), v.fineZ())
++                          : subtract(v.coarseX(), v.coarseY(), v.coarseZ());
++    }
++
++    @Override
++    default M multiply(int x, int y, int z) {
++        return set(coarseX() * x, coarseY() * y, coarseZ() * z);
++    }
++
++    @Override
++    default M multiply(double x, double y, double z) {
++        return set(coarseX() * x, coarseY() * y, coarseZ() * z);
++    }
++
++    @Override
++    default M multiply(Vec3 v) {
++        return v.isFine() ? multiply(v.fineX(), v.fineY(), v.fineZ())
++                          : multiply(v.coarseX(), v.coarseY(), v.coarseZ());
++    }
++
++    @Override
++    default M divide(int x, int y, int z) {
++        return set(coarseX() / x, coarseY() / y, coarseZ() / z);
++    }
++
++    @Override
++    default M divide(double x, double y, double z) {
++        return set(coarseX() / x, coarseY() / y, coarseZ() / z);
++    }
++
++    @Override
++    default M divide(Vec3 v) {
++        return v.isFine() ? divide(v.fineX(), v.fineY(), v.fineZ())
++                          : divide(v.coarseX(), v.coarseY(), v.coarseZ());
++    }
++}
+diff --git a/src/main/java/org/bukkit/geometry/MutableVec3Fine.java b/src/main/java/org/bukkit/geometry/MutableVec3Fine.java
+new file mode 100644
+index 0000000..62efc4a
+--- /dev/null
++++ b/src/main/java/org/bukkit/geometry/MutableVec3Fine.java
+@@ -0,0 +1,177 @@
++package org.bukkit.geometry;
++
++import java.util.function.DoubleBinaryOperator;
++import java.util.function.DoubleUnaryOperator;
++import java.util.function.IntBinaryOperator;
++import java.util.function.IntUnaryOperator;
++
++import com.google.common.base.Preconditions;
++import org.bukkit.util.NumberConversions;
++
++/**
++ * Base implementation for mutable fine vectors.
++ *
++ * This interface is intended to help with implementation of the API.
++ * It should NOT be used by consumers of the API.
++ *
++ * @see MutableVec3Coarse
++ */
++public interface MutableVec3Fine<V extends Vec3, M extends MutableVec3Fine<V, M>> extends MutableVec3, Vec3Fine<V> {
++
++    @Override M setX(double x);
++    @Override M setY(double y);
++    @Override M setZ(double z);
++
++    @Override
++    M set(double x, double y, double z);
++
++    @Override
++    default boolean isMutable() {
++        return true;
++    }
++
++    @Override
++    default V copy() {
++        return fineOf(fineX(), fineY(), fineZ());
++    }
++
++    @Override
++    default M setZero() {
++        return set(0, 0, 0);
++    }
++
++    @Override
++    default M setX(int x) {
++        return setX((double) x);
++    }
++
++    @Override
++    default M setY(int y) {
++        return setX((double) y);
++    }
++
++    @Override
++    default M setZ(int z) {
++        return setX((double) z);
++    }
++
++    @Override
++    default M set(int x, int y, int z) {
++        return set((double) x, (double) y, (double) z);
++    }
++
++    @Override
++    default M set(Vec3 v) {
++        return set(v.fineX(), v.fineY(), v.fineZ());
++    }
++
++    @Override
++    default M modify(IntUnaryOperator op) {
++        return set(op.applyAsInt(coarseX()),
++                   op.applyAsInt(coarseY()),
++                   op.applyAsInt(coarseZ()));
++    }
++
++    @Override
++    default M modify(DoubleUnaryOperator op) {
++        return set(op.applyAsDouble(fineX()),
++                   op.applyAsDouble(fineY()),
++                   op.applyAsDouble(fineZ()));
++    }
++
++    @Override
++    default M modify(Vec3 v, IntBinaryOperator op) {
++        return set(op.applyAsInt(coarseX(), v.coarseX()),
++                   op.applyAsInt(coarseY(), v.coarseY()),
++                   op.applyAsInt(coarseZ(), v.coarseZ()));
++    }
++
++    @Override
++    default M modify(Vec3 v, DoubleBinaryOperator op) {
++        return set(op.applyAsDouble(fineX(), v.fineX()),
++                   op.applyAsDouble(fineY(), v.fineY()),
++                   op.applyAsDouble(fineZ(), v.fineZ()));
++    }
++
++    @Override
++    default M minimize(Vec3 v) {
++        return set(Math.min(fineX(), v.fineX()),
++                   Math.min(fineY(), v.fineY()),
++                   Math.min(fineZ(), v.fineZ()));
++    }
++
++    @Override
++    default M maximize(Vec3 v) {
++        return set(Math.max(fineX(), v.fineX()),
++                   Math.max(fineY(), v.fineY()),
++                   Math.max(fineZ(), v.fineZ()));
++    }
++
++    @Override
++    default M clamp(Vec3 min, Vec3 max) {
++        Preconditions.checkArgument(min.fineLessOrEqual(max));
++        return set(NumberConversions.clamp(fineX(), min.fineX(), max.fineX()),
++                   NumberConversions.clamp(fineY(), min.fineY(), max.fineY()),
++                   NumberConversions.clamp(fineZ(), min.fineZ(), max.fineZ()));
++    }
++
++    @Override
++    default M add(int x, int y, int z) {
++        return add((double) x, (double) y, (double) z);
++    }
++
++    @Override
++    default M add(double x, double y, double z) {
++        return set(fineX() + x, fineY() + y, fineZ() + z);
++    }
++
++    @Override
++    default M add(Vec3 v) {
++        return add(v.fineX(), v.fineY(), v.fineZ());
++    }
++
++    @Override
++    default M subtract(int x, int y, int z) {
++        return subtract((double) x, (double) y, (double) z);
++    }
++
++    @Override
++    default M subtract(double x, double y, double z) {
++        return set(fineX() - x, fineY() - y, fineZ() - z);
++    }
++
++    @Override
++    default M subtract(Vec3 v) {
++        return subtract(v.fineX(), v.fineY(), v.fineZ());
++    }
++
++    @Override
++    default M multiply(int x, int y, int z) {
++        return set(fineX() * x, fineY() * y, fineZ() * z);
++    }
++
++    @Override
++    default M multiply(double x, double y, double z) {
++        return set(fineX() * x, fineY() * y, fineZ() * z);
++    }
++
++    @Override
++    default M multiply(Vec3 v) {
++        return multiply(v.fineX(), v.fineY(), v.fineZ());
++    }
++
++    @Override
++    default M divide(int x, int y, int z) {
++        return set(fineX() / x, fineY() / y, fineZ() / z);
++    }
++
++    @Override
++    default M divide(double x, double y, double z) {
++        return set(fineX() / x, fineY() / y, fineZ() / z);
++    }
++
++    @Override
++    default M divide(Vec3 v) {
++        return divide(v.fineX(), v.fineY(), v.fineZ());
++    }
++}
+diff --git a/src/main/java/org/bukkit/geometry/Nowhere.java b/src/main/java/org/bukkit/geometry/Nowhere.java
+new file mode 100644
+index 0000000..ca7b26d
+--- /dev/null
++++ b/src/main/java/org/bukkit/geometry/Nowhere.java
+@@ -0,0 +1,8 @@
++package org.bukkit.geometry;
++
++class Nowhere implements EmptyRegion {
++
++    static final Nowhere INSTANCE = new Nowhere();
++
++    private Nowhere() {}
++}
+diff --git a/src/main/java/org/bukkit/geometry/Ray.java b/src/main/java/org/bukkit/geometry/Ray.java
+new file mode 100644
+index 0000000..ab0dfa4
+--- /dev/null
++++ b/src/main/java/org/bukkit/geometry/Ray.java
+@@ -0,0 +1,79 @@
++package org.bukkit.geometry;
++
++import java.util.Objects;
++
++import com.google.common.base.Preconditions;
++import org.bukkit.Location;
++import org.bukkit.util.ImVector;
++
++public class Ray {
++
++    private final ImVector origin;
++    private final ImVector normal;
++
++    private Ray(Vec3 origin, Vec3 normal) {
++        this.origin = ImVector.copyOf(origin);
++        this.normal = ImVector.copyOf(normal.unit());
++    }
++
++    public static Ray fromOriginAndNormal(Vec3 origin, Vec3 normal) {
++        Preconditions.checkArgument(!normal.isZero(), "Ray normal must have non-zero length");
++        return new Ray(origin, normal);
++    }
++
++    public static Ray fromOriginAndTarget(Vec3 origin, Vec3 target) {
++        final Vec3 normal = target.minus(origin);
++        Preconditions.checkArgument(!normal.isZero(), "Ray target must be different from origin");
++        return new Ray(origin, normal);
++    }
++
++    public static Ray fromOriginAndDirection(Vec3 origin, Direction direction) {
++        return new Ray(origin, direction.toVector());
++    }
++
++    public static Ray fromLocation(Location location) {
++        return new Ray(location.toVector(), location.getDirection());
++    }
++
++    public ImVector origin() {
++        return origin;
++    }
++
++    public ImVector normal() {
++        return normal;
++    }
++
++    public Direction direction() {
++        return normal.direction();
++    }
++
++    public ImVector atDistance(double distance) {
++        return origin.plus(normal.times(distance));
++    }
++
++    public Ray translate(Vec3 offset) {
++        return new Ray(origin.plus(offset), normal);
++    }
++
++    @Override
++    public int hashCode() {
++        return Objects.hash(origin, normal);
++    }
++
++    @Override
++    public boolean equals(Object obj) {
++        if(this == obj) return true;
++        if(!(obj instanceof Ray)) return false;
++        final Ray that = (Ray) obj;
++        return origin.equals(that.origin) &&
++               normal.equals(that.normal);
++    }
++
++    @Override
++    public String toString() {
++        return getClass().getSimpleName() +
++               "{origin=" + origin +
++               " normal=" + normal +
++               "}";
++    }
++}
+diff --git a/src/main/java/org/bukkit/geometry/Region.java b/src/main/java/org/bukkit/geometry/Region.java
+new file mode 100644
+index 0000000..8d203b2
+--- /dev/null
++++ b/src/main/java/org/bukkit/geometry/Region.java
+@@ -0,0 +1,128 @@
++package org.bukkit.geometry;
++
++import java.util.Random;
++
++import org.bukkit.region.BlockRegion;
++
++public interface Region {
++
++    /**
++     * Does this cuboid contain no points?
++     */
++    boolean isEmpty();
++
++    /**
++     * Does this region contain the center point of any blocks?
++     */
++    boolean isBlockEmpty();
++
++    /**
++     * Does this region have a finite volume?
++     */
++    boolean isFinite();
++
++    /**
++     * Does this region contain a finite number of blocks?
++     */
++    boolean isBlockFinite();
++
++    /**
++     * Return the volume of this region
++     */
++    double volume();
++
++    /**
++     * Return the number of blocks with center points inside this region.
++     */
++    int blockVolume() throws ArithmeticException;
++
++    /**
++     * Does this region contain the given point?
++     */
++    boolean contains(Vec3 point);
++
++    /**
++     * Does this region contain the center point of the given block?
++     */
++    boolean containsBlock(Vec3 v);
++
++    /**
++     * Generate an evenly distributed random point inside this region,
++     * using the given source of random numbers. If the region is empty,
++     * the NaN vector is returned.
++     *
++     * @throws ArithmeticException if this region is unbounded
++     */
++    Vec3 randomPointInside(Random random) throws ArithmeticException;
++
++    /**
++     * Return a randomly chosen block with a center point inside this region.
++     *
++     * @throws ArithmeticException if this region is block-empty or block-unbounded
++     */
++    Vec3 randomBlockInside(Random random) throws ArithmeticException;
++
++    /**
++     * Return a {@link Cuboid} that contains this entire region.
++     *
++     * Implementations should try to make the cuboid small,
++     * but it does not have to be minimal.
++     */
++    Cuboid bounds();
++
++    /**
++     * Return a {@link BlockRegion} of all the blocks with center points
++     * inside this region.
++     */
++    BlockRegion blockRegion() throws ArithmeticException;
++
++    Region transform(Transform transform);
++
++    /**
++     * @throws ArithmeticException if this region is unbounded
++     */
++    default void assertFinite() throws ArithmeticException {
++        if(!isFinite()) {
++            throw new ArithmeticException("Region is unbounded");
++        }
++    }
++
++    /**
++     * @throws ArithmeticException unless this region contains a finite number of blocks
++     */
++    default void assertBlockFinite() throws ArithmeticException {
++        if(!isBlockFinite()) {
++            throw new ArithmeticException("Region is not block-bounded");
++        }
++    }
++
++    /**
++     * @throws ArithmeticException if this region is empty
++     */
++    default void assertNonEmpty() throws ArithmeticException {
++        if(!isEmpty()) {
++            throw new ArithmeticException("Region is empty");
++        }
++    }
++
++    /**
++     * @throws ArithmeticException if this region contains no blocks
++     */
++    default void assertBlockNonEmpty() throws ArithmeticException {
++        if(!isEmpty()) {
++            throw new ArithmeticException("Region contains no blocks");
++        }
++    }
++
++    static Region everywhere() {
++        return Everywhere.INSTANCE;
++    }
++
++    static Region nowhere() {
++        return Nowhere.INSTANCE;
++    }
++
++    static Region empty() {
++        return Nowhere.INSTANCE;
++    }
++}
+diff --git a/src/main/java/org/bukkit/geometry/Transform.java b/src/main/java/org/bukkit/geometry/Transform.java
+new file mode 100644
+index 0000000..49fe0a3
+--- /dev/null
++++ b/src/main/java/org/bukkit/geometry/Transform.java
+@@ -0,0 +1,66 @@
++package org.bukkit.geometry;
++
++import java.util.function.Function;
++import java.util.function.UnaryOperator;
++
++import org.bukkit.block.BlockFace;
++
++/**
++ * A transform applicable to {@link Vec3} and other spatial objects.
++ *
++ * Transforms are ALWAYS immutable.
++ *
++ * Currently, all implementations of this interface are also {@link CoarseTransform}s.
++ * In the future, fine-resolution transforms, which cannot always be applied to blocks,
++ * may extend this interface.
++ *
++ * @see CoarseTransform
++ */
++public interface Transform extends UnaryOperator<Vec3> {
++
++    void applyInPlace(MutableVec3 v);
++
++    default BlockFace apply(BlockFace face) {
++        return BlockFace.byDirection(apply((Vec3) face));
++    }
++
++    boolean isIdentity();
++
++    Transform inverse();
++
++    Transform compose(Transform before);
++
++    Transform andThen(Transform after);
++
++    @Override
++    default <V> Function<V, Vec3> compose(Function<? super V, ? extends Vec3> before) {
++        return before instanceof Transform ? (Function<V, Vec3>) compose((Transform) before)
++                                           : UnaryOperator.super.compose(before);
++    }
++
++    @Override
++    default <V> Function<Vec3, V> andThen(Function<? super Vec3, ? extends V> after) {
++        return after instanceof Transform ? (Function<Vec3, V>) andThen((Transform) after)
++                                          : UnaryOperator.super.andThen(after);
++    }
++
++    default Transform translate(int x, int y, int z) {
++        return andThen(CoarseTransform.translation(x, y, z));
++    }
++
++    default Transform translate(Vec3 offset) {
++        return andThen(CoarseTransform.translation(offset));
++    }
++
++    default Transform reflect(Axis axis) {
++        return andThen(CoarseTransform.reflection(axis));
++    }
++
++    default Transform rotate(int turns) {
++        return andThen(CoarseTransform.rotation(turns));
++    }
++
++    static CoarseTransform identity() {
++        return IdentityTransform.INSTANCE;
++    }
++}
+diff --git a/src/main/java/org/bukkit/geometry/Vec3.java b/src/main/java/org/bukkit/geometry/Vec3.java
+new file mode 100644
+index 0000000..0921461
+--- /dev/null
++++ b/src/main/java/org/bukkit/geometry/Vec3.java
+@@ -0,0 +1,602 @@
++package org.bukkit.geometry;
++
++import java.util.function.DoubleBinaryOperator;
++import java.util.function.DoublePredicate;
++import java.util.function.DoubleUnaryOperator;
++import java.util.function.IntBinaryOperator;
++import java.util.function.IntPredicate;
++import java.util.function.IntUnaryOperator;
++import java.util.stream.DoubleStream;
++import java.util.stream.IntStream;
++
++import org.bukkit.util.NumberConversions;
++
++/**
++ * Base interface for all 3-vector types.
++ *
++ * Subtypes may have either coarse (integer) resolution, or fine (real) resolution,
++ * which can be checked with {@link #isCoarse()} or {@link #isFine()}. Regardless of resolution,
++ * the element values are always available as either integers or doubles. For coarse vectors,
++ * the fine components are the closest double approximations of the coarse components. For fine
++ * vectors, the coarse components are the floors of the fine components.
++ *
++ * Coarse vectors compare equal if and only if their integer components are all equal.
++ * Fine vectors compare equal if and only if their fine components are all EXACTLY equal.
++ * Coarse and fine vectors NEVER compare equal to each other, even if they have equal components.
++ *
++ * These rules for (in)equality apply to ALL {@link Vec3} implementations, and any given implementation
++ * must be comparable to any other implementation, and generate identical {@link #hashCode}s.
++ * The methods {@link #fineHashCode()}, {@link #coarseHashCode()}, and {@link #equals(Vec3)} can be used to
++ * easily implement this.
++ *
++ * Note that coarse vectors MAY be able to store and retrieve fractional coordinates,
++ * but they must use only integer coordinates when comparing to other vectors or generating hash codes.
++ *
++ * Generally, methods that return a {@link Vec3} result will return a vector with the same resolution as the one
++ * the method is called on. Binary operations between a coarse and fine vector will (effectively) use the
++ * fine components of both vectors, and the result will be converted to a coarse vector if necessary.
++ * There are a few noted exceptions to this rule, such as {@link #unit()}, which always returns a fine vector.
++ *
++ * Vectors are generally immutable, and the operations defined in the {@link Vec3} interface ALWAYS return
++ * immutable vectors that are independent of the original vector (with a few obvious exceptions, such as
++ * {@link #mutableCopy()}. Mutable vectors implement {@link MutableVec3}, which is where all the mutating
++ * operations are defined.
++ *
++ * @see MutableVec3
++ * @see Vec3Coarse
++ * @see Vec3Fine
++ * @see VectorFactory
++ */
++public interface Vec3 {
++
++    /**
++     * Can the value of this vector change?
++     */
++    boolean isMutable();
++
++    /**
++     * Can this vector contain fractional coordinates?
++     */
++    boolean isFine();
++
++    /**
++     * Inverse of {@link #isFine()}
++     */
++    default boolean isCoarse() {
++        return !isFine();
++    }
++
++    /**
++     * Return the ith fine component of the vector, starting at 0
++     *
++     * @throws IndexOutOfBoundsException if there is no component with the given index
++     */
++    default double fineAt(int i) {
++        switch(i) {
++            case 0: return fineX();
++            case 1: return fineY();
++            case 2: return fineZ();
++        }
++        throw new IndexOutOfBoundsException();
++    }
++
++    default double fineAt(Axis axis) {
++        switch(axis) {
++            case X: return fineX();
++            case Y: return fineY();
++            case Z: return fineZ();
++        }
++        throw new IllegalStateException();
++    }
++
++    double fineX();
++
++    double fineY();
++
++    double fineZ();
++
++    default DoubleStream fineStream() {
++        return DoubleStream.of(fineX(), fineY(), fineZ());
++    }
++
++    default boolean isZero() {
++        return fineX() == 0 && fineY() == 0 && fineZ() == 0;
++    }
++
++    /**
++     * Return the ith coarse component of the vector, starting at 0
++     *
++     * @throws IndexOutOfBoundsException if there is no component with the given index
++     */
++    default int coarseAt(int i) {
++        switch(i) {
++            case 0: return coarseX();
++            case 1: return coarseY();
++            case 2: return coarseZ();
++        }
++        throw new IndexOutOfBoundsException();
++    }
++
++    default int coarseAt(Axis axis) {
++        switch(axis) {
++            case X: return coarseX();
++            case Y: return coarseY();
++            case Z: return coarseZ();
++        }
++        throw new IllegalStateException();
++    }
++
++    int coarseX();
++
++    int coarseY();
++
++    int coarseZ();
++
++    default IntStream coarseStream() {
++        return IntStream.of(coarseX(), coarseY(), coarseZ());
++    }
++
++    /**
++     * Are the integer components of this object all zero?
++     */
++    default boolean isCoarseZero() {
++        return coarseX() == 0 && coarseY() == 0 && coarseZ() == 0;
++    }
++
++    default boolean fineEquals(Vec3 v) {
++        return v != null &&
++               fineX() == v.fineX() &&
++               fineY() == v.fineY() &&
++               fineZ() == v.fineZ();
++    }
++
++    default boolean coarseEquals(Vec3 v) {
++        return v != null &&
++               coarseX() == v.coarseX() &&
++               coarseY() == v.coarseY() &&
++               coarseZ() == v.coarseZ();
++    }
++
++    /**
++     * Test if this vector is equal to the given vector.
++     *
++     * See the notes about equality in the {@link Vec3} documentation.
++     */
++    default boolean equals(Vec3 v) {
++        if(v == null) return false;
++
++        if(isFine()) {
++            return v.isFine() && fineEquals(v);
++        } else {
++            return v.isCoarse() && coarseEquals(v);
++        }
++    }
++
++    /**
++     * Return the proper hashCode of a vector whos individual components have the given hashCodes
++     *
++     * This is intended for use by implementors of this interface
++     */
++    static int combineHashCodes(int hashX, int hashY, int hashZ) {
++        // 31 bits gives us roughly 10 bits per axis, and 1021 is the closest prime to 2^10
++        return (hashX * 1021 + hashY) * 1021 + hashZ;
++    }
++
++    default int fineHashCode() {
++        return combineHashCodes(
++            NumberConversions.hashCode(fineX()),
++            NumberConversions.hashCode(fineY()),
++            NumberConversions.hashCode(fineZ())
++        );
++    }
++
++    default int coarseHashCode() {
++        return combineHashCodes(
++            coarseX(),
++            coarseY(),
++            coarseZ()
++        );
++    }
++
++    /**
++     * Return an immutable vector equal to the current value of this vector.
++     * If this vector is immutable, it may return itself.
++     */
++    Vec3 copy();
++
++    /**
++     * Return a new mutable vector equal to the current value of this vector.
++     * This is always a new object that is independent of this vector.
++     */
++    MutableVec3 mutableCopy();
++
++    /**
++     * Return an immutable fine vector with components equal to the fine
++     * components of this vector.
++     */
++    Vec3 fineCopy();
++
++    Vec3 fineOf(double x, double y, double z);
++
++    Vec3 fineZero();
++
++    /**
++     * Return an immutable coarse vector with components equal to the integer
++     * components of this vector.
++     */
++    Vec3 coarseCopy();
++
++    Vec3 coarseOf(int x, int y, int z);
++
++    Vec3 coarseZero();
++
++    /**
++     * Return true only if ALL fine components of this vector are strictly less
++     * than their respective fine component in the given vector.
++     */
++    default boolean fineLess(Vec3 v) {
++        return fineX() < v.fineX() &&
++               fineY() < v.fineY() &&
++               fineZ() < v.fineZ();
++    }
++
++    /**
++     * Return true only if ALL fine components of this vector are less or equal
++     * to their respective fine component in the given vector.
++     */
++    default boolean fineLessOrEqual(Vec3 v) {
++        return fineX() <= v.fineX() &&
++               fineY() <= v.fineY() &&
++               fineZ() <= v.fineZ();
++    }
++
++    /**
++     * Return true only if ALL fine components of this vector are strictly greater
++     * than their respective fine component in the given vector.
++     */
++    default boolean fineGreater(Vec3 v) {
++        return fineX() > v.fineX() &&
++               fineY() > v.fineY() &&
++               fineZ() > v.fineZ();
++    }
++
++    /**
++     * Return true only if ALL fine components of this vector are greater or equal
++     * to their respective fine component in the given vector.
++     */
++    default boolean fineGreaterOrEqual(Vec3 v) {
++        return fineX() >= v.fineX() &&
++               fineY() >= v.fineY() &&
++               fineZ() >= v.fineZ();
++    }
++
++    /**
++     * Return true only if ALL coarse components of this vector are strictly less
++     * than their respective coarse component in the given vector.
++     */
++    default boolean coarseLess(Vec3 v) {
++        return coarseX() < v.coarseX() &&
++               coarseY() < v.coarseY() &&
++               coarseZ() < v.coarseZ();
++    }
++
++    /**
++     * Return true only if ALL coarse components of this vector are less or equal
++     * to their respective coarse component in the given vector.
++     */
++    default boolean coarseLessOrEqual(Vec3 v) {
++        return coarseX() <= v.coarseX() &&
++               coarseY() <= v.coarseY() &&
++               coarseZ() <= v.coarseZ();
++    }
++
++    /**
++     * Return true only if ALL coarse components of this vector are strictly greater
++     * than their respective coarse component in the given vector.
++     */
++    default boolean coarseGreater(Vec3 v) {
++        return coarseX() > v.coarseX() &&
++               coarseY() > v.coarseY() &&
++               coarseZ() > v.coarseZ();
++    }
++
++    /**
++     * Return true only if ALL coarse components of this vector are greater or equal
++     * to their respective coarse component in the given vector.
++     */
++    default boolean coarseGreaterOrEqual(Vec3 v) {
++        return coarseX() >= v.coarseX() &&
++               coarseY() >= v.coarseY() &&
++               coarseZ() >= v.coarseZ();
++    }
++
++    default boolean isBlockCorner() {
++        return isFine() &&
++               fineX() == coarseX() &&
++               fineY() == coarseY() &&
++               fineZ() == coarseZ();
++    }
++
++    default boolean isBlockCenter() {
++        return isFine() &&
++               fineX() == coarseX() + 0.5 &&
++               fineY() == coarseY() + 0.5 &&
++               fineZ() == coarseZ() + 0.5;
++    }
++
++    /**
++     * Return an immutable fine vector at the center of the block position
++     * represented by this vector's coarse coordinates.
++     */
++    default Vec3 blockCenter() {
++        return fineOf(coarseX() + 0.5,
++                      coarseY() + 0.5,
++                      coarseZ() + 0.5);
++    }
++
++    default boolean anyMatch(DoublePredicate predicate) {
++        return predicate.test(fineX()) ||
++               predicate.test(fineY()) ||
++               predicate.test(fineZ());
++    }
++
++    default boolean anyMatch(IntPredicate predicate) {
++        return predicate.test(coarseX()) ||
++               predicate.test(coarseY()) ||
++               predicate.test(coarseZ());
++    }
++
++    default boolean allMatch(DoublePredicate predicate) {
++        return predicate.test(fineX()) &&
++               predicate.test(fineY()) &&
++               predicate.test(fineZ());
++    }
++
++    default boolean allMatch(IntPredicate predicate) {
++        return predicate.test(coarseX()) &&
++               predicate.test(coarseY()) &&
++               predicate.test(coarseZ());
++    }
++
++    boolean anyNaN();
++    boolean allNaN();
++    boolean anyFinite();
++    boolean allFinite();
++    boolean anyInfinite();
++    boolean allInfinite();
++
++    Vec3 map(IntUnaryOperator op);
++
++    Vec3 map(DoubleUnaryOperator op);
++
++    Vec3 map(Vec3 v, IntBinaryOperator op);
++
++    Vec3 map(Vec3 v, DoubleBinaryOperator op);
++
++    /**
++     * Return a vector of the minimums of each component of this vector
++     * and the respective component of the given vector.
++     */
++    Vec3 minimum(Vec3 v);
++
++    /**
++     * Return a vector of the maximums of each component of this vector
++     * and the respective component of the given vector.
++     */
++    Vec3 maximum(Vec3 v);
++
++    /**
++     * Return a vector of this vector's components, each clamped to the
++     * respective minimum and maximum components.
++     */
++    Vec3 clamped(Vec3 min, Vec3 max);
++
++    /**
++     * Add the given coarse vector components to this vector
++     */
++    Vec3 plus(int x, int y, int z);
++
++    /**
++     * Add the given fine vector components to this vector
++     */
++    Vec3 plus(double x, double y, double z);
++
++    /**
++     * Add the given vector to this one
++     */
++    Vec3 plus(Vec3 v);
++
++    /**
++     * Add the given value to all components of this vector
++     */
++    default Vec3 plus(int xyz) {
++        return plus(xyz, xyz, xyz);
++    }
++
++    /**
++     * Add the given value to all components of this vector
++     */
++    default Vec3 plus(double xyz) {
++        return plus(xyz, xyz, xyz);
++    }
++
++    default Vec3 plus(Axis axis, int delta) {
++        return plus(axis.positive().times(delta));
++    }
++
++    default Vec3 plus(Axis axis, double delta) {
++        return plus(axis.positive().times(delta));
++    }
++
++    /**
++     * Subtract the given coarse vector components from this one
++     */
++    Vec3 minus(int x, int y, int z);
++
++    /**
++     * Subtract the given fine vector components from this one
++     */
++    Vec3 minus(double x, double y, double z);
++
++    /**
++     * Subtract the given vector from this one
++     */
++    Vec3 minus(Vec3 v);
++
++    /**
++     * Subtract the given value from all components of this vector
++     */
++    default Vec3 minus(int xyz) {
++        return minus(xyz, xyz, xyz);
++    }
++
++    /**
++     * Subtract the given value from all components of this vector
++     */
++    default Vec3 minus(double xyz) {
++        return minus(xyz, xyz, xyz);
++    }
++
++    default Vec3 minus(Axis axis, int delta) {
++        return minus(axis.positive().times(delta));
++    }
++
++    default Vec3 minus(Axis axis, double delta) {
++        return minus(axis.positive().times(delta));
++    }
++
++    default Vec3 west(int delta) {
++        return minus(Axis.X, delta);
++    }
++
++    default Vec3 east(int delta) {
++        return plus(Axis.X, delta);
++    }
++
++    default Vec3 down(int delta) {
++        return minus(Axis.Y, delta);
++    }
++
++    default Vec3 up(int delta) {
++        return plus(Axis.Y, delta);
++    }
++
++    default Vec3 north(int delta) {
++        return minus(Axis.Z, delta);
++    }
++
++    default Vec3 south(int delta) {
++        return plus(Axis.Z, delta);
++    }
++
++    default Vec3 west()  { return west(1); }
++    default Vec3 east()  { return east(1); }
++    default Vec3 down()  { return down(1); }
++    default Vec3 up()    { return up(1); }
++    default Vec3 north() { return north(1); }
++    default Vec3 south() { return south(1); }
++
++    /**
++     * Multiply the components of this vector by the respective given values
++     */
++    Vec3 times(int x, int y, int z);
++
++    /**
++     * Multiply the components of this vector by the respective given values
++     */
++    Vec3 times(double x, double y, double z);
++
++    /**
++     * Multiply the components of this vector by the respective components of the given vector
++     */
++    Vec3 times(Vec3 v);
++
++    /**
++     * Multiply this vector by the given scalar
++     */
++    default Vec3 times(int n) {
++        return times(n, n, n);
++    }
++
++    /**
++     * Multiply this vector by the given scalar
++     */
++    default Vec3 times(double n) {
++        return times(n, n, n);
++    }
++
++    Vec3 over(int x, int y, int z);
++
++    Vec3 over(double x, double y, double z);
++
++    Vec3 over(Vec3 v);
++
++    default Vec3 over(int n) {
++        return over(n, n, n);
++    }
++
++    default Vec3 over(double n) {
++        return over(n, n, n);
++    }
++
++    /**
++     * Negate this vector
++     */
++    Vec3 negate();
++
++    /**
++     * Return a fine vector of length 1 pointing in the same direction as this vector
++     */
++    default Vec3 unit() {
++        final double n = length();
++        return fineOf(fineX() / n, fineY() / n, fineZ() / n);
++    }
++
++    /**
++     * Return the dot product of this vector and the given vector
++     */
++    default double dot(Vec3 v) {
++        return fineX() * v.fineX() +
++               fineY() * v.fineY() +
++               fineZ() * v.fineZ();
++    }
++
++    default double lengthSquared() {
++        return dot(this);
++    }
++
++    default double length() {
++        return Math.sqrt(lengthSquared());
++    }
++
++    default double distanceSquared(Vec3 v) {
++        return v.minus(this).lengthSquared();
++    }
++
++    default double distance(Vec3 v) {
++        return Math.sqrt(distanceSquared(v));
++    }
++
++    /**
++     * Return a fine vector interpolating linearly between this vector and the given vector
++     */
++    default Vec3 interpolate(Vec3 v, double n) {
++        final double u = 1 - n;
++        return fineOf(u * fineX() + n * v.fineX(),
++                      u * fineY() + n * v.fineY(),
++                      u * fineZ() + n * v.fineZ());
++    }
++
++    /**
++     * Return a fine vector half way between this vector and the given vector
++     */
++    default Vec3 midway(Vec3 v) {
++        return fineOf((fineX() + v.fineX()) / 2D,
++                      (fineY() + v.fineY()) / 2D,
++                      (fineZ() + v.fineZ()) / 2D);
++    }
++
++    default Direction direction() {
++        return Direction.fromVector(fineX(), fineY(), fineZ());
++    }
++}
+diff --git a/src/main/java/org/bukkit/geometry/Vec3Coarse.java b/src/main/java/org/bukkit/geometry/Vec3Coarse.java
+new file mode 100644
+index 0000000..ae12726
+--- /dev/null
++++ b/src/main/java/org/bukkit/geometry/Vec3Coarse.java
+@@ -0,0 +1,267 @@
++package org.bukkit.geometry;
++
++import java.util.function.DoubleBinaryOperator;
++import java.util.function.DoubleUnaryOperator;
++import java.util.function.IntBinaryOperator;
++import java.util.function.IntUnaryOperator;
++
++import com.google.common.base.Preconditions;
++import org.bukkit.util.NumberConversions;
++
++/**
++ * Base implementation for coarse vectors.
++ *
++ * This interface is intended to help with implementation of the API.
++ * It should NOT be used by consumers of the API.
++ *
++ * @see Vec3Fine
++ * @see MutableVec3Coarse
++ */
++public interface Vec3Coarse<V extends Vec3> extends Vec3 {
++
++    @Override
++    default boolean isMutable() {
++        return false;
++    }
++
++    @Override
++    default boolean isFine() {
++        return false;
++    }
++
++    @Override
++    default boolean isCoarse() {
++        return true;
++    }
++
++    @Override
++    V copy();
++
++    @Override
++    default V coarseCopy() {
++        return copy();
++    }
++
++    @Override
++    V coarseOf(int x, int y, int z);
++
++    @Override
++    V coarseZero();
++
++    default V coarseOf(double x, double y, double z) {
++        return coarseOf(NumberConversions.floor(x),
++                        NumberConversions.floor(y),
++                        NumberConversions.floor(z));
++    }
++
++    @Override
++    default double fineX() {
++        return coarseX();
++    }
++
++    @Override
++    default double fineY() {
++        return coarseY();
++    }
++
++    @Override
++    default double fineZ() {
++        return coarseZ();
++    }
++
++    @Override
++    default boolean equals(Vec3 v) {
++        return v != null && v.isCoarse() && coarseEquals(v);
++    }
++
++    @Override
++    default boolean fineLess(Vec3 v) {
++        return v.isCoarse() ? coarseLess(v)
++                            : Vec3.super.fineLess(v);
++    }
++
++    @Override
++    default boolean fineLessOrEqual(Vec3 v) {
++        return v.isCoarse() ? coarseLessOrEqual(v)
++                            : Vec3.super.fineLessOrEqual(v);
++    }
++
++    @Override
++    default boolean fineGreater(Vec3 v) {
++        return v.isCoarse() ? coarseGreater(v)
++                            : Vec3.super.fineGreater(v);
++    }
++
++    @Override
++    default boolean fineGreaterOrEqual(Vec3 v) {
++        return v.isCoarse() ? coarseGreaterOrEqual(v)
++                            : Vec3.super.fineGreaterOrEqual(v);
++    }
++
++    @Override
++    default boolean anyNaN() {
++        return false;
++    }
++
++    @Override
++    default boolean allNaN() {
++        return false;
++    }
++
++    @Override
++    default boolean anyFinite() {
++        return true;
++    }
++
++    @Override
++    default boolean allFinite() {
++        return true;
++    }
++
++    @Override
++    default boolean anyInfinite() {
++        return false;
++    }
++
++    @Override
++    default boolean allInfinite() {
++        return false;
++    }
++
++    @Override
++    default V map(IntUnaryOperator op) {
++        return coarseOf(op.applyAsInt(coarseX()),
++                        op.applyAsInt(coarseY()),
++                        op.applyAsInt(coarseZ()));
++    }
++
++    @Override
++    default V map(DoubleUnaryOperator op) {
++        return coarseOf(op.applyAsDouble(fineX()),
++                        op.applyAsDouble(fineY()),
++                        op.applyAsDouble(fineZ()));
++    }
++
++    @Override
++    default V map(Vec3 v, IntBinaryOperator op) {
++        return coarseOf(op.applyAsInt(coarseX(), v.coarseX()),
++                        op.applyAsInt(coarseY(), v.coarseY()),
++                        op.applyAsInt(coarseZ(), v.coarseZ()));
++    }
++
++    @Override
++    default V map(Vec3 v, DoubleBinaryOperator op) {
++        return coarseOf(op.applyAsDouble(fineX(), v.fineX()),
++                        op.applyAsDouble(fineY(), v.fineY()),
++                        op.applyAsDouble(fineZ(), v.fineZ()));
++    }
++
++    @Override
++    default V minimum(Vec3 v) {
++        return map(v, (IntBinaryOperator) Math::min);
++    }
++
++    @Override
++    default V maximum(Vec3 v) {
++        return map(v, (IntBinaryOperator) Math::max);
++    }
++
++    @Override
++    default V clamped(Vec3 min, Vec3 max) {
++        Preconditions.checkArgument(min.coarseLessOrEqual(max));
++        return coarseOf(NumberConversions.clamp(coarseX(), min.coarseX(), max.coarseX()),
++                        NumberConversions.clamp(coarseY(), min.coarseY(), max.coarseY()),
++                        NumberConversions.clamp(coarseZ(), min.coarseZ(), max.coarseZ()));
++    }
++
++    @Override
++    default V negate() {
++        return isZero() ? copy() : coarseOf(-coarseX(), -coarseY(), -coarseZ());
++    }
++
++    @Override
++    default V plus(int x, int y, int z) {
++        return x == 0 && y == 0 && z == 0
++               ? copy()
++               : coarseOf(coarseX() + x, coarseY() + y, coarseZ() + z);
++    }
++
++    @Override
++    default V plus(double x, double y, double z) {
++        return x == 0D && y == 0D && z == 0D
++               ? copy()
++               : coarseOf(coarseX() + x, coarseY() + y, coarseZ() + z);
++    }
++
++    @Override
++    default V plus(Vec3 v) {
++        return plus(v.coarseX(), v.coarseY(), v.coarseZ());
++    }
++
++    @Override
++    default V minus(int x, int y, int z) {
++        return plus(-x, -y, -z);
++    }
++
++    @Override
++    default V minus(double x, double y, double z) {
++        return plus(-x, -y, -z);
++    }
++
++    @Override
++    default V minus(Vec3 v) {
++        return minus(v.coarseX(), v.coarseY(), v.coarseZ());
++    }
++
++    @Override
++    default V times(int n) {
++        if(n == 0 || isCoarseZero()) return coarseZero();
++        return coarseOf(coarseX() * n, coarseY() * n, coarseZ() * n);
++    }
++
++    @Override
++    default V times(double n) {
++        if(n == 0D || isCoarseZero()) return coarseZero();
++        return coarseOf(coarseX() * n, coarseY() * n, coarseZ() * n);
++    }
++
++    @Override
++    default V times(int x, int y, int z) {
++        if((x == 0 && y == 0 && z == 0) || isCoarseZero()) return coarseZero();
++        if(x == 1 && y == 1 && z == 1) return copy();
++        return coarseOf(coarseX() * x, coarseY() * y, coarseZ() * z);
++    }
++
++    @Override
++    default V times(double x, double y, double z) {
++        if((x == 0D && y == 0D && z == 0D) || isCoarseZero()) return coarseZero();
++        if(x == 1D && y == 1D && z == 1D) return copy();
++        return coarseOf(coarseX() * x, coarseY() * y, coarseZ() * z);
++    }
++
++    @Override
++    default V times(Vec3 v) {
++        if(v.isZero() || isCoarseZero()) return coarseZero();
++        return v.isFine() ? coarseOf(coarseX() * v.fineX(), coarseY() * v.fineY(), coarseZ() * v.fineZ())
++                          : coarseOf(coarseX() * v.coarseX(), coarseY() * v.coarseY(), coarseZ() * v.coarseZ());
++    }
++
++    @Override
++    default V over(int x, int y, int z) {
++        if(x == 1 && y == 1 && z == 1) return copy();
++        return coarseOf(coarseX() / x, coarseY() / y, coarseZ() / z);
++    }
++
++    @Override
++    default V over(double x, double y, double z) {
++        if(x == 1 && y == 1 && z == 1) return copy();
++        if(Double.isInfinite(x) && Double.isInfinite(y) && Double.isInfinite(z)) return coarseZero();
++        return coarseOf(coarseX() / x, coarseY() / y, coarseZ() / z);
++    }
++
++    @Override
++    default V over(Vec3 v) {
++        return v.isFine() ? coarseOf(coarseX() / v.fineX(), coarseY() / v.fineY(), coarseZ() / v.fineZ())
++                          : coarseOf(coarseX() / v.coarseX(), coarseY() / v.coarseY(), coarseZ() / v.coarseZ());
++    }
++}
+diff --git a/src/main/java/org/bukkit/geometry/Vec3Fine.java b/src/main/java/org/bukkit/geometry/Vec3Fine.java
+new file mode 100644
+index 0000000..2004d4d
+--- /dev/null
++++ b/src/main/java/org/bukkit/geometry/Vec3Fine.java
+@@ -0,0 +1,232 @@
++package org.bukkit.geometry;
++
++import java.util.function.DoubleBinaryOperator;
++import java.util.function.DoublePredicate;
++import java.util.function.DoubleUnaryOperator;
++import java.util.function.IntBinaryOperator;
++import java.util.function.IntUnaryOperator;
++
++import com.google.common.base.Preconditions;
++import org.bukkit.util.NumberConversions;
++
++/**
++ * Base implementation for fine vectors.
++ *
++ * This interface is intended to help with implementation of the API.
++ * It should NOT be used by consumers of the API.
++ *
++ * @see Vec3Coarse
++ * @see MutableVec3Fine
++ */
++public interface Vec3Fine<V extends Vec3> extends Vec3 {
++
++    @Override
++    default boolean isMutable() {
++        return false;
++    }
++
++    @Override
++    default boolean isFine() {
++        return true;
++    }
++
++    @Override
++    default boolean isCoarse() {
++        return false;
++    }
++
++    @Override
++    V copy();
++
++    @Override
++    default V fineCopy() {
++        return copy();
++    }
++
++    @Override
++    V fineOf(double x, double y, double z);
++
++    @Override
++    V fineZero();
++
++    @Override
++    default Vec3 coarseCopy() {
++        return coarseOf(coarseX(), coarseY(), coarseZ());
++    }
++
++    @Override
++    default int coarseX() {
++        return NumberConversions.floor(fineX());
++    }
++
++    @Override
++    default int coarseY() {
++        return NumberConversions.floor(fineY());
++    }
++
++    @Override
++    default int coarseZ() {
++        return NumberConversions.floor(fineZ());
++    }
++
++    @Override
++    default boolean equals(Vec3 v) {
++        return v != null && v.isFine() && fineEquals(v);
++    }
++
++    @Override
++    default boolean anyNaN() {
++        return anyMatch((DoublePredicate) Double::isNaN);
++    }
++
++    @Override
++    default boolean allNaN() {
++        return allMatch((DoublePredicate) Double::isNaN);
++    }
++
++    @Override
++    default boolean anyFinite() {
++        return anyMatch((DoublePredicate) Double::isFinite);
++    }
++
++    @Override
++    default boolean allFinite() {
++        return allMatch((DoublePredicate) Double::isFinite);
++    }
++
++    @Override
++    default boolean anyInfinite() {
++        return anyMatch((DoublePredicate) Double::isInfinite);
++    }
++
++    @Override
++    default boolean allInfinite() {
++        return allMatch((DoublePredicate) Double::isInfinite);
++    }
++
++    @Override
++    default V map(IntUnaryOperator op) {
++        return fineOf(op.applyAsInt(coarseX()),
++                      op.applyAsInt(coarseY()),
++                      op.applyAsInt(coarseZ()));
++    }
++
++    @Override
++    default V map(DoubleUnaryOperator op) {
++        return fineOf(op.applyAsDouble(fineX()),
++                      op.applyAsDouble(fineY()),
++                      op.applyAsDouble(fineZ()));
++    }
++
++    @Override
++    default V map(Vec3 v, IntBinaryOperator op) {
++        return fineOf(op.applyAsInt(coarseX(), v.coarseX()),
++                      op.applyAsInt(coarseY(), v.coarseY()),
++                      op.applyAsInt(coarseZ(), v.coarseZ()));
++    }
++
++    @Override
++    default V map(Vec3 v, DoubleBinaryOperator op) {
++        return fineOf(op.applyAsDouble(fineX(), v.fineX()),
++                      op.applyAsDouble(fineY(), v.fineY()),
++                      op.applyAsDouble(fineZ(), v.fineZ()));
++    }
++
++    @Override
++    default V minimum(Vec3 v) {
++        return map(v, (DoubleBinaryOperator) Math::min);
++    }
++
++    @Override
++    default V maximum(Vec3 v) {
++        return map(v, (DoubleBinaryOperator) Math::max);
++    }
++
++    @Override
++    default V clamped(Vec3 min, Vec3 max) {
++        Preconditions.checkArgument(min.fineLessOrEqual(max));
++        return fineOf(NumberConversions.clamp(fineX(), min.fineX(), max.fineX()),
++                      NumberConversions.clamp(fineY(), min.fineY(), max.fineY()),
++                      NumberConversions.clamp(fineZ(), min.fineZ(), max.fineZ()));
++    }
++
++    @Override
++    default V plus(Vec3 v) {
++        return fineOf(fineX() + v.fineX(), fineY() + v.fineY(), fineZ() + v.fineZ());
++    }
++
++    @Override
++    default V plus(int x, int y, int z) {
++        return plus((double) x, (double) y, (double) z);
++    }
++
++    @Override
++    default V plus(double x, double y, double z) {
++        return fineOf(this.fineX() + x, this.fineY() + y, this.fineZ() + z);
++    }
++
++    @Override
++    default V minus(Vec3 v) {
++        return fineOf(fineX() - v.fineX(), fineY() - v.fineY(), fineZ() - v.fineZ());
++    }
++
++    @Override
++    default V minus(int x, int y, int z) {
++        return fineOf(this.fineX() - x, this.fineY() - y, this.fineZ() - z);
++    }
++
++    @Override
++    default V minus(double x, double y, double z) {
++        return fineOf(this.fineX() - x, this.fineY() - y, this.fineZ() - z);
++    }
++
++    @Override
++    default V times(double n) {
++        return fineOf(fineX() * n, fineY() * n, fineZ() * n);
++    }
++
++    @Override
++    default V times(int n) {
++        return fineOf(fineX() * n, fineY() * n, fineZ() * n);
++    }
++
++    @Override
++    default V times(int x, int y, int z) {
++        return fineOf(this.fineX() * x, this.fineY() * y, this.fineZ() * z);
++    }
++
++    @Override
++    default V times(double x, double y, double z) {
++        return fineOf(this.fineX() * x, this.fineY() * y, this.fineZ() * z);
++    }
++
++    @Override
++    default V times(Vec3 v) {
++        return fineOf(fineX() + v.fineZ(), fineY() + v.fineY(), fineZ() + v.fineZ());
++    }
++
++    @Override
++    default V over(int x, int y, int z) {
++        return fineOf(this.fineX() / x, this.fineY() / y, this.fineZ() / z);
++    }
++
++    @Override
++    default V over(double x, double y, double z) {
++        return fineOf(this.fineX() / x, this.fineY() / y, this.fineZ() / z);
++    }
++
++    @Override
++    default V over(double n) {
++        return fineOf(fineX() / n, fineY() / n, fineZ() / n);
++    }
++
++    @Override
++    default V over(Vec3 v) {
++        return fineOf(fineX() / v.fineX(), fineY() / v.fineY(), fineZ() / v.fineZ());
++    }
++
++    @Override
++    default V negate() {
++        return fineOf(-fineX(), -fineY(), -fineZ());
++    }
++}
+diff --git a/src/main/java/org/bukkit/geometry/VectorFactory.java b/src/main/java/org/bukkit/geometry/VectorFactory.java
+new file mode 100644
+index 0000000..e18729a
+--- /dev/null
++++ b/src/main/java/org/bukkit/geometry/VectorFactory.java
+@@ -0,0 +1,67 @@
++package org.bukkit.geometry;
++
++/**
++ * Construct {@link Vec3} instances
++ */
++public interface VectorFactory {
++
++    Vec3 coarse(int x, int y, int z);
++
++    default Vec3 coarse(int xyz) {
++        return coarse(xyz, xyz, xyz);
++    }
++
++    Vec3 coarse(double x, double y, double z);
++
++    default Vec3 coarse(double xyz) {
++        return coarse(xyz, xyz, xyz);
++    }
++
++    Vec3 fine(int x, int y, int z);
++
++    default Vec3 fine(int xyz) {
++        return fine(xyz, xyz, xyz);
++    }
++
++    Vec3 fine(double x, double y, double z);
++
++    default Vec3 fine(double xyz) {
++        return fine(xyz, xyz, xyz);
++    }
++
++    MutableVec3 coarseMutable(int x, int y, int z);
++
++    default MutableVec3 coarseMutable(int xyz) {
++        return coarseMutable(xyz, xyz, xyz);
++    }
++
++    MutableVec3 fineMutable(double x, double y, double z);
++
++    default MutableVec3 fineMutable(double xyz) {
++        return fineMutable(xyz, xyz, xyz);
++    }
++
++    default Vec3 coarseZero() {
++        return coarse(0, 0, 0);
++    }
++
++    default Vec3 fineZero() {
++        return fine(0, 0, 0);
++    }
++
++    default MutableVec3 coarseMutableZero() {
++        return coarseMutable(0, 0, 0);
++    }
++
++    default MutableVec3 fineMutableZero() {
++        return fineMutable(0, 0, 0);
++    }
++
++    default MutableVec3 coarseMutable(Vec3 v) {
++        return coarseMutable(v.coarseX(), v.coarseY(), v.coarseZ());
++    }
++
++    default MutableVec3 fineMutable(Vec3 v) {
++        return fineMutable(v.fineX(), v.fineY(), v.fineZ());
++    }
++}
+diff --git a/src/main/java/org/bukkit/region/BakedBlockRegion.java b/src/main/java/org/bukkit/region/BakedBlockRegion.java
+new file mode 100644
+index 0000000..7a3041f
+--- /dev/null
++++ b/src/main/java/org/bukkit/region/BakedBlockRegion.java
+@@ -0,0 +1,113 @@
++package org.bukkit.region;
++
++import java.util.Collection;
++import java.util.Iterator;
++import java.util.function.Predicate;
++import java.util.stream.Stream;
++
++import com.google.common.collect.ImmutableSet;
++import org.bukkit.geometry.CoarseTransform;
++import org.bukkit.geometry.Vec3;
++
++class BakedBlockRegion implements BlockRegion {
++
++    private final ImmutableSet<Vec3> positions;
++
++    BakedBlockRegion(ImmutableSet<Vec3> positions) {
++        this.positions = positions;
++    }
++
++    static BlockRegion of(Stream<? extends Vec3> positions) {
++        final ImmutableSet.Builder<Vec3> builder = ImmutableSet.builder();
++        positions.forEach(builder::add);
++        return of(builder.build());
++    }
++
++    static BlockRegion of(Iterator<? extends Vec3> positions) {
++        final ImmutableSet<Vec3> set = ImmutableSet.copyOf(positions);
++        return new BakedBlockRegion(set);
++    }
++
++    static BlockRegion of(Iterable<? extends Vec3> positions) {
++        if(positions instanceof BlockRegion) {
++            final BlockRegion region = (BlockRegion) positions;
++            if(!region.isMutable()) return region;
++        }
++        return of(ImmutableSet.copyOf(positions));
++    }
++
++    static BlockRegion of(Collection<? extends Vec3> positions) {
++        if(positions.isEmpty()) return EmptyBlockRegion.INSTANCE;
++        if(positions instanceof BlockRegion) {
++            final BlockRegion region = (BlockRegion) positions;
++            if(!region.isMutable()) return region;
++        }
++        return new BakedBlockRegion(ImmutableSet.copyOf(positions));
++    }
++
++    static BlockRegion of(ImmutableSet<? extends Vec3> positions) {
++        if(positions.isEmpty()) return EmptyBlockRegion.INSTANCE;
++        return new BakedBlockRegion((ImmutableSet<Vec3>) positions);
++    }
++
++    @Override
++    public boolean isMutable() {
++        return false;
++    }
++
++    @Override
++    public BlockRegion copy() {
++        return this;
++    }
++
++    @Override
++    public boolean isEmpty() {
++        return positions.isEmpty();
++    }
++
++    @Override
++    public int size() {
++        return positions.size();
++    }
++
++    @Override
++    public boolean contains(Vec3 position) {
++        return positions.contains(position);
++    }
++
++    @Override
++    public boolean containsAll(Collection<?> c) {
++        return positions.containsAll(c);
++    }
++
++    @Override
++    public Iterator<Vec3> mutableIterator() {
++        return positions.iterator();
++    }
++
++    @Override
++    public Iterator<Vec3> iterator() {
++        return positions.iterator();
++    }
++
++    @Override
++    public BlockRegion transform(CoarseTransform transform) {
++        if(transform.isIdentity()) return this;
++        return new TransformedBlockRegion(this, transform);
++    }
++
++    @Override
++    public BlockRegion filter(Predicate<? super Vec3> predicate) {
++        return new FilteredBlockRegion(this, predicate);
++    }
++
++    @Override
++    public int hashCode() {
++        return positions.hashCode();
++    }
++
++    @Override
++    public boolean equals(Object obj) {
++        return positions.equals(obj);
++    }
++}
+diff --git a/src/main/java/org/bukkit/region/BlockRegion.java b/src/main/java/org/bukkit/region/BlockRegion.java
+new file mode 100644
+index 0000000..7c4bcef
+--- /dev/null
++++ b/src/main/java/org/bukkit/region/BlockRegion.java
+@@ -0,0 +1,158 @@
++package org.bukkit.region;
++
++import java.util.Collection;
++import java.util.Iterator;
++import java.util.Set;
++import java.util.function.Predicate;
++import java.util.stream.Stream;
++
++import com.google.common.collect.ImmutableCollection;
++import com.google.common.collect.Iterators;
++import org.bukkit.geometry.CoarseTransform;
++import org.bukkit.geometry.Vec3;
++import org.bukkit.util.SetBase;
++
++/**
++ * Represents a set of block coordinates, and supports iteration over them and tests for inclusion.
++ *
++ * Some region types have changing contents. This can be checked with {@link #isMutable()}, and an
++ * immutable region can always be obtained from {@link #copy()}. Other operations may return mutable
++ * regions, even when applied to immutable regions.
++ *
++ * Since regions are {@link Set}s, they must follow the equality contract for sets, and compare equal
++ * to any other {@link Set} of the same {@link Vec3} elements.
++ */
++public interface BlockRegion extends SetBase<Vec3> {
++
++    /**
++     * Can the contents of this region change?
++     *
++     * If this returns false, then the set of blocks in the region must NEVER change.
++     * If this returns true, then the set of blocks may or may not change.
++     */
++    boolean isMutable();
++
++    boolean contains(Vec3 pos);
++
++    @Override
++    default boolean contains(Object o) {
++        return o instanceof Vec3 && contains((Vec3) o);
++    }
++
++    default boolean containsAll(BlockRegion region) {
++        // Use the mutable iterator for efficiency
++        for(Vec3 pos : region.mutableIterable()) {
++            if(!contains(pos)) return false;
++        }
++        return true;
++    }
++
++    @Override
++    default boolean containsAll(Collection<?> c) {
++        return c instanceof BlockRegion ? containsAll((BlockRegion) c)
++                                        : SetBase.super.containsAll(c);
++    }
++
++    /**
++     * Return an {@link Iterator} over the blocks in this region that MAY return the same {@link Vec3}
++     * instance from multiple calls to {@link Iterator#next()}, with the vector assuming a new value
++     * for each iteration.
++     *
++     * This can be considerably more efficient, but care must be taken to not use vector instances
++     * outside of their own iteration, without copying them first. Call {@link #iterator()} for an
++     * iterator that returns an independent, immutable vector for each iteration.
++     */
++    Iterator<Vec3> mutableIterator();
++
++    default Iterable<Vec3> mutableIterable() {
++        return this::mutableIterator;
++    }
++
++    default Iterator<Vec3> iterator() {
++        return Iterators.transform(mutableIterator(), Vec3::copy);
++    }
++
++    /**
++     * Return an immutable {@link BlockRegion} containing the same positions that this
++     * region currently contains. If this region is immutable, it may return itself.
++     */
++    BlockRegion copy();
++
++    /**
++     * Return a region equal to this region with the given transform applied to all elements.
++     *
++     * The returned region is a live view of this one, and any changes to this region are
++     * immediately reflected in the transformed region. If this region is immutable, then
++     * the transformed region will also be immutable.
++     *
++     * This region may return itself if it would be unaffected by the transform.
++     */
++    BlockRegion transform(CoarseTransform transform);
++
++    /**
++     * Return a region containing the elements of this region that pass the given predicate.
++     *
++     * The returned region is a live view of this one, and any changes to this region are
++     * immediately reflected in the filtered region.
++     *
++     * This region may return itself if it would be unaffected by the filter.
++     */
++    BlockRegion filter(Predicate<? super Vec3> predicate);
++
++    default int standardHashCode() {
++        int h = 0;
++        for(Vec3 p : mutableIterable()) {
++            h += p.hashCode();
++        }
++        return h;
++    }
++
++    default boolean standardEquals(Object that) {
++        return that instanceof Set &&
++               size() == ((Set) that).size() &&
++               containsAll((Set) that);
++    }
++
++    /**
++     * Return the empty region
++     */
++    static BlockRegion empty() {
++        return EmptyBlockRegion.INSTANCE;
++    }
++
++    /**
++     * Return a live view of the given {@link Set} as a {@link BlockRegion}.
++     *
++     * Changes to the underlying set are instantly reflected in the region.
++     */
++    static BlockRegion of(Set<Vec3> positions) {
++        if(positions instanceof BlockRegion) {
++            return (BlockRegion) positions;
++        }
++        if(positions instanceof ImmutableCollection) {
++            return BakedBlockRegion.of(positions);
++        }
++        return new BlockRegionAdapter(positions);
++    }
++
++    /**
++     * Return an immutable region containing exactly the given set of block positions.
++     */
++    static BlockRegion copyOf(Stream<Vec3> positions) {
++        return BakedBlockRegion.of(positions);
++    }
++
++    /**
++     * Return an immutable region containing exactly the given set of block positions.
++     */
++    static BlockRegion copyOf(Iterator<Vec3> positions) {
++        return BakedBlockRegion.of(positions);
++    }
++
++    /**
++     * Return an immutable region containing exactly the given set of block positions.
++     */
++    static BlockRegion copyOf(Iterable<Vec3> positions) {
++        return BakedBlockRegion.of(positions);
++    }
++}
+diff --git a/src/main/java/org/bukkit/region/BlockRegionAdapter.java b/src/main/java/org/bukkit/region/BlockRegionAdapter.java
+new file mode 100644
+index 0000000..34353b7
+--- /dev/null
++++ b/src/main/java/org/bukkit/region/BlockRegionAdapter.java
+@@ -0,0 +1,151 @@
++package org.bukkit.region;
++
++import java.util.Collection;
++import java.util.Iterator;
++import java.util.Set;
++import java.util.Spliterator;
++import java.util.function.Consumer;
++import java.util.function.Predicate;
++import java.util.stream.Stream;
++
++import org.bukkit.geometry.CoarseTransform;
++import org.bukkit.geometry.Vec3;
++
++class BlockRegionAdapter implements BlockRegion {
++
++    private final Set<Vec3> positions;
++
++    BlockRegionAdapter(Set<Vec3> positions) {
++        this.positions = positions;
++    }
++
++    @Override
++    public boolean isMutable() {
++        return true;
++    }
++
++    @Override
++    public BlockRegion copy() {
++        return BakedBlockRegion.of(positions);
++    }
++
++    @Override
++    public BlockRegion transform(CoarseTransform transform) {
++        return new TransformedBlockRegion(this, transform);
++    }
++
++    @Override
++    public BlockRegion filter(Predicate<? super Vec3> predicate) {
++        return new FilteredBlockRegion(this, predicate);
++    }
++
++    @Override
++    public int hashCode() {
++        return positions.hashCode();
++    }
++
++    @Override
++    public boolean equals(Object obj) {
++        return positions.equals(obj);
++    }
++
++    @Override
++    public boolean contains(Vec3 pos) {
++        return positions.contains(pos);
++    }
++
++    @Override
++    public Iterator<Vec3> mutableIterator() {
++        return positions.iterator();
++    }
++
++    @Override
++    public int size() {
++        return positions.size();
++    }
++
++    @Override
++    public boolean isEmpty() {
++        return positions.isEmpty();
++    }
++
++    @Override
++    public boolean contains(Object o) {
++        return positions.contains(o);
++    }
++
++    @Override
++    public Iterator<Vec3> iterator() {
++        return positions.iterator();
++    }
++
++    @Override
++    public Object[] toArray() {
++        return positions.toArray();
++    }
++
++    @Override
++    public <T> T[] toArray(T[] a) {
++        return positions.toArray(a);
++    }
++
++    @Override
++    public boolean add(Vec3 vec3) {
++        return positions.add(vec3);
++    }
++
++    @Override
++    public boolean remove(Object o) {
++        return positions.remove(o);
++    }
++
++    @Override
++    public boolean containsAll(Collection<?> c) {
++        return positions.containsAll(c);
++    }
++
++    @Override
++    public boolean addAll(Collection<? extends Vec3> c) {
++        return positions.addAll(c);
++    }
++
++    @Override
++    public boolean retainAll(Collection<?> c) {
++        return positions.retainAll(c);
++    }
++
++    @Override
++    public boolean removeAll(Collection<?> c) {
++        return positions.removeAll(c);
++    }
++
++    @Override
++    public void clear() {
++        positions.clear();
++    }
++
++    @Override
++    public Spliterator<Vec3> spliterator() {
++        return positions.spliterator();
++    }
++
++    @Override
++    public boolean removeIf(Predicate<? super Vec3> filter) {
++        return positions.removeIf(filter);
++    }
++
++    @Override
++    public Stream<Vec3> stream() {
++        return positions.stream();
++    }
++
++    @Override
++    public Stream<Vec3> parallelStream() {
++        return positions.parallelStream();
++    }
++
++    @Override
++    public void forEach(Consumer<? super Vec3> action) {
++        positions.forEach(action);
++    }
++}
+diff --git a/src/main/java/org/bukkit/region/CuboidBlockIterator.java b/src/main/java/org/bukkit/region/CuboidBlockIterator.java
+new file mode 100644
+index 0000000..5648660
+--- /dev/null
++++ b/src/main/java/org/bukkit/region/CuboidBlockIterator.java
+@@ -0,0 +1,51 @@
++package org.bukkit.region;
++
++import java.util.NoSuchElementException;
++
++import org.bukkit.geometry.MutableVec3;
++import org.bukkit.geometry.Vec3;
++
++public class CuboidBlockIterator extends MutableBlockIterator {
++
++    private final int xMin, yMin;
++    private final int xMax, yMax, zMax;
++
++    private int x, y, z;
++    private boolean hasNext;
++
++    public CuboidBlockIterator(Vec3 min, Vec3 max) {
++        x = this.xMin = min.coarseX();
++        y = this.yMin = min.coarseY();
++        z = min.coarseZ();
++
++        this.xMax = max.coarseX();
++        this.yMax = max.coarseY();
++        this.zMax = max.coarseZ();
++
++        this.hasNext = x < xMax && y < yMax && z < zMax;
++    }
++
++    @Override
++    public boolean hasNext() {
++        return hasNext;
++    }
++
++    @Override
++    protected void advance(MutableVec3 value) {
++        if(!hasNext) {
++            throw new NoSuchElementException();
++        }
++
++        value.set(x, y, z);
++
++        if(++x >= xMax) {
++            x = xMin;
++            if(++y >= yMax) {
++                y = yMin;
++                if(++z >= zMax) {
++                    hasNext = false;
++                }
++            }
++        }
++    }
++}
+diff --git a/src/main/java/org/bukkit/region/CuboidBlockRegion.java b/src/main/java/org/bukkit/region/CuboidBlockRegion.java
+new file mode 100644
+index 0000000..690caa0
+--- /dev/null
++++ b/src/main/java/org/bukkit/region/CuboidBlockRegion.java
+@@ -0,0 +1,104 @@
++package org.bukkit.region;
++
++import java.util.Iterator;
++import java.util.function.Predicate;
++
++import org.bukkit.geometry.CoarseTransform;
++import org.bukkit.geometry.Vec3;
++
++public class CuboidBlockRegion implements BlockRegion {
++
++    private final Vec3 min;
++    private final Vec3 max; // Upper bound is exclusive
++
++    public static BlockRegion between(Vec3 a, Vec3 b) {
++        a = a.coarseCopy();
++        b = b.coarseCopy();
++
++        if(a.coarseX() == b.coarseX() ||
++           a.coarseY() == b.coarseY() ||
++           a.coarseZ() == b.coarseZ()) {
++            return EmptyBlockRegion.INSTANCE;
++        }
++
++        return new CuboidBlockRegion(a.minimum(b), a.maximum(b));
++    }
++
++    public static BlockRegion fromMinAndSize(Vec3 min, Vec3 size) {
++        size = size.coarseCopy();
++        if(size.coarseX() == 0 || size.coarseY() == 0 || size.coarseZ() == 0) {
++            return EmptyBlockRegion.INSTANCE;
++        }
++        min = min.coarseCopy();
++        return new CuboidBlockRegion(min, min.plus(size));
++    }
++
++    private CuboidBlockRegion(Vec3 min, Vec3 max) {
++        this.min = min;
++        this.max = max;
++    }
++
++    @Override
++    public boolean isMutable() {
++        return false;
++    }
++
++    @Override
++    public int size() {
++        final Vec3 d = max.minus(min);
++        return d.coarseX() * d.coarseY() * d.coarseZ();
++    }
++
++    @Override
++    public boolean contains(Vec3 position) {
++        position = position.coarseCopy();
++        return min.coarseLessOrEqual(position) && max.coarseGreater(position);
++    }
++
++    @Override
++    public Iterator<Vec3> mutableIterator() {
++        return new CuboidBlockIterator(min, max);
++    }
++
++    @Override
++    public BlockRegion copy() {
++        return this;
++    }
++
++    @Override
++    public BlockRegion transform(CoarseTransform transform) {
++        return new CuboidBlockRegion(transform.apply(min), transform.apply(max));
++    }
++
++    @Override
++    public BlockRegion filter(Predicate<? super Vec3> predicate) {
++        return new FilteredBlockRegion(this, predicate);
++    }
++
++    @Override
++    public int hashCode() {
++        final int x0 = min.coarseX(), y0 = min.coarseY(), z0 = min.coarseZ();
++        final int x1 = max.coarseX(), y1 = max.coarseY(), z1 = max.coarseZ();
++
++        // There is probably some crazy formula for this
++        int hash = 0;
++        for(int x = x0; x < x1; x++) {
++            for(int y = y0; y < y1; y++) {
++                for(int z = z0; z < z1; z++) {
++                    hash += Vec3.combineHashCodes(x, y, z);
++                }
++            }
++        }
++        return hash;
++    }
++
++    @Override
++    public boolean equals(Object obj) {
++        if(this == obj) return true;
++        if(obj instanceof CuboidBlockRegion) {
++            return min.equals(((CuboidBlockRegion) obj).min) &&
++                   max.equals(((CuboidBlockRegion) obj).max);
++        }
++        return standardEquals(obj);
++    }
++}
+diff --git a/src/main/java/org/bukkit/region/EmptyBlockRegion.java b/src/main/java/org/bukkit/region/EmptyBlockRegion.java
+new file mode 100644
+index 0000000..f03e35b
+--- /dev/null
++++ b/src/main/java/org/bukkit/region/EmptyBlockRegion.java
+@@ -0,0 +1,82 @@
++package org.bukkit.region;
++
++import java.util.Collection;
++import java.util.Collections;
++import java.util.Iterator;
++import java.util.Set;
++import java.util.function.Predicate;
++
++import org.bukkit.geometry.CoarseTransform;
++import org.bukkit.geometry.Vec3;
++
++class EmptyBlockRegion implements BlockRegion {
++
++    static final EmptyBlockRegion INSTANCE = new EmptyBlockRegion();
++
++    private EmptyBlockRegion() {}
++
++    @Override
++    public boolean isMutable() {
++        return false;
++    }
++
++    @Override
++    public boolean isEmpty() {
++        return true;
++    }
++
++    @Override
++    public int size() {
++        return 0;
++    }
++
++    @Override
++    public boolean contains(Vec3 pos) {
++        return false;
++    }
++
++    @Override
++    public boolean contains(Object o) {
++        return false;
++    }
++
++    @Override
++    public boolean containsAll(Collection<?> c) {
++        return c.isEmpty();
++    }
++
++    @Override
++    public Iterator<Vec3> mutableIterator() {
++        return Collections.emptyIterator();
++    }
++
++    @Override
++    public Iterator<Vec3> iterator() {
++        return Collections.emptyIterator();
++    }
++
++    @Override
++    public BlockRegion copy() {
++        return this;
++    }
++
++    @Override
++    public BlockRegion transform(CoarseTransform transform) {
++        return this;
++    }
++
++    @Override
++    public BlockRegion filter(Predicate<? super Vec3> predicate) {
++        return this;
++    }
++
++    @Override
++    public int hashCode() {
++        return 0;
++    }
++
++    @Override
++    public boolean equals(Object obj) {
++        return obj instanceof Set && ((Set) obj).isEmpty();
++    }
++}
+diff --git a/src/main/java/org/bukkit/region/FilteredBlockIterator.java b/src/main/java/org/bukkit/region/FilteredBlockIterator.java
+new file mode 100644
+index 0000000..4f82147
+--- /dev/null
++++ b/src/main/java/org/bukkit/region/FilteredBlockIterator.java
+@@ -0,0 +1,55 @@
++package org.bukkit.region;
++
++import java.util.Iterator;
++import java.util.NoSuchElementException;
++import java.util.function.Predicate;
++
++import org.bukkit.geometry.MutableVec3;
++import org.bukkit.geometry.Vec3;
++
++public class FilteredBlockIterator extends MutableBlockIterator {
++
++    public static Iterator<Vec3> of(Iterator<Vec3> iterator, Predicate<? super Vec3> filter) {
++        if(iterator instanceof FilteredBlockIterator) {
++            final FilteredBlockIterator filtered = (FilteredBlockIterator) iterator;
++            return new FilteredBlockIterator(filtered.iterator, v -> filtered.filter.test(v) && filter.test(v));
++        }
++        return new FilteredBlockIterator(iterator, filter);
++    }
++
++    private final Iterator<Vec3> iterator;
++    private final Predicate<? super Vec3> filter;
++
++    private Vec3 next = null;
++
++    private FilteredBlockIterator(Iterator<Vec3> iterator, Predicate<? super Vec3> filter) {
++        this.iterator = iterator;
++        this.filter = filter;
++    }
++
++    @Override
++    public boolean hasNext() {
++        if(next != null) return true;
++
++        while(iterator.hasNext()) {
++            Vec3 v = iterator.next();
++
++            if(filter.test(v)) {
++                next = v;
++                return true;
++            }
++        }
++
++        return false;
++    }
++
++    @Override
++    protected void advance(MutableVec3 value) {
++        if(!hasNext()) {
++            throw new NoSuchElementException();
++        }
++
++        value.set(next);
++        next = null;
++    }
++}
+diff --git a/src/main/java/org/bukkit/region/FilteredBlockRegion.java b/src/main/java/org/bukkit/region/FilteredBlockRegion.java
+new file mode 100644
+index 0000000..c568e17
+--- /dev/null
++++ b/src/main/java/org/bukkit/region/FilteredBlockRegion.java
+@@ -0,0 +1,79 @@
++package org.bukkit.region;
++
++import java.util.Iterator;
++import java.util.function.Predicate;
++
++import org.bukkit.geometry.CoarseTransform;
++import org.bukkit.geometry.Vec3;
++
++import static com.google.common.base.Preconditions.checkNotNull;
++
++class FilteredBlockRegion implements BlockRegion {
++
++    protected final BlockRegion unfiltered;
++    protected final Predicate<? super Vec3> filter;
++
++    FilteredBlockRegion(BlockRegion unfiltered, Predicate<? super Vec3> filter) {
++        this.unfiltered = checkNotNull(unfiltered);
++        this.filter = checkNotNull(filter);
++    }
++
++    @Override
++    public boolean isMutable() {
++        return true; // Cannot be sure the predicate is constant
++    }
++
++    @Override
++    public boolean isEmpty() {
++        for(Vec3 p : unfiltered) {
++            if(filter.test(p)) return false;
++        }
++        return true;
++    }
++
++    @Override
++    public int size() {
++        int count = 0;
++        for(Vec3 p : unfiltered) {
++            if(filter.test(p)) count++;
++        }
++        return count;
++    }
++
++    @Override
++    public boolean contains(Vec3 position) {
++        return unfiltered.contains(position) && filter.test(position);
++    }
++
++    @Override
++    public Iterator<Vec3> mutableIterator() {
++        return FilteredBlockIterator.of(unfiltered.mutableIterator(), filter);
++    }
++
++    @Override
++    public int hashCode() {
++        return standardHashCode();
++    }
++
++    @Override
++    public boolean equals(Object obj) {
++        return standardEquals(obj);
++    }
++
++    @Override
++    public BlockRegion copy() {
++        return BakedBlockRegion.of(this);
++    }
++
++    @Override
++    public BlockRegion transform(CoarseTransform transform) {
++        if(transform.isIdentity()) return this;
++        return new TransformedBlockRegion(this, transform);
++    }
++
++    @Override
++    public BlockRegion filter(Predicate<? super Vec3> predicate) {
++        if(filter.equals(predicate)) return this;
++        return new FilteredBlockRegion(unfiltered, filter.and((Predicate) predicate));
++    }
++}
+diff --git a/src/main/java/org/bukkit/region/MutableBlockIterator.java b/src/main/java/org/bukkit/region/MutableBlockIterator.java
+new file mode 100644
+index 0000000..ce5ed1c
+--- /dev/null
++++ b/src/main/java/org/bukkit/region/MutableBlockIterator.java
+@@ -0,0 +1,22 @@
++package org.bukkit.region;
++
++import java.util.Iterator;
++import java.util.NoSuchElementException;
++
++import org.bukkit.Bukkit;
++import org.bukkit.geometry.MutableVec3;
++import org.bukkit.geometry.Vec3;
++
++public abstract class MutableBlockIterator implements Iterator<Vec3> {
++
++    private final MutableVec3 value = Bukkit.vectors().coarseMutableZero();
++    private final Vec3 view = value.unmodifiable();
++
++    protected abstract void advance(MutableVec3 value) throws NoSuchElementException;
++
++    @Override
++    public final Vec3 next() {
++        advance(value);
++        return view;
++    }
++}
+diff --git a/src/main/java/org/bukkit/region/TransformedBlockIterator.java b/src/main/java/org/bukkit/region/TransformedBlockIterator.java
+new file mode 100644
+index 0000000..2fa9325
+--- /dev/null
++++ b/src/main/java/org/bukkit/region/TransformedBlockIterator.java
+@@ -0,0 +1,37 @@
++package org.bukkit.region;
++
++import java.util.Iterator;
++
++import org.bukkit.geometry.CoarseTransform;
++import org.bukkit.geometry.MutableVec3;
++import org.bukkit.geometry.Vec3;
++
++public class TransformedBlockIterator extends MutableBlockIterator {
++
++    public static Iterator<Vec3> of(Iterator<Vec3> iterator, CoarseTransform transform) {
++        if(iterator instanceof TransformedBlockIterator) {
++            final TransformedBlockIterator transformed = (TransformedBlockIterator) iterator;
++            return new TransformedBlockIterator(transformed.iterator, transformed.transform.andThen(transform));
++        }
++        return new TransformedBlockIterator(iterator, transform);
++    }
++
++    private final Iterator<Vec3> iterator;
++    private final CoarseTransform transform;
++
++    private TransformedBlockIterator(Iterator<Vec3> iterator, CoarseTransform transform) {
++        this.iterator = iterator;
++        this.transform = transform;
++    }
++
++    @Override
++    public boolean hasNext() {
++        return iterator.hasNext();
++    }
++
++    @Override
++    protected void advance(MutableVec3 value) {
++        value.set(iterator.next());
++        transform.applyInPlace(value);
++    }
++}
+diff --git a/src/main/java/org/bukkit/region/TransformedBlockRegion.java b/src/main/java/org/bukkit/region/TransformedBlockRegion.java
+new file mode 100644
+index 0000000..93f613e
+--- /dev/null
++++ b/src/main/java/org/bukkit/region/TransformedBlockRegion.java
+@@ -0,0 +1,73 @@
++package org.bukkit.region;
++
++import java.util.Iterator;
++import java.util.function.Predicate;
++
++import org.bukkit.geometry.CoarseTransform;
++import org.bukkit.geometry.Vec3;
++
++class TransformedBlockRegion implements BlockRegion {
++
++    private final BlockRegion original;
++    private final CoarseTransform transform, inverse;
++
++    TransformedBlockRegion(BlockRegion original, CoarseTransform transform) {
++        this.original = original;
++        this.transform = transform;
++        this.inverse = transform.inverse();
++    }
++
++    @Override
++    public boolean isMutable() {
++        return original.isMutable();
++    }
++
++    @Override
++    public boolean isEmpty() {
++        return original.isEmpty();
++    }
++
++    @Override
++    public int size() {
++        return original.size();
++    }
++
++    @Override
++    public boolean contains(Vec3 pos) {
++        return original.contains(inverse.apply(pos));
++    }
++
++    @Override
++    public Iterator<Vec3> mutableIterator() {
++        return TransformedBlockIterator.of(original.mutableIterator(), transform);
++    }
++
++    @Override
++    public BlockRegion copy() {
++        if(!original.isMutable()) return this;
++        return BakedBlockRegion.of(this);
++    }
++
++    @Override
++    public BlockRegion transform(CoarseTransform transform) {
++        if(transform.isIdentity()) return this;
++        transform = this.transform.andThen(transform);
++        if(transform.isIdentity()) return original;
++        return new TransformedBlockRegion(original, transform);
++    }
++
++    @Override
++    public BlockRegion filter(Predicate<? super Vec3> predicate) {
++        return new FilteredBlockRegion(this, predicate);
++    }
++
++    @Override
++    public int hashCode() {
++        return standardHashCode();
++    }
++
++    @Override
++    public boolean equals(Object obj) {
++        return standardEquals(obj);
++    }
++}
+diff --git a/src/main/java/org/bukkit/util/BlockVector.java b/src/main/java/org/bukkit/util/BlockVector.java
+index bdf8f6d..cc2b700 100644
+--- a/src/main/java/org/bukkit/util/BlockVector.java
++++ b/src/main/java/org/bukkit/util/BlockVector.java
+@@ -2,6 +2,7 @@ package org.bukkit.util;
+ 
+ import java.util.Map;
+ import org.bukkit.configuration.serialization.SerializableAs;
++import org.bukkit.geometry.Vec3;
+ 
+ /**
+  * A vector with a hash function that floors the X, Y, Z components, a la
+@@ -16,9 +17,7 @@ public class BlockVector extends Vector {
+      * Construct the vector with all components as 0.
+      */
+     public BlockVector() {
+-        this.x = 0;
+-        this.y = 0;
+-        this.z = 0;
++        super();
+     }
+ 
+     /**
+@@ -27,9 +26,7 @@ public class BlockVector extends Vector {
+      * @param vec The other vector.
+      */
+     public BlockVector(Vector vec) {
+-        this.x = vec.getX();
+-        this.y = vec.getY();
+-        this.z = vec.getZ();
++        super(vec);
+     }
+ 
+     /**
+@@ -40,9 +37,7 @@ public class BlockVector extends Vector {
+      * @param z Z component
+      */
+     public BlockVector(int x, int y, int z) {
+-        this.x = x;
+-        this.y = y;
+-        this.z = z;
++        super(x, y, z);
+     }
+ 
+     /**
+@@ -53,9 +48,7 @@ public class BlockVector extends Vector {
+      * @param z Z component
+      */
+     public BlockVector(double x, double y, double z) {
+-        this.x = x;
+-        this.y = y;
+-        this.z = z;
++        super(x, y, z);
+     }
+ 
+     /**
+@@ -66,9 +59,26 @@ public class BlockVector extends Vector {
+      * @param z Z component
+      */
+     public BlockVector(float x, float y, float z) {
+-        this.x = x;
+-        this.y = y;
+-        this.z = z;
++        super(x, y, z);
++    }
++
++    public BlockVector(Vec3 v) {
++        super(v);
++    }
++
++    @Override
++    public boolean isFine() {
++        return false;
++    }
++
++    @Override
++    public boolean isCoarse() {
++        return true;
++    }
++
++    @Override
++    public boolean equals(Vec3 v) {
++        return v != null && v.isCoarse() && coarseEquals(v);
+     }
+ 
+     /**
+@@ -79,13 +89,7 @@ public class BlockVector extends Vector {
+      */
+     @Override
+     public boolean equals(Object obj) {
+-        if (!(obj instanceof BlockVector)) {
+-            return false;
+-        }
+-        BlockVector other = (BlockVector) obj;
+-
+-        return (int) other.getX() == (int) this.x && (int) other.getY() == (int) this.y && (int) other.getZ() == (int) this.z;
+-
++        return this == obj || (obj instanceof Vec3 && equals((Vec3) obj));
+     }
+ 
+     /**
+@@ -95,7 +99,7 @@ public class BlockVector extends Vector {
+      */
+     @Override
+     public int hashCode() {
+-        return (Integer.valueOf((int) x).hashCode() >> 13) ^ (Integer.valueOf((int) y).hashCode() >> 7) ^ Integer.valueOf((int) z).hashCode();
++        return coarseHashCode();
+     }
+ 
+     /**
+diff --git a/src/main/java/org/bukkit/util/ImVector.java b/src/main/java/org/bukkit/util/ImVector.java
+new file mode 100644
+index 0000000..0c53b96
+--- /dev/null
++++ b/src/main/java/org/bukkit/util/ImVector.java
+@@ -0,0 +1,190 @@
++package org.bukkit.util;
++
++import org.bukkit.block.Block;
++import org.bukkit.block.BlockState;
++import org.bukkit.geometry.Vec3;
++
++/**
++ * An immutable {@link Vector}
++ *
++ * All the mutating methods inherited from {@link Vector}
++ * will throw an exception.
++ */
++public class ImVector extends Vector {
++
++    private static final ImVector ZERO = new ImVector(0, 0, 0);
++    private static final ImVector NaN = new ImVector(Double.NaN, Double.NaN, Double.NaN);
++
++    ImVector(double x, double y, double z) {
++        super(x, y, z);
++    }
++
++    public static ImVector of(double x, double y, double z) {
++        return x == 0 && y == 0 && z == 0 ? ZERO : new ImVector(x, y, z);
++    }
++
++    public static ImVector of(double n) {
++        return n == 0 ? ZERO : new ImVector(n, n, n);
++    }
++
++    public static ImVector ofZero() {
++        return ZERO;
++    }
++
++    public static ImVector ofNaN() {
++        return NaN;
++    }
++
++    public static ImVector copyOf(Vec3 v) {
++        return v instanceof ImVector ? (ImVector) v
++                                     : new ImVector(v.fineX(), v.fineY(), v.fineZ());
++    }
++
++    private static class Corner extends ImVector {
++        public Corner(int x, int y, int z) {
++            super((double) x, (double) y, (double) z);
++        }
++
++        @Override public boolean isBlockCorner() { return true; }
++        @Override public boolean isBlockCenter() { return false; }
++    }
++
++    private static class Center extends ImVector {
++        Center(int x, int y, int z) {
++            super(x + 0.5, y + 0.5, z + 0.5);
++        }
++
++        @Override public boolean isBlockCorner() { return false; }
++        @Override public boolean isBlockCenter() { return true; }
++    }
++
++    public static ImVector cornerOf(int x, int y, int z) {
++        return new Corner(x, y, z);
++    }
++
++    public static ImVector cornerOf(Vec3 v) {
++        return v instanceof Corner ? (Corner) v : new Corner(v.coarseX(), v.coarseY(), v.coarseZ());
++    }
++
++    public static ImVector cornerOf(Block block) {
++        return new Corner(block.getX(), block.getY(), block.getZ());
++    }
++
++    public static ImVector cornerOf(BlockState block) {
++        return new Corner(block.getX(), block.getY(), block.getZ());
++    }
++
++    public static ImVector centerOf(int x, int y, int z) {
++        return new Center(x, y, z);
++    }
++
++    public static ImVector centerOf(Vec3 v) {
++        return v instanceof Center ? (Center) v : new Center(v.coarseX(), v.coarseY(), v.coarseZ());
++    }
++
++    public static ImVector centerOf(Block block) {
++        return new Center(block.getX(), block.getY(), block.getZ());
++    }
++
++    public static ImVector centerOf(BlockState block) {
++        return new Center(block.getX(), block.getY(), block.getZ());
++    }
++
++    public static ImVector minimum(Vec3 a, Vec3 b) {
++        return of(Math.min(a.fineX(), b.fineX()),
++                  Math.min(a.fineY(), b.fineY()),
++                  Math.min(a.fineZ(), b.fineZ()));
++    }
++
++    public static ImVector maximum(Vec3 a, Vec3 b) {
++        return of(Math.max(a.fineX(), b.fineX()),
++                  Math.max(a.fineY(), b.fineY()),
++                  Math.max(a.fineZ(), b.fineZ()));
++    }
++
++    public static ImVector min(Vec3... a) {
++        double x, y, z;
++        x = y = z = Double.POSITIVE_INFINITY;
++        for(Vec3 v : a) {
++            x = Math.min(x, v.fineX());
++            y = Math.min(y, v.fineY());
++            z = Math.min(z, v.fineZ());
++        }
++        return of(x, y, z);
++    }
++
++    public static ImVector max(Vec3... a) {
++        double x, y, z;
++        x = y = z = Double.NEGATIVE_INFINITY;
++        for(Vec3 v : a) {
++            x = Math.max(x, v.fineX());
++            y = Math.max(y, v.fineY());
++            z = Math.max(z, v.fineZ());
++        }
++        return of(x, y, z);
++    }
++
++    public static ImVector interpolate(Vec3 a, Vec3 b, double n) {
++        return of(NumberConversions.interpolate(a.fineX(), b.fineX(), n),
++                  NumberConversions.interpolate(a.fineY(), b.fineY(), n),
++                  NumberConversions.interpolate(a.fineZ(), b.fineZ(), n));
++    }
++
++    @Override
++    public boolean isMutable() {
++        return false;
++    }
++
++    @Override
++    public ImVector copy() {
++        return this;
++    }
++
++    @Override
++    public ImVector times(int n) {
++        if(n == 0) return ZERO;
++        if(n == 1) return this;
++        return super.times(n);
++    }
++
++    @Override
++    public ImVector times(double n) {
++        if(n == 0) return ZERO;
++        if(n == 1) return this;
++        return super.times(n);
++    }
++
++    @Override
++    public ImVector over(double n) {
++        if(Double.isInfinite(n)) {
++            return ZERO;
++        } else if(n == 1) {
++            return this;
++        } else {
++            return super.over(n);
++        }
++    }
++
++    @Override
++    public ImVector getCrossProduct(Vector v) {
++        return of(this.fineY() * v.fineZ() - v.fineY() * this.fineZ(),
++                  this.fineZ() * v.fineX() - v.fineZ() * this.fineX(),
++                  this.fineX() * v.fineY() - v.fineX() * this.fineY());
++    }
++
++    @Override
++    public ImVector getMidpoint(Vector v) {
++        return of((fineX() + v.getX()) / 2,
++                  (fineY() + v.getY()) / 2,
++                  (fineZ() + v.getZ()) / 2);
++    }
++
++    private UnsupportedOperationException ex() {
++        return new UnsupportedOperationException("object is immutable");
++    }
++
++    @Override public Vector setX(double x) { throw ex(); }
++    @Override public Vector setY(double y) { throw ex(); }
++    @Override public Vector setZ(double z) { throw ex(); }
++    @Override public Vector set(double x, double y, double z) { throw ex(); }
++}
+diff --git a/src/main/java/org/bukkit/util/NumberConversions.java b/src/main/java/org/bukkit/util/NumberConversions.java
+index e6af9ec..ff04e6a 100644
+--- a/src/main/java/org/bukkit/util/NumberConversions.java
++++ b/src/main/java/org/bukkit/util/NumberConversions.java
+@@ -121,4 +121,45 @@ public final class NumberConversions {
+             throw new IllegalArgumentException(message);
+         }
+     }
++
++    public static double interpolate(double a, double b, double n) {
++        return (1D - n) * a + n * b;
++    }
++
++    public static double min(double... a) {
++        double n = Double.POSITIVE_INFINITY;
++        for(int i = 0; i < a.length; i++) {
++            n = Math.min(n, a[i]);
++        }
++        return n;
++    }
++
++    public static double max(double... a) {
++        double n = Double.NEGATIVE_INFINITY;
++        for(int i = 0; i < a.length; i++) {
++            n = Math.max(n, a[i]);
++        }
++        return n;
++    }
++
++    public static int mod(int n, int m) {
++        if(m <= 0) {
++            throw new ArithmeticException("Modulus " + m + " must be > 0");
++        }
++        int result = n % m;
++        return (result >= 0) ? result : result + m;
++    }
++
++    public static int hashCode(double n) {
++        final long bits = Double.doubleToLongBits(n);
++        return (int) (bits ^ (bits >>> 32));
++    }
++
++    public static int clamp(int n, int min, int max) {
++        return n < min ? min : n > max ? max : n;
++    }
++
++    public static double clamp(double n, double min, double max) {
++        return n < min ? min : n > max ? max : n;
++    }
+ }
+diff --git a/src/main/java/org/bukkit/util/RayBlockIntersection.java b/src/main/java/org/bukkit/util/RayBlockIntersection.java
+index b1ba1d8..f2c986c 100644
+--- a/src/main/java/org/bukkit/util/RayBlockIntersection.java
++++ b/src/main/java/org/bukkit/util/RayBlockIntersection.java
+@@ -2,6 +2,7 @@ package org.bukkit.util;
+ 
+ import org.bukkit.block.Block;
+ import org.bukkit.block.BlockFace;
++import org.bukkit.geometry.Vec3;
+ 
+ /**
+  * Result of a ray-block intersection test
+@@ -9,12 +10,12 @@ import org.bukkit.block.BlockFace;
+ public class RayBlockIntersection {
+     private final Block block;
+     private final BlockFace face;
+-    private final Vector position;
++    private final ImVector position;
+ 
+-    public RayBlockIntersection(Block block, BlockFace face, Vector position) {
++    public RayBlockIntersection(Block block, BlockFace face, Vec3 position) {
+         this.block = block;
+         this.face = face;
+-        this.position = position;
++        this.position = ImVector.copyOf(position);
+     }
+ 
+     /**
+diff --git a/src/main/java/org/bukkit/util/SetBase.java b/src/main/java/org/bukkit/util/SetBase.java
+new file mode 100644
+index 0000000..036df35
+--- /dev/null
++++ b/src/main/java/org/bukkit/util/SetBase.java
+@@ -0,0 +1,60 @@
++package org.bukkit.util;
++
++import java.util.Collection;
++import java.util.Set;
++
++public interface SetBase<E> extends Set<E> {
++
++    @Override
++    default boolean isEmpty() {
++        return size() <= 0;
++    }
++
++    @Override
++    default boolean containsAll(Collection<?> c) {
++        for(Object o : c) {
++            if(contains(o)) return true;
++        }
++        return false;
++    }
++
++    @Override
++    default Object[] toArray() {
++        throw new UnsupportedOperationException();
++    }
++
++    @Override
++    default <T> T[] toArray(T[] a) {
++        throw new UnsupportedOperationException();
++    }
++
++    @Override
++    default boolean add(E vec3) {
++        throw new UnsupportedOperationException();
++    }
++
++    @Override
++    default boolean remove(Object o) {
++        throw new UnsupportedOperationException();
++    }
++
++    @Override
++    default boolean addAll(Collection<? extends E> c) {
++        throw new UnsupportedOperationException();
++    }
++
++    @Override
++    default boolean retainAll(Collection<?> c) {
++        throw new UnsupportedOperationException();
++    }
++
++    @Override
++    default boolean removeAll(Collection<?> c) {
++        throw new UnsupportedOperationException();
++    }
++
++    @Override
++    default void clear() {
++        throw new UnsupportedOperationException();
++    }
++}
+diff --git a/src/main/java/org/bukkit/util/Vector.java b/src/main/java/org/bukkit/util/Vector.java
+index cebd3cc..b44e5e4 100644
+--- a/src/main/java/org/bukkit/util/Vector.java
++++ b/src/main/java/org/bukkit/util/Vector.java
+@@ -3,11 +3,14 @@ package org.bukkit.util;
+ import java.util.LinkedHashMap;
+ import java.util.Map;
+ import java.util.Random;
++
++import org.bukkit.Bukkit;
+ import org.bukkit.Location;
+ import org.bukkit.World;
+ import org.bukkit.configuration.serialization.ConfigurationSerializable;
+ import org.bukkit.configuration.serialization.SerializableAs;
+-import static org.bukkit.util.NumberConversions.checkFinite;
++import org.bukkit.geometry.Cuboid;
++import org.bukkit.geometry.Vec3;
+ 
+ /**
+  * Represents a mutable vector. Because the components of Vectors are mutable,
+@@ -16,7 +19,7 @@ import static org.bukkit.util.NumberConversions.checkFinite;
+  * <code>clone()</code> in order to get a copy.
+  */
+ @SerializableAs("Vector")
+-public class Vector implements Cloneable, ConfigurationSerializable {
++public class Vector extends VectorBase<Vector> implements Cloneable, ConfigurationSerializable {
+     private static final long serialVersionUID = -2657651106777219169L;
+ 
+     private static Random random = new Random();
+@@ -26,17 +29,11 @@ public class Vector implements Cloneable, ConfigurationSerializable {
+      */
+     private static final double epsilon = 0.000001;
+ 
+-    protected double x;
+-    protected double y;
+-    protected double z;
+-
+     /**
+      * Construct the vector with all components as 0.
+      */
+     public Vector() {
+-        this.x = 0;
+-        this.y = 0;
+-        this.z = 0;
++        super(0, 0, 0);
+     }
+ 
+     /**
+@@ -47,9 +44,7 @@ public class Vector implements Cloneable, ConfigurationSerializable {
+      * @param z Z component
+      */
+     public Vector(int x, int y, int z) {
+-        this.x = x;
+-        this.y = y;
+-        this.z = z;
++        super(x, y, z);
+     }
+ 
+     /**
+@@ -60,9 +55,14 @@ public class Vector implements Cloneable, ConfigurationSerializable {
+      * @param z Z component
+      */
+     public Vector(double x, double y, double z) {
+-        this.x = x;
+-        this.y = y;
+-        this.z = z;
++        super(x, y, z);
++    }
++
++    /**
++     * Construct the vector with all components set to the given value
++     */
++    public Vector(double n) {
++        super(n, n, n);
+     }
+ 
+     /**
+@@ -73,9 +73,63 @@ public class Vector implements Cloneable, ConfigurationSerializable {
+      * @param z Z component
+      */
+     public Vector(float x, float y, float z) {
+-        this.x = x;
+-        this.y = y;
+-        this.z = z;
++        super(x, y, z);
++    }
++
++    /**
++     * Construct a copy of the given Vector
++     */
++    public Vector(Vec3 that) {
++        super(that.fineX(), that.fineY(), that.fineZ());
++    }
++
++    @Override
++    public Vector mutableCopy() {
++        return new Vector(this);
++    }
++
++    @Override
++    public Vec3 coarseOf(int x, int y, int z) {
++        return Bukkit.vectors().coarse(x, y, z);
++    }
++
++    @Override
++    public Vec3 coarseZero() {
++        return Bukkit.vectors().coarseZero();
++    }
++
++    @Override
++    public ImVector fineOf(double x, double y, double z) {
++        return ImVector.of(x, y, z);
++    }
++
++    @Override
++    public ImVector fineZero() {
++        return ImVector.ofZero();
++    }
++
++    public Vector clamp(Cuboid bounds) {
++        return clamp(bounds.minimum(), bounds.maximum());
++    }
++
++    @Override
++    public Vec3 unmodifiable() {
++        return new ImVector(0, 0, 0) {
++            @Override
++            public double fineX() {
++                return Vector.this.fineX();
++            }
++
++            @Override
++            public double fineY() {
++                return Vector.this.fineY();
++            }
++
++            @Override
++            public double fineZ() {
++                return Vector.this.fineZ();
++            }
++        };
+     }
+ 
+     /**
+@@ -85,10 +139,7 @@ public class Vector implements Cloneable, ConfigurationSerializable {
+      * @return the same vector
+      */
+     public Vector add(Vector vec) {
+-        x += vec.x;
+-        y += vec.y;
+-        z += vec.z;
+-        return this;
++        return add((Vec3) vec);
+     }
+ 
+     /**
+@@ -98,10 +149,7 @@ public class Vector implements Cloneable, ConfigurationSerializable {
+      * @return the same vector
+      */
+     public Vector subtract(Vector vec) {
+-        x -= vec.x;
+-        y -= vec.y;
+-        z -= vec.z;
+-        return this;
++        return subtract((Vec3) vec);
+     }
+ 
+     /**
+@@ -111,10 +159,7 @@ public class Vector implements Cloneable, ConfigurationSerializable {
+      * @return the same vector
+      */
+     public Vector multiply(Vector vec) {
+-        x *= vec.x;
+-        y *= vec.y;
+-        z *= vec.z;
+-        return this;
++        return set(this.fineX() * vec.fineX(), this.fineY() * vec.fineY(), this.fineZ() * vec.fineZ());
+     }
+ 
+     /**
+@@ -124,10 +169,7 @@ public class Vector implements Cloneable, ConfigurationSerializable {
+      * @return the same vector
+      */
+     public Vector divide(Vector vec) {
+-        x /= vec.x;
+-        y /= vec.y;
+-        z /= vec.z;
+-        return this;
++        return set(this.fineX() / vec.fineX(), this.fineY() / vec.fineY(), this.fineZ() / vec.fineZ());
+     }
+ 
+     /**
+@@ -137,10 +179,7 @@ public class Vector implements Cloneable, ConfigurationSerializable {
+      * @return the same vector
+      */
+     public Vector copy(Vector vec) {
+-        x = vec.x;
+-        y = vec.y;
+-        z = vec.z;
+-        return this;
++        return set(vec);
+     }
+ 
+     /**
+@@ -153,7 +192,7 @@ public class Vector implements Cloneable, ConfigurationSerializable {
+      * @return the magnitude
+      */
+     public double length() {
+-        return Math.sqrt(NumberConversions.square(x) + NumberConversions.square(y) + NumberConversions.square(z));
++        return super.length();
+     }
+ 
+     /**
+@@ -162,7 +201,7 @@ public class Vector implements Cloneable, ConfigurationSerializable {
+      * @return the magnitude
+      */
+     public double lengthSquared() {
+-        return NumberConversions.square(x) + NumberConversions.square(y) + NumberConversions.square(z);
++        return super.lengthSquared();
+     }
+ 
+     /**
+@@ -176,7 +215,7 @@ public class Vector implements Cloneable, ConfigurationSerializable {
+      * @return the distance
+      */
+     public double distance(Vector o) {
+-        return Math.sqrt(NumberConversions.square(x - o.x) + NumberConversions.square(y - o.y) + NumberConversions.square(z - o.z));
++        return distance((Vec3) o);
+     }
+ 
+     /**
+@@ -186,7 +225,7 @@ public class Vector implements Cloneable, ConfigurationSerializable {
+      * @return the distance
+      */
+     public double distanceSquared(Vector o) {
+-        return NumberConversions.square(x - o.x) + NumberConversions.square(y - o.y) + NumberConversions.square(z - o.z);
++        return distanceSquared((Vec3) o);
+     }
+ 
+     /**
+@@ -208,10 +247,9 @@ public class Vector implements Cloneable, ConfigurationSerializable {
+      * @return this same vector (now a midpoint)
+      */
+     public Vector midpoint(Vector other) {
+-        x = (x + other.x) / 2;
+-        y = (y + other.y) / 2;
+-        z = (z + other.z) / 2;
+-        return this;
++        return set((fineX() + other.fineX()) / 2,
++                   (fineY() + other.fineY()) / 2,
++                   (fineZ() + other.fineZ()) / 2);
+     }
+ 
+     /**
+@@ -221,9 +259,9 @@ public class Vector implements Cloneable, ConfigurationSerializable {
+      * @return a new midpoint vector
+      */
+     public Vector getMidpoint(Vector other) {
+-        double x = (this.x + other.x) / 2;
+-        double y = (this.y + other.y) / 2;
+-        double z = (this.z + other.z) / 2;
++        double x = (this.fineX() + other.fineX()) / 2;
++        double y = (this.fineY() + other.fineY()) / 2;
++        double z = (this.fineZ() + other.fineZ()) / 2;
+         return new Vector(x, y, z);
+     }
+ 
+@@ -235,10 +273,7 @@ public class Vector implements Cloneable, ConfigurationSerializable {
+      * @return the same vector
+      */
+     public Vector multiply(int m) {
+-        x *= m;
+-        y *= m;
+-        z *= m;
+-        return this;
++        return set(fineX() * m, fineY() * m, fineZ() * m);
+     }
+ 
+     /**
+@@ -249,10 +284,7 @@ public class Vector implements Cloneable, ConfigurationSerializable {
+      * @return the same vector
+      */
+     public Vector multiply(double m) {
+-        x *= m;
+-        y *= m;
+-        z *= m;
+-        return this;
++        return set(fineX() * m, fineY() * m, fineZ() * m);
+     }
+ 
+     /**
+@@ -263,10 +295,11 @@ public class Vector implements Cloneable, ConfigurationSerializable {
+      * @return the same vector
+      */
+     public Vector multiply(float m) {
+-        x *= m;
+-        y *= m;
+-        z *= m;
+-        return this;
++        return set(fineX() * m, fineY() * m, fineZ() * m);
++    }
++
++    public Vector divide(double m) {
++        return set(fineX() / m, fineY() / m, fineZ() / m);
+     }
+ 
+     /**
+@@ -277,7 +310,7 @@ public class Vector implements Cloneable, ConfigurationSerializable {
+      * @return dot product
+      */
+     public double dot(Vector other) {
+-        return x * other.x + y * other.y + z * other.z;
++        return dot((Vec3) other);
+     }
+ 
+     /**
+@@ -293,14 +326,9 @@ public class Vector implements Cloneable, ConfigurationSerializable {
+      * @return the same vector
+      */
+     public Vector crossProduct(Vector o) {
+-        double newX = y * o.z - o.y * z;
+-        double newY = z * o.x - o.z * x;
+-        double newZ = x * o.y - o.x * y;
+-
+-        x = newX;
+-        y = newY;
+-        z = newZ;
+-        return this;
++        return set(fineY() * o.fineZ() - o.fineY() * fineZ(),
++                   fineZ() * o.fineX() - o.fineZ() * fineX(),
++                   fineX() * o.fineY() - o.fineX() * fineY());
+     }
+ 
+     /**
+@@ -316,9 +344,9 @@ public class Vector implements Cloneable, ConfigurationSerializable {
+      * @return a new vector
+      */
+     public Vector getCrossProduct(Vector o) {
+-        double x = this.y * o.z - o.y * this.z;
+-        double y = this.z * o.x - o.z * this.x;
+-        double z = this.x * o.y - o.x * this.y;
++        double x = this.fineY() * o.fineZ() - o.fineY() * this.fineZ();
++        double y = this.fineZ() * o.fineX() - o.fineZ() * this.fineX();
++        double z = this.fineX() * o.fineY() - o.fineX() * this.fineY();
+         return new Vector(x, y, z);
+     }
+ 
+@@ -328,13 +356,7 @@ public class Vector implements Cloneable, ConfigurationSerializable {
+      * @return the same vector
+      */
+     public Vector normalize() {
+-        double length = length();
+-
+-        x /= length;
+-        y /= length;
+-        z /= length;
+-
+-        return this;
++        return divide(length());
+     }
+ 
+     /**
+@@ -343,10 +365,7 @@ public class Vector implements Cloneable, ConfigurationSerializable {
+      * @return the same vector
+      */
+     public Vector zero() {
+-        x = 0;
+-        y = 0;
+-        z = 0;
+-        return this;
++        return setZero();
+     }
+ 
+     /**
+@@ -360,7 +379,7 @@ public class Vector implements Cloneable, ConfigurationSerializable {
+      * @return whether this vector is in the AABB
+      */
+     public boolean isInAABB(Vector min, Vector max) {
+-        return x >= min.x && x <= max.x && y >= min.y && y <= max.y && z >= min.z && z <= max.z;
++        return fineX() >= min.fineX() && fineX() <= max.fineX() && fineY() >= min.fineY() && fineY() <= max.fineY() && fineZ() >= min.fineZ() && fineZ() <= max.fineZ();
+     }
+ 
+     /**
+@@ -371,7 +390,7 @@ public class Vector implements Cloneable, ConfigurationSerializable {
+      * @return whether this vector is in the sphere
+      */
+     public boolean isInSphere(Vector origin, double radius) {
+-        return (NumberConversions.square(origin.x - x) + NumberConversions.square(origin.y - y) + NumberConversions.square(origin.z - z)) <= NumberConversions.square(radius);
++        return (NumberConversions.square(origin.fineX() - fineX()) + NumberConversions.square(origin.fineY() - fineY()) + NumberConversions.square(origin.fineZ() - fineZ())) <= NumberConversions.square(radius);
+     }
+ 
+     /**
+@@ -380,7 +399,7 @@ public class Vector implements Cloneable, ConfigurationSerializable {
+      * @return The X component.
+      */
+     public double getX() {
+-        return x;
++        return fineX();
+     }
+ 
+     /**
+@@ -390,7 +409,7 @@ public class Vector implements Cloneable, ConfigurationSerializable {
+      * @return block X
+      */
+     public int getBlockX() {
+-        return NumberConversions.floor(x);
++        return coarseX();
+     }
+ 
+     /**
+@@ -399,7 +418,7 @@ public class Vector implements Cloneable, ConfigurationSerializable {
+      * @return The Y component.
+      */
+     public double getY() {
+-        return y;
++        return fineY();
+     }
+ 
+     /**
+@@ -409,7 +428,7 @@ public class Vector implements Cloneable, ConfigurationSerializable {
+      * @return block y
+      */
+     public int getBlockY() {
+-        return NumberConversions.floor(y);
++        return coarseY();
+     }
+ 
+     /**
+@@ -418,7 +437,7 @@ public class Vector implements Cloneable, ConfigurationSerializable {
+      * @return The Z component.
+      */
+     public double getZ() {
+-        return z;
++        return fineZ();
+     }
+ 
+     /**
+@@ -428,7 +447,7 @@ public class Vector implements Cloneable, ConfigurationSerializable {
+      * @return block z
+      */
+     public int getBlockZ() {
+-        return NumberConversions.floor(z);
++        return coarseZ();
+     }
+ 
+     /**
+@@ -437,8 +456,9 @@ public class Vector implements Cloneable, ConfigurationSerializable {
+      * @param x The new X component.
+      * @return This vector.
+      */
++    @Override
+     public Vector setX(int x) {
+-        this.x = x;
++        setX((double) x);
+         return this;
+     }
+ 
+@@ -448,8 +468,9 @@ public class Vector implements Cloneable, ConfigurationSerializable {
+      * @param x The new X component.
+      * @return This vector.
+      */
++    @Override
+     public Vector setX(double x) {
+-        this.x = x;
++        super.setX(x);
+         return this;
+     }
+ 
+@@ -460,7 +481,7 @@ public class Vector implements Cloneable, ConfigurationSerializable {
+      * @return This vector.
+      */
+     public Vector setX(float x) {
+-        this.x = x;
++        setX((double) x);
+         return this;
+     }
+ 
+@@ -470,8 +491,9 @@ public class Vector implements Cloneable, ConfigurationSerializable {
+      * @param y The new Y component.
+      * @return This vector.
+      */
++    @Override
+     public Vector setY(int y) {
+-        this.y = y;
++        setY((double) y);
+         return this;
+     }
+ 
+@@ -481,8 +503,9 @@ public class Vector implements Cloneable, ConfigurationSerializable {
+      * @param y The new Y component.
+      * @return This vector.
+      */
++    @Override
+     public Vector setY(double y) {
+-        this.y = y;
++        super.setY(y);
+         return this;
+     }
+ 
+@@ -493,7 +516,7 @@ public class Vector implements Cloneable, ConfigurationSerializable {
+      * @return This vector.
+      */
+     public Vector setY(float y) {
+-        this.y = y;
++        setY((double) y);
+         return this;
+     }
+ 
+@@ -503,8 +526,9 @@ public class Vector implements Cloneable, ConfigurationSerializable {
+      * @param z The new Z component.
+      * @return This vector.
+      */
++    @Override
+     public Vector setZ(int z) {
+-        this.z = z;
++        setZ((double) z);
+         return this;
+     }
+ 
+@@ -514,8 +538,9 @@ public class Vector implements Cloneable, ConfigurationSerializable {
+      * @param z The new Z component.
+      * @return This vector.
+      */
++    @Override
+     public Vector setZ(double z) {
+-        this.z = z;
++        super.setZ(z);
+         return this;
+     }
+ 
+@@ -526,26 +551,13 @@ public class Vector implements Cloneable, ConfigurationSerializable {
+      * @return This vector.
+      */
+     public Vector setZ(float z) {
+-        this.z = z;
++        setZ((double) z);
+         return this;
+     }
+ 
+-    /**
+-     * Checks to see if two objects are equal.
+-     * <p>
+-     * Only two Vectors can ever return true. This method uses a fuzzy match
+-     * to account for floating point errors. The epsilon can be retrieved
+-     * with epsilon.
+-     */
+     @Override
+     public boolean equals(Object obj) {
+-        if (!(obj instanceof Vector)) {
+-            return false;
+-        }
+-
+-        Vector other = (Vector) obj;
+-
+-        return Math.abs(x - other.x) < epsilon && Math.abs(y - other.y) < epsilon && Math.abs(z - other.z) < epsilon && (this.getClass().equals(obj.getClass()));
++        return this == obj || (obj instanceof Vec3 && equals((Vec3) obj));
+     }
+ 
+     /**
+@@ -555,12 +567,7 @@ public class Vector implements Cloneable, ConfigurationSerializable {
+      */
+     @Override
+     public int hashCode() {
+-        int hash = 7;
+-
+-        hash = 79 * hash + (int) (Double.doubleToLongBits(this.x) ^ (Double.doubleToLongBits(this.x) >>> 32));
+-        hash = 79 * hash + (int) (Double.doubleToLongBits(this.y) ^ (Double.doubleToLongBits(this.y) >>> 32));
+-        hash = 79 * hash + (int) (Double.doubleToLongBits(this.z) ^ (Double.doubleToLongBits(this.z) >>> 32));
+-        return hash;
++        return fineHashCode();
+     }
+ 
+     /**
+@@ -582,7 +589,7 @@ public class Vector implements Cloneable, ConfigurationSerializable {
+      */
+     @Override
+     public String toString() {
+-        return x + "," + y + "," + z;
++        return fineX() + "," + fineY() + "," + fineZ();
+     }
+ 
+     /**
+@@ -592,7 +599,7 @@ public class Vector implements Cloneable, ConfigurationSerializable {
+      * @return the location
+      */
+     public Location toLocation(World world) {
+-        return new Location(world, x, y, z);
++        return new Location(world, fineX(), fineY(), fineZ());
+     }
+ 
+     /**
+@@ -604,7 +611,7 @@ public class Vector implements Cloneable, ConfigurationSerializable {
+      * @return the location
+      */
+     public Location toLocation(World world, float yaw, float pitch) {
+-        return new Location(world, x, y, z, yaw, pitch);
++        return new Location(world, fineX(), fineY(), fineZ(), yaw, pitch);
+     }
+ 
+     /**
+@@ -613,7 +620,7 @@ public class Vector implements Cloneable, ConfigurationSerializable {
+      * @return A block vector.
+      */
+     public BlockVector toBlockVector() {
+-        return new BlockVector(x, y, z);
++        return new BlockVector(fineX(), fineY(), fineZ());
+     }
+ 
+     /**
+@@ -633,7 +640,7 @@ public class Vector implements Cloneable, ConfigurationSerializable {
+      * @return minimum
+      */
+     public static Vector getMinimum(Vector v1, Vector v2) {
+-        return new Vector(Math.min(v1.x, v2.x), Math.min(v1.y, v2.y), Math.min(v1.z, v2.z));
++        return new Vector(Math.min(v1.fineX(), v2.fineX()), Math.min(v1.fineY(), v2.fineY()), Math.min(v1.fineZ(), v2.fineZ()));
+     }
+ 
+     /**
+@@ -644,7 +651,19 @@ public class Vector implements Cloneable, ConfigurationSerializable {
+      * @return maximum
+      */
+     public static Vector getMaximum(Vector v1, Vector v2) {
+-        return new Vector(Math.max(v1.x, v2.x), Math.max(v1.y, v2.y), Math.max(v1.z, v2.z));
++        return new Vector(Math.max(v1.fineX(), v2.fineX()), Math.max(v1.fineY(), v2.fineY()), Math.max(v1.fineZ(), v2.fineZ()));
++    }
++
++    public static Vector minimum(Vec3 a, Vec3 b) {
++        return new Vector(Math.min(a.fineX(), b.fineX()),
++                          Math.min(a.fineY(), b.fineY()),
++                          Math.min(a.fineZ(), b.fineZ()));
++    }
++
++    public static Vector maximum(Vec3 a, Vec3 b) {
++        return new Vector(Math.max(a.fineX(), b.fineX()),
++                          Math.max(a.fineY(), b.fineY()),
++                          Math.max(a.fineZ(), b.fineZ()));
+     }
+ 
+     /**
+diff --git a/src/main/java/org/bukkit/util/VectorBase.java b/src/main/java/org/bukkit/util/VectorBase.java
+new file mode 100644
+index 0000000..ab193d3
+--- /dev/null
++++ b/src/main/java/org/bukkit/util/VectorBase.java
+@@ -0,0 +1,57 @@
++package org.bukkit.util;
++
++import org.bukkit.geometry.MutableVec3Fine;
++
++abstract class VectorBase<M extends VectorBase<M>> implements MutableVec3Fine<ImVector, M> {
++
++    private double x;
++    private double y;
++    private double z;
++
++    protected VectorBase(double x, double y, double z) {
++        this.x = x;
++        this.y = y;
++        this.z = z;
++    }
++
++    @Override
++    public double fineX() {
++        return x;
++    }
++
++    @Override
++    public double fineY() {
++        return y;
++    }
++
++    @Override
++    public double fineZ() {
++        return z;
++    }
++
++    @Override
++    public M setX(double x) {
++        this.x = x;
++        return (M) this;
++    }
++
++    @Override
++    public M setY(double y) {
++        this.y = y;
++        return (M) this;
++    }
++
++    @Override
++    public M setZ(double z) {
++        this.z = z;
++        return (M) this;
++    }
++
++    @Override
++    public M set(double x, double y, double z) {
++        this.x = x;
++        this.y = y;
++        this.z = z;
++        return (M) this;
++    }
++}
+-- 
+1.9.0
+

--- a/Bukkit/0067-Velocity-API.patch
+++ b/Bukkit/0067-Velocity-API.patch
@@ -1,0 +1,207 @@
+From 6190fe4ae67c628243965e2e1ccc4a6923b79b49 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Wed, 16 Mar 2016 21:24:15 -0400
+Subject: [PATCH] Velocity API
+
+
+diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
+index 1519aae..05193b0 100644
+--- a/src/main/java/org/bukkit/Bukkit.java
++++ b/src/main/java/org/bukkit/Bukkit.java
+@@ -392,6 +392,13 @@ public final class Bukkit {
+     }
+ 
+     /**
++     * @see Server#getLegacyKnockback()
++     */
++    public static boolean getLegacyKnockback() {
++        return server.getLegacyKnockback();
++    }
++
++    /**
+      * Should plugins be able to access classes from other plugins that are not explicit dependencies?
+      */
+     public static boolean getIsolatePlugins() {
+diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
+index d165beb..b7b2690 100644
+--- a/src/main/java/org/bukkit/Server.java
++++ b/src/main/java/org/bukkit/Server.java
+@@ -304,6 +304,11 @@ public interface Server extends PluginMessageRecipient, BukkitRuntime, tc.oc.min
+     public boolean getWaterPushesTNT();
+ 
+     /**
++     * Recreate knockback mechanics from Minecraft 1.8
++     */
++    public boolean getLegacyKnockback();
++
++    /**
+      * Should plugins be able to access classes from other plugins that are not explicit dependencies?
+      */
+     public boolean getIsolatePlugins();
+diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
+index 100de93..756273d 100644
+--- a/src/main/java/org/bukkit/entity/Entity.java
++++ b/src/main/java/org/bukkit/entity/Entity.java
+@@ -54,6 +54,48 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Physical {
+     public Vector getVelocity();
+ 
+     /**
++     * Apply an impulse to this entity, i.e. a relative change in velocity.
++     *
++     * The given vector is added to the current velocity, and the entity's new
++     * velocity is synced to players in visible range.
++     *
++     * If this entity is a player, the impulse is sent directly to them,
++     * and will be applied by their client at the moment they receive it.
++     * This results in more accurate physics, from the player's perspective,
++     * particularly with high-latency connections. However, their final
++     * velocity is more difficult to predict from the server.
++     */
++    void applyImpulse(Vector impulse);
++    void applyImpulse(Vector impulse, boolean relative);
++
++    /**
++     * Set the knockback reduction for this entity.
++     *
++     * Set this to 0 for standard knockback mechanics.
++     * Set this to 1 to disable all knockback effects.
++     * Values between 0 and 1 reduce knockback impulses proportionally.
++     */
++    void setKnockbackReduction(float n);
++
++    /**
++     * Get this entity's knockback reduction
++     *
++     * @see #setKnockbackReduction(float)
++     */
++    float getKnockbackReduction();
++
++    /**
++     * Get the velocity of this entity, preferring an inferred value, if there is one.
++     *
++     * For {@link Player}s, this velocity is partly derived from positions reported by
++     * the client. This can be much more accurate than the velocity stored on the
++     * server, which is not affected by player movement at all.
++     *
++     * For all other entities, this returns the same value as {@link #getVelocity()}.
++     */
++    Vector getPredictedVelocity();
++
++    /**
+      * Returns true if the entity is supported by a block. This value is a
+      * state updated by the server and is not recalculated unless the entity
+      * moves.
+diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
+index 807d28d..70cca09 100644
+--- a/src/main/java/org/bukkit/entity/Player.java
++++ b/src/main/java/org/bukkit/entity/Player.java
+@@ -25,6 +25,7 @@ import org.bukkit.map.MapView;
+ import org.bukkit.plugin.messaging.PluginMessageRecipient;
+ import org.bukkit.scoreboard.Scoreboard;
+ import org.bukkit.util.RayBlockIntersection;
++import org.bukkit.util.Vector;
+ 
+ /**
+  * Represents a player, connected or not
+@@ -1642,4 +1643,12 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
+      * @return Information about the targeted block, or null if no blocks were found
+      */
+     RayBlockIntersection getTargetedBlock(boolean nonSolids, boolean liquids);
++
++    Vector getClientVelocity();
++
++    Vector getUnackedImpulse();
++
++    boolean hasUnackedVelocity();
++
++
+ }
+diff --git a/src/main/java/org/bukkit/event/player/PlayerKnockbackEvent.java b/src/main/java/org/bukkit/event/player/PlayerKnockbackEvent.java
+new file mode 100644
+index 0000000..7411633
+--- /dev/null
++++ b/src/main/java/org/bukkit/event/player/PlayerKnockbackEvent.java
+@@ -0,0 +1,26 @@
++package org.bukkit.event.player;
++
++import org.bukkit.entity.Entity;
++import org.bukkit.entity.Player;
++import org.bukkit.util.Vector;
++
++/**
++ * Called when a player is knocked back by an attack or injury.
++ */
++public class PlayerKnockbackEvent extends PlayerVelocityEvent {
++
++    private final Entity damager;
++
++    public PlayerKnockbackEvent(Player player, Entity damager, Vector velocity, boolean impulse) {
++        super(player, velocity, impulse);
++        this.damager = damager;
++    }
++
++    /**
++     * The entity that is knocking the player back, or null if the knockback
++     * is not caused by an entity.
++     */
++    public Entity getDamager() {
++        return damager;
++    }
++}
+diff --git a/src/main/java/org/bukkit/event/player/PlayerVelocityEvent.java b/src/main/java/org/bukkit/event/player/PlayerVelocityEvent.java
+index 69d2fce..9005c9c 100644
+--- a/src/main/java/org/bukkit/event/player/PlayerVelocityEvent.java
++++ b/src/main/java/org/bukkit/event/player/PlayerVelocityEvent.java
+@@ -6,16 +6,18 @@ import org.bukkit.event.HandlerList;
+ import org.bukkit.util.Vector;
+ 
+ /**
+- * Called when the velocity of a player changes.
++ * Called when an impulse is applied to a player.
+  */
+ public class PlayerVelocityEvent extends PlayerEvent implements Cancellable {
+     private static final HandlerList handlers = new HandlerList();
+     private boolean cancel = false;
+-    private Vector velocity;
++    private final Vector velocity;
++    private final boolean impulse;
+ 
+-    public PlayerVelocityEvent(final Player player, final Vector velocity) {
++    public PlayerVelocityEvent(final Player player, Vector velocity, boolean impulse) {
+         super(player);
+         this.velocity = velocity;
++        this.impulse = impulse;
+     }
+ 
+     public boolean isCancelled() {
+@@ -26,22 +28,16 @@ public class PlayerVelocityEvent extends PlayerEvent implements Cancellable {
+         this.cancel = cancel;
+     }
+ 
+-    /**
+-     * Gets the velocity vector that will be sent to the player
+-     *
+-     * @return Vector the player will get
+-     */
++    public boolean isImpulse() {
++        return impulse;
++    }
++
+     public Vector getVelocity() {
+         return velocity;
+     }
+ 
+-    /**
+-     * Sets the velocity vector that will be sent to the player
+-     *
+-     * @param velocity The velocity vector that will be sent to the player
+-     */
+     public void setVelocity(Vector velocity) {
+-        this.velocity = velocity;
++        this.velocity.set(velocity);
+     }
+ 
+     @Override
+-- 
+1.9.0
+

--- a/Bukkit/0068-Access-items-by-EquipmentSlot.patch
+++ b/Bukkit/0068-Access-items-by-EquipmentSlot.patch
@@ -1,0 +1,24 @@
+From 8c56b4b18592316b30a3c4c9ab08d7e8fe3a0efc Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Sun, 20 Mar 2016 06:44:49 -0400
+Subject: [PATCH] Access items by EquipmentSlot
+
+
+diff --git a/src/main/java/org/bukkit/inventory/PlayerInventory.java b/src/main/java/org/bukkit/inventory/PlayerInventory.java
+index 557cc04..6ce8509 100644
+--- a/src/main/java/org/bukkit/inventory/PlayerInventory.java
++++ b/src/main/java/org/bukkit/inventory/PlayerInventory.java
+@@ -179,6 +179,10 @@ public interface PlayerInventory extends Inventory {
+     @Deprecated
+     public void setItemInHand(ItemStack stack);
+ 
++    ItemStack getItem(EquipmentSlot slot);
++
++    void setItem(EquipmentSlot slot, ItemStack stack);
++
+     /**
+      * Get the slot number of the currently held item
+      *
+-- 
+1.9.0
+

--- a/Bukkit/0069-Multi-passenger-API.patch
+++ b/Bukkit/0069-Multi-passenger-API.patch
@@ -1,0 +1,55 @@
+From 38d1bbd1acdd60f2e30b38f2967998e4f57a7b55 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Mon, 21 Mar 2016 01:41:04 -0400
+Subject: [PATCH] Multi-passenger API
+
+
+diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
+index 756273d..5048bd6 100644
+--- a/src/main/java/org/bukkit/entity/Entity.java
++++ b/src/main/java/org/bukkit/entity/Entity.java
+@@ -248,6 +248,28 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Physical {
+     public abstract boolean eject();
+ 
+     /**
++     * @return true if the given entity is a passenger of this vehicle
++     */
++    boolean hasPassenger(Entity passenger);
++
++    /**
++     * @return all of the current passengers in this vehicle
++     */
++    List<Entity> getPassengers();
++
++    /**
++     * Make the given entities passengers of this vehicle. Any existing
++     * passengers who are not in the list are ejected.
++     * @return given entities that could NOT become passengers for whatever reason
++     */
++    List<Entity> setPassengers(List<Entity> passengers);
++
++    /**
++     * Eject all passengers from this vehicle
++     */
++    void ejectAll();
++
++    /**
+      * Returns the distance this entity has fallen
+      *
+      * @return The distance.
+@@ -327,6 +349,12 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Physical {
+     public boolean isInsideVehicle();
+ 
+     /**
++     * Enter the given vehicle
++     * @return true if successful
++     */
++    boolean enterVehicle(Entity vehicle);
++
++    /**
+      * Leave the current vehicle. If the entity is currently in a vehicle (and
+      * is removed from it), true will be returned, otherwise false will be
+      * returned.
+-- 
+1.9.0
+

--- a/Bukkit/0070-Natural-regeneration-API.patch
+++ b/Bukkit/0070-Natural-regeneration-API.patch
@@ -1,0 +1,28 @@
+From 028256f22b9b96f192e9bdcea6824cdc4218804d Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Mon, 21 Mar 2016 04:31:06 -0400
+Subject: [PATCH] Natural regeneration API
+
+
+diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
+index 70cca09..b13c16a 100644
+--- a/src/main/java/org/bukkit/entity/Player.java
++++ b/src/main/java/org/bukkit/entity/Player.java
+@@ -980,6 +980,14 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
+      */
+     public void setFoodLevel(int value);
+ 
++    boolean getFastNaturalRegeneration();
++
++    void setFastNaturalRegeneration(boolean enabled);
++
++    boolean getSlowNaturalRegeneration();
++
++    void setSlowNaturalRegeneration(boolean enabled);
++
+     /**
+      * Gets the Location where the player will spawn at their bed, null if
+      * they have not slept in one or their current bed spawn is invalid.
+-- 
+1.9.0
+

--- a/Bukkit/0071-Entity-bounding-box-API.patch
+++ b/Bukkit/0071-Entity-bounding-box-API.patch
@@ -1,0 +1,53 @@
+From 542b3cf5a69b5e8f2922e2e776e7002dbb2ce287 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Tue, 29 Mar 2016 02:00:35 -0400
+Subject: [PATCH] Entity bounding box API
+
+
+diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
+index 5048bd6..dfb542b 100644
+--- a/src/main/java/org/bukkit/entity/Entity.java
++++ b/src/main/java/org/bukkit/entity/Entity.java
+@@ -7,6 +7,7 @@ import org.bukkit.Server;
+ import org.bukkit.World;
+ import org.bukkit.Physical;
+ import org.bukkit.event.entity.EntityDamageEvent;
++import org.bukkit.geometry.Cuboid;
+ import org.bukkit.metadata.Metadatable;
+ import org.bukkit.util.Vector;
+ 
+@@ -493,4 +494,6 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Physical {
+      * @return true if the tag was successfully removed
+      */
+     boolean removeScoreboardTag(String tag);
++
++    Cuboid getBoundingBox();
+ }
+diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
+index 3a9f98d..e5c6f97 100644
+--- a/src/main/java/org/bukkit/entity/LivingEntity.java
++++ b/src/main/java/org/bukkit/entity/LivingEntity.java
+@@ -13,6 +13,7 @@ import org.bukkit.inventory.EntityEquipment;
+ import org.bukkit.potion.PotionEffect;
+ import org.bukkit.potion.PotionEffectType;
+ import org.bukkit.projectiles.ProjectileSource;
++import org.bukkit.geometry.Ray;
+ 
+ /**
+  * Represents a living entity, such as a monster or player
+@@ -43,6 +44,12 @@ public interface LivingEntity extends Attributable, Entity, Damageable, Projecti
+     public Location getEyeLocation();
+ 
+     /**
++     * Get a {@link Ray} originating at this entity's eye position,
++     * and pointing in the direction this entity is looking.
++     */
++    Ray getEyeRay();
++
++    /**
+      * Gets all blocks along the living entity's line of sight.
+      * <p>
+      * This list contains all blocks from the living entity's eye position to
+-- 
+1.9.0
+

--- a/Bukkit/0072-Attack-cooldown-info-API.patch
+++ b/Bukkit/0072-Attack-cooldown-info-API.patch
@@ -1,0 +1,35 @@
+From 62b056bcfd09348047e8b4ce6d28f9eb50c033db Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Tue, 29 Mar 2016 02:08:56 -0400
+Subject: [PATCH] Attack cooldown info API
+
+
+diff --git a/src/main/java/org/bukkit/entity/HumanEntity.java b/src/main/java/org/bukkit/entity/HumanEntity.java
+index 4757478..224581d 100644
+--- a/src/main/java/org/bukkit/entity/HumanEntity.java
++++ b/src/main/java/org/bukkit/entity/HumanEntity.java
+@@ -244,4 +244,21 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, Permissible, Inv
+      *         random spawning and despawning near them.
+      */
+     public boolean getAffectsSpawning();
++
++    /**
++     * Get the number of ticks since this entity last swung their weapon.
++     *
++     * Damage calculations are ultimately based on this value.
++     */
++    int getAttackCooldownTicks();
++
++    /**
++     * Get the coefficient that would be applied by the attack cooldown to a
++     * melee attack, at this moment, from this entity.
++     *
++     * This is calculated from the entity's attackSpeed attribute, and the
++     * number of ticks since their last swing. It current always falls in
++     * the range 0.2 to 1.0
++     */
++    float getAttackCooldownCoefficient();
+ }
+-- 
+1.9.0
+

--- a/Bukkit/0073-Add-PlayerUseUnknownEntityEvent.patch
+++ b/Bukkit/0073-Add-PlayerUseUnknownEntityEvent.patch
@@ -1,0 +1,50 @@
+From 65f8385e8d9e98ae8d33c3bda0f6b5ee54dc64ca Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Sat, 2 Apr 2016 05:08:36 -0400
+Subject: [PATCH] Add PlayerUseUnknownEntityEvent
+
+
+diff --git a/src/main/java/org/bukkit/event/player/PlayerUseUnknownEntityEvent.java b/src/main/java/org/bukkit/event/player/PlayerUseUnknownEntityEvent.java
+new file mode 100644
+index 0000000..26cda06
+--- /dev/null
++++ b/src/main/java/org/bukkit/event/player/PlayerUseUnknownEntityEvent.java
+@@ -0,0 +1,35 @@
++package org.bukkit.event.player;
++
++import org.bukkit.entity.Player;
++import org.bukkit.event.HandlerList;
++import org.bukkit.inventory.EquipmentSlot;
++
++public class PlayerUseUnknownEntityEvent extends PlayerActionBase {
++
++    private final int entityId;
++    private final boolean attack;
++    private final EquipmentSlot hand;
++
++    public PlayerUseUnknownEntityEvent(Player who, int entityId, boolean attack, EquipmentSlot hand) {
++        super(who);
++        this.entityId = entityId;
++        this.attack = attack;
++        this.hand = hand;
++    }
++
++    public int getEntityId() {
++        return entityId;
++    }
++
++    public boolean isAttack() {
++        return attack;
++    }
++
++    public EquipmentSlot getHand() {
++        return hand;
++    }
++
++    private static final HandlerList handlers = new HandlerList();
++    public static HandlerList getHandlerList() { return handlers; }
++    @Override public HandlerList getHandlers() { return handlers; }
++}
+-- 
+1.9.0
+

--- a/Bukkit/0074-Custom-attributes.patch
+++ b/Bukkit/0074-Custom-attributes.patch
@@ -1,0 +1,28 @@
+From d300f420a9c7939ce8e156f46925efc4aae267f0 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Sat, 2 Apr 2016 21:57:13 -0400
+Subject: [PATCH] Custom attributes
+
+
+diff --git a/src/main/java/org/bukkit/attribute/Attribute.java b/src/main/java/org/bukkit/attribute/Attribute.java
+index d9e83ad..183fcb4 100644
+--- a/src/main/java/org/bukkit/attribute/Attribute.java
++++ b/src/main/java/org/bukkit/attribute/Attribute.java
+@@ -47,7 +47,13 @@ public enum Attribute {
+     /**
+      * Chance of a zombie to spawn reinforcements.
+      */
+-    ZOMBIE_SPAWN_REINFORCEMENTS("zombie.spawnReinforcements");
++    ZOMBIE_SPAWN_REINFORCEMENTS("zombie.spawnReinforcements"),
++
++    ARROW_ACCURACY("sportbukkit.arrowAccuracy"),
++
++    ARROW_VELOCITY_TRANSFER("sportbukkit.arrowVelocityTransfer"),
++
++    SHIELD_STRENGTH("sportbukkit.shieldStrength");
+ 
+     private final String name;
+ 
+-- 
+1.9.0
+

--- a/Bukkit/0075-Add-Player.willBeOnline-method.patch
+++ b/Bukkit/0075-Add-Player.willBeOnline-method.patch
@@ -1,0 +1,37 @@
+From b445a3731aa82caa5a852a7b9fdb1f969635b29f Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Mon, 25 Apr 2016 20:47:00 -0400
+Subject: [PATCH] Add Player.willBeOnline method
+
+
+diff --git a/src/main/java/org/bukkit/OfflinePlayer.java b/src/main/java/org/bukkit/OfflinePlayer.java
+index e98706a..98494cb 100644
+--- a/src/main/java/org/bukkit/OfflinePlayer.java
++++ b/src/main/java/org/bukkit/OfflinePlayer.java
+@@ -6,6 +6,8 @@ import java.util.UUID;
+ import org.bukkit.configuration.serialization.ConfigurationSerializable;
+ import org.bukkit.entity.AnimalTamer;
+ import org.bukkit.entity.Player;
++import org.bukkit.event.player.PlayerLoginEvent;
++import org.bukkit.event.player.PlayerQuitEvent;
+ import org.bukkit.permissions.ServerOperator;
+ 
+ public interface OfflinePlayer extends ServerOperator, AnimalTamer, ConfigurationSerializable {
+@@ -18,6 +20,14 @@ public interface OfflinePlayer extends ServerOperator, AnimalTamer, Configuratio
+     public boolean isOnline();
+ 
+     /**
++     * Will this player be online after the current event is finished?
++     *
++     * Unlike {@link #isOnline()}, this returns true from within {@link PlayerLoginEvent},
++     * and false from within a {@link PlayerQuitEvent}.
++     */
++    boolean willBeOnline();
++
++    /**
+      * Returns the name of this player
+      * <p>
+      * Names are no longer unique past a single game session. For persistent storage
+-- 
+1.9.0
+

--- a/Bukkit/0076-Component-support-for-signs.patch
+++ b/Bukkit/0076-Component-support-for-signs.patch
@@ -1,0 +1,159 @@
+From d130ff22b8ba390f3b0df0bc0c1e01997c1c1295 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Fri, 3 Jun 2016 02:02:23 -0400
+Subject: [PATCH] Component support for signs
+
+
+diff --git a/src/main/java/org/bukkit/block/Sign.java b/src/main/java/org/bukkit/block/Sign.java
+index 5d7a633..7ded5ab 100644
+--- a/src/main/java/org/bukkit/block/Sign.java
++++ b/src/main/java/org/bukkit/block/Sign.java
+@@ -1,5 +1,7 @@
+ package org.bukkit.block;
+ 
++import net.md_5.bungee.api.chat.BaseComponent;
++
+ /**
+  * Represents either a SignPost or a WallSign
+  */
+@@ -8,8 +10,11 @@ public interface Sign extends BlockState {
+     /**
+      * Gets all the lines of text currently on this sign.
+      *
+-     * @return Array of Strings containing each line of text
++     * @return Array of BaseComponents containing each line of text
+      */
++    BaseComponent[] lines();
++
++    @Deprecated
+     public String[] getLines();
+ 
+     /**
+@@ -21,6 +26,9 @@ public interface Sign extends BlockState {
+      * @throws IndexOutOfBoundsException Thrown when the line does not exist
+      * @return Text on the given line
+      */
++    BaseComponent line(int index);
++
++    @Deprecated
+     public String getLine(int index) throws IndexOutOfBoundsException;
+ 
+     /**
+@@ -33,5 +41,8 @@ public interface Sign extends BlockState {
+      * @param line New text to set at the specified index
+      * @throws IndexOutOfBoundsException If the index is out of the range 0..3
+      */
++    void setLine(int index, BaseComponent line);
++
++    @Deprecated
+     public void setLine(int index, String line) throws IndexOutOfBoundsException;
+ }
+diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
+index b13c16a..0ab4a72 100644
+--- a/src/main/java/org/bukkit/entity/Player.java
++++ b/src/main/java/org/bukkit/entity/Player.java
+@@ -1,8 +1,10 @@
+ package org.bukkit.entity;
+ 
+ import java.net.InetSocketAddress;
++import java.util.List;
+ import java.util.Set;
+ 
++import net.md_5.bungee.api.chat.BaseComponent;
+ import org.bukkit.Achievement;
+ import org.bukkit.ChatColor;
+ import org.bukkit.Effect;
+@@ -509,6 +511,9 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
+      * @throws IllegalArgumentException if location is null
+      * @throws IllegalArgumentException if lines is non-null and has a length less than 4
+      */
++    void sendSignChange(Location loc, BaseComponent[] lines);
++
++    @Deprecated
+     public void sendSignChange(Location loc, String[] lines) throws IllegalArgumentException;
+ 
+     /**
+diff --git a/src/main/java/org/bukkit/event/block/SignChangeEvent.java b/src/main/java/org/bukkit/event/block/SignChangeEvent.java
+index 702eca0..14a3808 100644
+--- a/src/main/java/org/bukkit/event/block/SignChangeEvent.java
++++ b/src/main/java/org/bukkit/event/block/SignChangeEvent.java
+@@ -1,5 +1,7 @@
+ package org.bukkit.event.block;
+ 
++import net.md_5.bungee.api.chat.BaseComponent;
++import net.md_5.bungee.api.chat.TextComponent;
+ import org.bukkit.block.Block;
+ import org.bukkit.entity.Player;
+ import org.bukkit.event.Cancellable;
+@@ -15,9 +17,9 @@ public class SignChangeEvent extends BlockEvent implements Cancellable, PlayerAc
+     private static final HandlerList handlers = new HandlerList();
+     private boolean cancel = false;
+     private final Player player;
+-    private final String[] lines;
++    private final BaseComponent[] lines;
+ 
+-    public SignChangeEvent(final Block theBlock, final Player thePlayer, final String[] theLines) {
++    public SignChangeEvent(final Block theBlock, final Player thePlayer, final BaseComponent[] theLines) {
+         super(theBlock);
+         this.player = thePlayer;
+         this.lines = theLines;
+@@ -40,25 +42,35 @@ public class SignChangeEvent extends BlockEvent implements Cancellable, PlayerAc
+     /**
+      * Gets all of the lines of text from the sign involved in this event.
+      *
+-     * @return the String array for the sign's lines new text
++     * @return the BaseComponent array for the sign's lines new text
+      */
+-    public String[] getLines() {
++    public BaseComponent[] lines() {
+         return lines;
+     }
+ 
++    @Deprecated
++    public String[] getLines() {
++        return BaseComponent.toLegacyArray(lines);
++    }
++
+     /**
+      * Gets a single line of text from the sign involved in this event.
+      *
+      * @param index index of the line to get
+-     * @return the String containing the line of text associated with the
++     * @return the BaseComponent containing the line of text associated with the
+      *     provided index
+      * @throws IndexOutOfBoundsException thrown when the provided index is {@literal > 3
+      *     or < 0}
+      */
+-    public String getLine(int index) throws IndexOutOfBoundsException {
++    public BaseComponent line(int index) {
+         return lines[index];
+     }
+ 
++    @Deprecated
++    public String getLine(int index) throws IndexOutOfBoundsException {
++        return lines[index].toLegacyText();
++    }
++
+     /**
+      * Sets a single line for the sign involved in this event
+      *
+@@ -67,10 +79,15 @@ public class SignChangeEvent extends BlockEvent implements Cancellable, PlayerAc
+      * @throws IndexOutOfBoundsException thrown when the provided index is {@literal > 3
+      *     or < 0}
+      */
+-    public void setLine(int index, String line) throws IndexOutOfBoundsException {
++    public void setLine(int index, BaseComponent line) {
+         lines[index] = line;
+     }
+ 
++    @Deprecated
++    public void setLine(int index, String line) throws IndexOutOfBoundsException {
++        lines[index] = TextComponent.fromLegacyToComponent(line, false);
++    }
++
+     public boolean isCancelled() {
+         return cancel;
+     }
+-- 
+1.9.0
+

--- a/Bukkit/0077-Block-physics-API.patch
+++ b/Bukkit/0077-Block-physics-API.patch
@@ -1,0 +1,48 @@
+From 793c60808611cdcce0a0b5f9fefc443736058f10 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Sat, 18 Jun 2016 08:17:57 -0400
+Subject: [PATCH] Block physics API
+
+
+diff --git a/src/main/java/org/bukkit/block/Block.java b/src/main/java/org/bukkit/block/Block.java
+index 158bd8f..ddd6c65 100644
+--- a/src/main/java/org/bukkit/block/Block.java
++++ b/src/main/java/org/bukkit/block/Block.java
+@@ -8,6 +8,7 @@ import org.bukkit.World;
+ import org.bukkit.Location;
+ import org.bukkit.Physical;
+ import org.bukkit.inventory.ItemStack;
++import org.bukkit.material.MaterialData;
+ import org.bukkit.metadata.Metadatable;
+ import org.bukkit.util.RayBlockIntersection;
+ import org.bukkit.util.Vector;
+@@ -408,4 +409,26 @@ public interface Block extends Metadatable, Physical {
+      * @return A data structure describing the intersection, or null if there was no intersection
+      */
+     RayBlockIntersection rayTrace(Location start, double distance);
++
++    /**
++     * Simulate the effects on this block of an adjacent block changing state.
++     *
++     * An appropriate {@link org.bukkit.event.block.BlockPhysicsEvent} is fired,
++     * and can be cancelled.
++     *
++     * @param before            Neighbor material before the change
++     * @param after             Neighbor material after the change
++     */
++    void simulateNeighborChange(BlockFace neighbor, MaterialData before, MaterialData after);
++
++    /**
++     * Simulate the effects of this block changing state on all adjacent blocks
++     *
++     * Appropriate {@link org.bukkit.event.block.BlockPhysicsEvent}s are fired
++     * for each affected block, and they can be cancelled.
++     *
++     * @param before            Material before change
++     * @param after             Material after change
++     */
++    void simulateChangeForNeighbors(MaterialData before, MaterialData after);
+ }
+-- 
+1.9.0
+

--- a/Bukkit/0078-Item-cooldown-API.patch
+++ b/Bukkit/0078-Item-cooldown-API.patch
@@ -1,0 +1,43 @@
+From e1ef385bc62a2a2cc58537c83a4919ee6c09140e Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Sun, 26 Jun 2016 01:57:07 -0400
+Subject: [PATCH] Item cooldown API
+
+
+diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
+index 0ab4a72..f57d4b1 100644
+--- a/src/main/java/org/bukkit/entity/Player.java
++++ b/src/main/java/org/bukkit/entity/Player.java
+@@ -1663,5 +1663,29 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
+ 
+     boolean hasUnackedVelocity();
+ 
++    /**
++     * Start a timed cooldown of the given item type for this player.
++     *
++     * Items of the given type will be unusable by this player for the
++     * duration of the cooldown, and any stacks of the item viewed by
++     * the player will show a progress indicator.
++     *
++     * Starting a cooldown for an item that is already cooling down will
++     * replace the existing cooldown.
++     *
++     * @param item     Item type to cooldown
++     * @param ticks    Ticks to cooldown for
++     */
++    void startItemCooldown(Material item, int ticks);
+ 
++    /**
++     * Return the fraction of time remaining on any current cooldown of
++     * the given item type for this player, relative to the initial
++     * duration of the cooldown.
++     *
++     * The returned value is always between 0 and 1 inclusive.
++     *
++     * If the given item type is not cooling down, 0 is returned.
++     */
++    float getRemainingItemCooldown(Material item);
+ }
+-- 
+1.9.0
+

--- a/Bukkit/0079-Add-armorToughness-attribute.patch
+++ b/Bukkit/0079-Add-armorToughness-attribute.patch
@@ -1,0 +1,24 @@
+From 2b2803d86abc90e7c9150634e2bca1c3ced19f2f Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Sun, 26 Jun 2016 19:18:01 -0400
+Subject: [PATCH] Add armorToughness attribute
+
+
+diff --git a/src/main/java/org/bukkit/attribute/Attribute.java b/src/main/java/org/bukkit/attribute/Attribute.java
+index 183fcb4..26affb9 100644
+--- a/src/main/java/org/bukkit/attribute/Attribute.java
++++ b/src/main/java/org/bukkit/attribute/Attribute.java
+@@ -37,6 +37,10 @@ public enum Attribute {
+      */
+     GENERIC_ARMOR("generic.armor"),
+     /**
++     * Armor bonus of an Entity.
++     */
++    GENERIC_ARMOR_TOUGHNESS("generic.armorToughness"),
++    /**
+      * Luck bonus of an Entity.
+      */
+     GENERIC_LUCK("generic.luck"),
+-- 
+1.9.0
+

--- a/Bukkit/0080-Add-PoseFlag-and-EntityLocation.patch
+++ b/Bukkit/0080-Add-PoseFlag-and-EntityLocation.patch
@@ -1,0 +1,417 @@
+From 51d7d8910fbdc1b82da21e5e4a546cc779612056 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Fri, 1 Jul 2016 03:36:15 -0400
+Subject: [PATCH] Add PoseFlag and EntityLocation
+
+
+diff --git a/src/main/java/org/bukkit/EntityLocation.java b/src/main/java/org/bukkit/EntityLocation.java
+new file mode 100644
+index 0000000..41e6da8
+--- /dev/null
++++ b/src/main/java/org/bukkit/EntityLocation.java
+@@ -0,0 +1,120 @@
++package org.bukkit;
++
++import java.util.Arrays;
++import java.util.EnumSet;
++import java.util.Set;
++
++import org.bukkit.util.EnumUtils;
++import org.bukkit.util.Vector;
++
++public class EntityLocation extends Location {
++
++    private final Vector velocity;
++    private final Set<PoseFlag> poseFlags;
++
++    /**
++     * Create a new EntityLocation from the given values.
++     *
++     * Note that velocity and poseFlags are NOT copied.
++     */
++    public EntityLocation(World world, double x, double y, double z, float yaw, float pitch, Vector velocity, Set<PoseFlag> poseFlags) {
++        super(world, x, y, z, yaw, pitch);
++        this.velocity = velocity;
++        this.poseFlags = poseFlags;
++
++    }
++
++    public EntityLocation(World world, Vector position, float yaw, float pitch, Vector velocity, Set<PoseFlag> poseFlags) {
++        this(world, position.getX(), position.getY(), position.getZ(), yaw, pitch, velocity, poseFlags);
++    }
++
++    /**
++     * Create a new EntityLocation from the given values.
++     *
++     * Only the position and angles are copied from the location argument,
++     * even if it is another EntityLocation.
++     *
++     * Note that velocity and poseFlags are NOT copied.
++     */
++    public EntityLocation(Location location, Vector velocity, Set<PoseFlag> poseFlags) {
++        this(location.getWorld(), location.getX(), location.getY(), location.getZ(), location.getYaw(), location.getPitch(), velocity, poseFlags);
++    }
++
++    /**
++     * Create a new EntityLocation from the given values, with zero velocity and no {@link PoseFlag}s.
++     */
++    public EntityLocation(World world, double x, double y, double z, float yaw, float pitch) {
++        this(world, x, y, z, yaw, pitch, new Vector(), EnumSet.noneOf(PoseFlag.class));
++    }
++
++    public static EntityLocation coerce(Location value, EntityLocation defaults) {
++        if(value instanceof EntityLocation) {
++            return (EntityLocation) value;
++        } else {
++            return new EntityLocation(value, defaults.velocity(), defaults.poseFlags());
++        }
++    }
++
++    public static EntityLocation copyOf(Location location, Vector velocity, Set<PoseFlag> poseFlags) {
++        return new EntityLocation(location, new Vector(velocity), EnumUtils.copySet(PoseFlag.class, poseFlags));
++    }
++
++    public static EntityLocation copyOf(EntityLocation that) {
++        return copyOf(that, that.velocity(), that.poseFlags());
++    }
++
++    /**
++     * Mutable velocity vector.
++     *
++     * Changes to the returned object are reflected in this {@link EntityLocation},
++     * and vice-versa.
++     */
++    public Vector velocity() {
++        return velocity;
++    }
++
++    /**
++     * A mutable set of {@link PoseFlag}s.
++     *
++     * Changes to the returned object are reflected in this {@link EntityLocation},
++     * and vice-versa.
++     */
++    public Set<PoseFlag> poseFlags() {
++        return poseFlags;
++    }
++
++    @Override
++    public String toString() {
++        return getClass().getSimpleName() +
++               "{world=" + getWorld() +
++               " x=" + getX() +
++               " y=" + getY() +
++               " z=" + getZ() +
++               " pitch=" + getPitch() +
++               " yaw=" + getYaw() +
++               " velocity=" + velocity() +
++               " poseFlags=" + poseFlags() +
++               '}';
++    }
++
++    @Override
++    public boolean equals(Object that) {
++        return this == that || (
++            super.equals(that) &&
++            that instanceof EntityLocation &&
++            this.velocity.equals(((EntityLocation) that).velocity()) &&
++            this.poseFlags.equals(((EntityLocation) that).poseFlags())
++        );
++    }
++
++    @Override
++    public int hashCode() {
++        return Arrays.hashCode(new Object[] {super.hashCode(), velocity, poseFlags});
++    }
++
++    @Override
++    public EntityLocation clone() {
++        // Can't call super.clone(), because we have final fields
++        return copyOf(this);
++    }
++}
+diff --git a/src/main/java/org/bukkit/PoseFlag.java b/src/main/java/org/bukkit/PoseFlag.java
+new file mode 100644
+index 0000000..4d8fbee
+--- /dev/null
++++ b/src/main/java/org/bukkit/PoseFlag.java
+@@ -0,0 +1,41 @@
++package org.bukkit;
++
++import org.bukkit.entity.Entity;
++import org.bukkit.entity.HumanEntity;
++import org.bukkit.entity.LivingEntity;
++import org.bukkit.entity.Player;
++
++public enum PoseFlag {
++    /** @see Entity#isOnGround() */
++    GROUNDED,
++
++    /** @see Entity#isDead() */
++    DEAD,
++
++    /** @see HumanEntity#isSleeping() */
++    SLEEPING,
++
++    /** @see Player#isSneaking() */
++    SNEAKING,
++
++    /** @see Player#isSprinting() */
++    SPRINTING,
++
++    /** @see HumanEntity#isBlocking() */
++    BLOCKING,
++
++    /** @see Player#isDigging() */
++    DIGGING,
++
++    /** @see LivingEntity#isGliding() */
++    GLIDING,
++
++    /** @see Player#isFlying() */
++    FLYING,
++
++    /** @see LivingEntity#isLeashed() */
++    LEASHED,
++
++    /** @see Entity#isInsideVehicle() */
++    RIDING;
++}
+diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
+index dfb542b..35e3af9 100644
+--- a/src/main/java/org/bukkit/entity/Entity.java
++++ b/src/main/java/org/bukkit/entity/Entity.java
+@@ -1,8 +1,10 @@
+ package org.bukkit.entity;
+ 
++import org.bukkit.EntityLocation;
+ import org.bukkit.Location;
+ import org.bukkit.EntityEffect;
+ import org.bukkit.Nameable;
++import org.bukkit.PoseFlag;
+ import org.bukkit.Server;
+ import org.bukkit.World;
+ import org.bukkit.Physical;
+@@ -29,6 +31,8 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Physical {
+      */
+     public Location getLocation();
+ 
++    EntityLocation getEntityLocation();
++
+     /**
+      * Stores the entity's current position in the provided Location object.
+      * <p>
+@@ -41,6 +45,11 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Physical {
+     public Location getLocation(Location loc);
+ 
+     /**
++     * The set of {@link PoseFlag}s describing this entity's current state
++     */
++    Set<PoseFlag> getPoseFlags();
++
++    /**
+      * Sets this entity's velocity
+      *
+      * @param velocity New velocity to travel with
+diff --git a/src/main/java/org/bukkit/event/player/PlayerMoveEvent.java b/src/main/java/org/bukkit/event/player/PlayerMoveEvent.java
+index 7687667..b587a5a 100644
+--- a/src/main/java/org/bukkit/event/player/PlayerMoveEvent.java
++++ b/src/main/java/org/bukkit/event/player/PlayerMoveEvent.java
+@@ -1,24 +1,35 @@
+ package org.bukkit.event.player;
+ 
+ import com.google.common.base.Preconditions;
++import org.bukkit.EntityLocation;
+ import org.bukkit.Location;
+ import org.bukkit.entity.Player;
+ import org.bukkit.event.Cancellable;
+ import org.bukkit.event.HandlerList;
+ 
++import static com.google.common.base.Preconditions.checkNotNull;
++
+ /**
+  * Holds information for player movement events
+  */
+ public class PlayerMoveEvent extends PlayerActionBase implements Cancellable {
+     private static final HandlerList handlers = new HandlerList();
+     private boolean cancel = false;
+-    private Location from;
+-    private Location to;
++    private EntityLocation from;
++    private EntityLocation to;
+ 
+-    public PlayerMoveEvent(final Player player, final Location from, final Location to) {
++    public PlayerMoveEvent(final Player player, final EntityLocation from, final EntityLocation to) {
+         super(player);
+-        this.from = from;
+-        this.to = to;
++        this.from = checkNotNull(from);
++        this.to = checkNotNull(to);
++    }
++
++    public PlayerMoveEvent(final Player player, final Location from, final Location to) {
++        this(
++            player,
++            EntityLocation.coerce(from, player.getEntityLocation()),
++            EntityLocation.coerce(to, player.getEntityLocation())
++        );
+     }
+ 
+     /**
+@@ -58,6 +69,10 @@ public class PlayerMoveEvent extends PlayerActionBase implements Cancellable {
+         return from;
+     }
+ 
++    public EntityLocation getEntityFrom() {
++        return from;
++    }
++
+     /**
+      * Sets the location to mark as where the player moved from
+      *
+@@ -65,7 +80,7 @@ public class PlayerMoveEvent extends PlayerActionBase implements Cancellable {
+      */
+     public void setFrom(Location from) {
+         validateLocation(from);
+-        this.from = from;
++        this.from = EntityLocation.coerce(from, this.from);
+     }
+ 
+     /**
+@@ -77,6 +92,10 @@ public class PlayerMoveEvent extends PlayerActionBase implements Cancellable {
+         return to;
+     }
+ 
++    public EntityLocation getEntityTo() {
++        return to;
++    }
++
+     /**
+      * Sets the location that this player will move to
+      *
+@@ -84,7 +103,7 @@ public class PlayerMoveEvent extends PlayerActionBase implements Cancellable {
+      */
+     public void setTo(Location to) {
+         validateLocation(to);
+-        this.to = to;
++        this.to = EntityLocation.coerce(to, this.to);
+     }
+ 
+     private void validateLocation(Location loc) {
+diff --git a/src/main/java/org/bukkit/event/player/PlayerPortalEvent.java b/src/main/java/org/bukkit/event/player/PlayerPortalEvent.java
+index 93752f7..e2b31d7 100644
+--- a/src/main/java/org/bukkit/event/player/PlayerPortalEvent.java
++++ b/src/main/java/org/bukkit/event/player/PlayerPortalEvent.java
+@@ -1,5 +1,7 @@
+ package org.bukkit.event.player;
+ 
++import javax.annotation.Nullable;
++
+ import org.bukkit.Location;
+ import org.bukkit.TravelAgent;
+ import org.bukkit.entity.Player;
+@@ -9,6 +11,11 @@ import org.bukkit.event.HandlerList;
+  * Called when a player is about to teleport because it is in contact with a
+  * portal.
+  * <p>
++ * The player will exit the portal at the {@link #getTo()} location, which can
++ * be altered by event handlers through {@link #setTo(Location)}. If the portal
++ * is not going to teleport the player, then {@link #getTo()} will be the same
++ * as {@link #getFrom()}, and the event will be initially set to cancelled.
++ * <p>
+  * For other entities see {@link org.bukkit.event.entity.EntityPortalEvent}
+  */
+ public class PlayerPortalEvent extends PlayerTeleportEvent {
+@@ -16,14 +23,14 @@ public class PlayerPortalEvent extends PlayerTeleportEvent {
+     protected boolean useTravelAgent = true;
+     protected TravelAgent travelAgent;
+ 
+-    public PlayerPortalEvent(final Player player, final Location from, final Location to, final TravelAgent pta) {
+-        super(player, from, to);
+-        this.travelAgent = pta;
++    public PlayerPortalEvent(final Player player, final Location from, final @Nullable Location to, final TravelAgent pta) {
++        this(player, from, to, pta, TeleportCause.UNKNOWN);
+     }
+ 
+-    public PlayerPortalEvent(Player player, Location from, Location to, TravelAgent pta, TeleportCause cause) {
+-        super(player, from, to, cause);
++    public PlayerPortalEvent(Player player, Location from, @Nullable Location to, TravelAgent pta, TeleportCause cause) {
++        super(player, from, to != null ? to : from, cause);
+         this.travelAgent = pta;
++        setCancelled(to == null);
+     }
+ 
+     /**
+diff --git a/src/main/java/org/bukkit/util/EnumUtils.java b/src/main/java/org/bukkit/util/EnumUtils.java
+new file mode 100644
+index 0000000..d064568
+--- /dev/null
++++ b/src/main/java/org/bukkit/util/EnumUtils.java
+@@ -0,0 +1,22 @@
++package org.bukkit.util;
++
++import java.util.Collection;
++import java.util.EnumSet;
++import java.util.Set;
++
++public final class EnumUtils {
++    private EnumUtils() {}
++
++    /**
++     * Create a new {@link EnumSet} of the given type, copying the initial
++     * contents from the given set.
++     *
++     * Unlike {@link EnumSet#copyOf(Collection)}, this method always works,
++     * even if the given set is empty, and is not another {@link EnumSet}.
++     */
++    public static <E extends Enum<E>> EnumSet<E> copySet(Class<E> type, Set<E> set) {
++        final EnumSet<E> copy = EnumSet.noneOf(type);
++        copy.addAll(set);
++        return copy;
++    }
++}
+diff --git a/src/test/java/org/bukkit/plugin/TimedRegisteredListenerTest.java b/src/test/java/org/bukkit/plugin/TimedRegisteredListenerTest.java
+index ef75e5a..1d88ffb 100644
+--- a/src/test/java/org/bukkit/plugin/TimedRegisteredListenerTest.java
++++ b/src/test/java/org/bukkit/plugin/TimedRegisteredListenerTest.java
+@@ -9,9 +9,8 @@ import org.bukkit.event.EventPriority;
+ import org.bukkit.event.Listener;
+ import org.bukkit.event.block.BlockBreakEvent;
+ import org.bukkit.event.player.PlayerActionBase;
+-import org.bukkit.event.player.PlayerEvent;
++import org.bukkit.event.player.PlayerAnimationEvent;
+ import org.bukkit.event.player.PlayerInteractEvent;
+-import org.bukkit.event.player.PlayerMoveEvent;
+ import org.junit.Test;
+ 
+ public class TimedRegisteredListenerTest {
+@@ -25,7 +24,7 @@ public class TimedRegisteredListenerTest {
+         TestPlugin plugin = new TestPlugin("Test");
+ 
+         PlayerInteractEvent interactEvent = new PlayerInteractEvent(null, null, null, null, null);
+-        PlayerMoveEvent moveEvent = new PlayerMoveEvent(null, null, null);
++        PlayerAnimationEvent animationEvent = new PlayerAnimationEvent(null);
+         BlockBreakEvent breakEvent = new BlockBreakEvent(null, null);
+ 
+         TimedRegisteredListener trl = new TimedRegisteredListener(listener, executor, EventPriority.NORMAL, plugin, false);
+@@ -37,7 +36,7 @@ public class TimedRegisteredListenerTest {
+         trl.callEvent(interactEvent);
+         assertThat(trl.getEventClass(), is((Object) PlayerInteractEvent.class));
+         // Ensure that the closest superclass of the two events is chosen
+-        trl.callEvent(moveEvent);
++        trl.callEvent(animationEvent);
+         assertThat(trl.getEventClass(), is((Object) PlayerActionBase.class));
+         // As above, so below
+         trl.callEvent(breakEvent);
+@@ -51,7 +50,7 @@ public class TimedRegisteredListenerTest {
+         trl.callEvent(breakEvent);
+         assertThat(trl.getEventClass(), is((Object) BlockBreakEvent.class));
+         // Test moving up the class hierarchy by more than one class at a time
+-        trl.callEvent(moveEvent);
++        trl.callEvent(animationEvent);
+         assertThat(trl.getEventClass(), is((Object) Event.class));
+     }
+ }
+-- 
+1.9.0
+

--- a/Bukkit/0081-Mojang-task-queue-access.patch
+++ b/Bukkit/0081-Mojang-task-queue-access.patch
@@ -1,0 +1,73 @@
+From 869f756be52f6d4d9783964f206eb1de1da6525f Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Fri, 5 Aug 2016 09:52:58 -0400
+Subject: [PATCH] Mojang task queue access
+
+
+diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
+index 05193b0..2c1fb24 100644
+--- a/src/main/java/org/bukkit/Bukkit.java
++++ b/src/main/java/org/bukkit/Bukkit.java
+@@ -34,6 +34,7 @@ import org.bukkit.inventory.Merchant;
+ import org.bukkit.inventory.Recipe;
+ import org.bukkit.map.MapView;
+ import org.bukkit.permissions.Permissible;
++import org.bukkit.plugin.Plugin;
+ import org.bukkit.plugin.PluginManager;
+ import org.bukkit.plugin.ServicesManager;
+ import org.bukkit.plugin.messaging.Messenger;
+@@ -1306,4 +1307,12 @@ public final class Bukkit {
+     public static PotionEffectRegistry potionEffectRegistry() {
+         return runtime().potionEffectRegistry();
+     }
++
++    public static void postToMainThread(Plugin plugin, boolean priority, Runnable task) {
++        server.postToMainThread(plugin, priority, task);
++    }
++
++    public static boolean runOnMainThread(Plugin plugin, boolean priority, Runnable task) {
++        return server.runOnMainThread(plugin, priority, task);
++    }
+ }
+diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
+index b7b2690..6d47a61 100644
+--- a/src/main/java/org/bukkit/Server.java
++++ b/src/main/java/org/bukkit/Server.java
+@@ -34,6 +34,7 @@ import org.bukkit.inventory.Merchant;
+ import org.bukkit.inventory.Recipe;
+ import org.bukkit.map.MapView;
+ import org.bukkit.permissions.Permissible;
++import org.bukkit.plugin.Plugin;
+ import org.bukkit.plugin.PluginManager;
+ import org.bukkit.plugin.ServicesManager;
+ import org.bukkit.plugin.messaging.Messenger;
+@@ -1051,4 +1052,26 @@ public interface Server extends PluginMessageRecipient, BukkitRuntime, tc.oc.min
+      * @param components the components to send
+      */
+     public void broadcast(net.md_5.bungee.api.chat.BaseComponent... components);
++
++    /**
++     * Post the given task to the main thread queue. This is the queue used to handle
++     * incoming packets (NOT the {@link BukkitScheduler} queue).
++     *
++     * The priority flag determines which end of the queue the task is posted to, and
++     * therefor whether it will run before (true) or after (false) any other tasks
++     * that are currently queued.
++     *
++     * Since incoming packets are also handled through this queue,
++     */
++    void postToMainThread(Plugin plugin, boolean priority, Runnable task);
++
++    /**
++     * If called on the main thread, run the given task immediately and return when
++     * the task completes. If run from any other thread, this is the same as calling
++     * {@link #postToMainThread(Plugin, boolean, Runnable)}.
++     *
++     * @return true if the task ran synchronously,
++     *         false if it was added to the main thread queue
++     */
++    boolean runOnMainThread(Plugin plugin, boolean priority, Runnable task);
+ }
+-- 
+1.9.0
+

--- a/Bukkit/0082-Fix-several-block-rotation-data-values.patch
+++ b/Bukkit/0082-Fix-several-block-rotation-data-values.patch
@@ -1,0 +1,349 @@
+From 59e4befe58da4a3649ff7970a9bf80232b5f66ae Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Sun, 9 Oct 2016 08:04:12 -0400
+Subject: [PATCH] Fix several block rotation data values
+
+
+diff --git a/src/main/java/org/bukkit/material/Alignable.java b/src/main/java/org/bukkit/material/Alignable.java
+new file mode 100644
+index 0000000..c9ad81e
+--- /dev/null
++++ b/src/main/java/org/bukkit/material/Alignable.java
+@@ -0,0 +1,8 @@
++package org.bukkit.material;
++
++import org.bukkit.util.Axis;
++
++public interface Alignable {
++
++    Axis getAxis();
++}
+diff --git a/src/main/java/org/bukkit/material/Banner.java b/src/main/java/org/bukkit/material/Banner.java
+index 80a7616..1900953 100644
+--- a/src/main/java/org/bukkit/material/Banner.java
++++ b/src/main/java/org/bukkit/material/Banner.java
+@@ -56,6 +56,7 @@ public class Banner extends MaterialData implements Attachable {
+                     return BlockFace.SOUTH;
+ 
+                 case 0x3:
++                default:
+                     return BlockFace.NORTH;
+ 
+                 case 0x4:
+@@ -64,8 +65,6 @@ public class Banner extends MaterialData implements Attachable {
+                 case 0x5:
+                     return BlockFace.WEST;
+             }
+-
+-            return null;
+         } else {
+             return BlockFace.DOWN;
+         }
+diff --git a/src/main/java/org/bukkit/material/Button.java b/src/main/java/org/bukkit/material/Button.java
+index fd6a7db..a81dc4f 100644
+--- a/src/main/java/org/bukkit/material/Button.java
++++ b/src/main/java/org/bukkit/material/Button.java
+@@ -83,6 +83,7 @@ public class Button extends SimpleAttachableMaterialData implements Redstone {
+             return BlockFace.EAST;
+ 
+         case 0x3:
++        default:
+             return BlockFace.NORTH;
+ 
+         case 0x4:
+@@ -91,8 +92,6 @@ public class Button extends SimpleAttachableMaterialData implements Redstone {
+         case 0x5:
+             return BlockFace.DOWN;
+         }
+-
+-        return null;
+     }
+ 
+     /**
+diff --git a/src/main/java/org/bukkit/material/CocoaPlant.java b/src/main/java/org/bukkit/material/CocoaPlant.java
+index 6dede93..0f7667a 100644
+--- a/src/main/java/org/bukkit/material/CocoaPlant.java
++++ b/src/main/java/org/bukkit/material/CocoaPlant.java
+@@ -114,11 +114,11 @@ public class CocoaPlant extends MaterialData implements Directional, Attachable
+             case 1:
+                 return BlockFace.WEST;
+             case 2:
++            default:
+                 return BlockFace.NORTH;
+             case 3:
+                 return BlockFace.EAST;
+         }
+-        return null;
+     }
+ 
+     @Override
+diff --git a/src/main/java/org/bukkit/material/DirectionalContainer.java b/src/main/java/org/bukkit/material/DirectionalContainer.java
+index b56f098..5fda3dd 100644
+--- a/src/main/java/org/bukkit/material/DirectionalContainer.java
++++ b/src/main/java/org/bukkit/material/DirectionalContainer.java
+@@ -68,6 +68,7 @@ public class DirectionalContainer extends MaterialData implements Directional {
+         byte data = getData();
+ 
+         switch (data) {
++        default:
+         case 0x2:
+             return BlockFace.NORTH;
+ 
+@@ -78,7 +79,6 @@ public class DirectionalContainer extends MaterialData implements Directional {
+             return BlockFace.WEST;
+ 
+         case 0x5:
+-        default:
+             return BlockFace.EAST;
+         }
+     }
+diff --git a/src/main/java/org/bukkit/material/Gate.java b/src/main/java/org/bukkit/material/Gate.java
+index 8adc1cf..363f3f4 100644
+--- a/src/main/java/org/bukkit/material/Gate.java
++++ b/src/main/java/org/bukkit/material/Gate.java
+@@ -31,16 +31,16 @@ public class Gate extends MaterialData implements Directional, Openable {
+ 
+         switch (face) {
+             default:
+-            case EAST:
++            case SOUTH:
+                 data |= GATE_SOUTH;
+                 break;
+-            case SOUTH:
++            case WEST:
+                 data |= GATE_WEST;
+                 break;
+-            case WEST:
++            case NORTH:
+                 data |= GATE_NORTH;
+                 break;
+-            case NORTH:
++            case EAST:
+                 data |= GATE_EAST;
+                 break;
+         }
+@@ -51,13 +51,13 @@ public class Gate extends MaterialData implements Directional, Openable {
+     public BlockFace getFacing() {
+         switch (getData() & DIR_BIT) {
+             case GATE_SOUTH:
+-                return BlockFace.EAST;
+-            case GATE_WEST:
+                 return BlockFace.SOUTH;
+-            case GATE_NORTH:
++            case GATE_WEST:
+                 return BlockFace.WEST;
+-            case GATE_EAST:
++            case GATE_NORTH:
+                 return BlockFace.NORTH;
++            case GATE_EAST:
++                return BlockFace.EAST;
+         }
+ 
+         return BlockFace.EAST;
+diff --git a/src/main/java/org/bukkit/material/Ladder.java b/src/main/java/org/bukkit/material/Ladder.java
+index cd4d691..4c510d6 100644
+--- a/src/main/java/org/bukkit/material/Ladder.java
++++ b/src/main/java/org/bukkit/material/Ladder.java
+@@ -54,6 +54,7 @@ public class Ladder extends SimpleAttachableMaterialData {
+ 
+         switch (data) {
+         case 0x2:
++            default:
+             return BlockFace.SOUTH;
+ 
+         case 0x3:
+@@ -65,8 +66,6 @@ public class Ladder extends SimpleAttachableMaterialData {
+         case 0x5:
+             return BlockFace.WEST;
+         }
+-
+-        return null;
+     }
+ 
+     /**
+@@ -76,19 +75,19 @@ public class Ladder extends SimpleAttachableMaterialData {
+         byte data = (byte) 0x0;
+ 
+         switch (face) {
+-        case SOUTH:
++        case NORTH:
+             data = 0x2;
+             break;
+ 
+-        case NORTH:
++        case SOUTH:
+             data = 0x3;
+             break;
+ 
+-        case EAST:
++        case WEST:
+             data = 0x4;
+             break;
+ 
+-        case WEST:
++        case EAST:
+             data = 0x5;
+             break;
+         }
+diff --git a/src/main/java/org/bukkit/material/Lever.java b/src/main/java/org/bukkit/material/Lever.java
+index c6d3882..3b76ed0 100644
+--- a/src/main/java/org/bukkit/material/Lever.java
++++ b/src/main/java/org/bukkit/material/Lever.java
+@@ -2,11 +2,12 @@ package org.bukkit.material;
+ 
+ import org.bukkit.block.BlockFace;
+ import org.bukkit.Material;
++import org.bukkit.util.Axis;
+ 
+ /**
+  * Represents a lever
+  */
+-public class Lever extends SimpleAttachableMaterialData implements Redstone {
++public class Lever extends SimpleAttachableMaterialData implements Redstone, Alignable {
+     public Lever() {
+         super(Material.LEVER);
+     }
+@@ -101,56 +102,62 @@ public class Lever extends SimpleAttachableMaterialData implements Redstone {
+      * Sets the direction this lever is pointing in
+      */
+     public void setFacingDirection(BlockFace face) {
++        setFacingDirection(face, Axis.Z);
++    }
++
++    /**
++     * Set the direction this lever is facing, and the axis that it moves along, if it is facing vertically.
++     */
++    public void setFacingDirection(BlockFace facing, Axis axis) {
+         byte data = (byte) (getData() & 0x8);
+-        BlockFace attach = getAttachedFace();
+-
+-        if (attach == BlockFace.DOWN) {
+-            switch (face) {
+-            case SOUTH:
+-            case NORTH:
+-                data |= 0x5;
+-                break;
+-
+-            case EAST:
+-            case WEST:
+-                data |= 0x6;
+-                break;
+-            }
+-        } else if (attach == BlockFace.UP) {
+-            switch (face) {
+-            case SOUTH:
+-            case NORTH:
+-                data |= 0x7;
+-                break;
+-
+-            case EAST:
+-            case WEST:
+-                data |= 0x0;
+-                break;
+-            }
+-        } else {
+-            switch (face) {
+-            case EAST:
+-                data |= 0x1;
+-                break;
+-
+-            case WEST:
+-                data |= 0x2;
+-                break;
+-
+-            case SOUTH:
+-                data |= 0x3;
+-                break;
+-
+-            case NORTH:
+-                data |= 0x4;
+-                break;
+-            }
++
++        switch (facing) {
++        case EAST:
++            data |= 0x1;
++            break;
++
++        case WEST:
++            data |= 0x2;
++            break;
++
++        case SOUTH:
++            data |= 0x3;
++            break;
++
++        case NORTH:
++            data |= 0x4;
++            break;
++
++        case UP:
++            data |= axis == Axis.Z ? 0x5 : 0x6;
++            break;
++
++        case DOWN:
++            data |= axis == Axis.Z ? 0x7 : 0x0;
++            break;
+         }
++
+         setData(data);
+     }
+ 
+     @Override
++    public Axis getAxis() {
++        final byte data = (byte) (getData() & 0x7);
++        switch(data) {
++            case 5:
++            case 7:
++                return Axis.Z;
++
++            case 0:
++            case 6:
++                return Axis.X;
++
++            default:
++                return Axis.Y;
++        }
++    }
++
++    @Override
+     public String toString() {
+         return super.toString() + " facing " + getFacing() + " " + (isPowered() ? "" : "NOT ") + "POWERED";
+     }
+diff --git a/src/main/java/org/bukkit/material/Sign.java b/src/main/java/org/bukkit/material/Sign.java
+index 0accdbc..5781240 100644
+--- a/src/main/java/org/bukkit/material/Sign.java
++++ b/src/main/java/org/bukkit/material/Sign.java
+@@ -65,6 +65,7 @@ public class Sign extends MaterialData implements Attachable {
+ 
+             switch (data) {
+             case 0x2:
++                default:
+                 return BlockFace.SOUTH;
+ 
+             case 0x3:
+@@ -76,8 +77,6 @@ public class Sign extends MaterialData implements Attachable {
+             case 0x5:
+                 return BlockFace.WEST;
+             }
+-
+-            return null;
+         } else {
+             return BlockFace.DOWN;
+         }
+diff --git a/src/main/java/org/bukkit/material/Stairs.java b/src/main/java/org/bukkit/material/Stairs.java
+index 7dde021..48de7f6 100644
+--- a/src/main/java/org/bukkit/material/Stairs.java
++++ b/src/main/java/org/bukkit/material/Stairs.java
+@@ -76,7 +76,7 @@ public class Stairs extends MaterialData implements Directional {
+     public void setFacingDirection(BlockFace face) {
+         byte data;
+ 
+-        switch (face) {
++        switch (face.getOppositeFace()) {
+         case NORTH:
+             data = 0x3;
+             break;
+-- 
+1.9.0
+

--- a/Bukkit/0083-Block-images.patch
+++ b/Bukkit/0083-Block-images.patch
@@ -1,0 +1,542 @@
+From 5d6f189de965137d924050d3ab5061d43b1c2d5e Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Wed, 16 Mar 2016 21:20:38 -0400
+Subject: [PATCH] Block images
+
+
+diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
+index 2c1fb24..b3837d9 100644
+--- a/src/main/java/org/bukkit/Bukkit.java
++++ b/src/main/java/org/bukkit/Bukkit.java
+@@ -33,6 +33,7 @@ import org.bukkit.inventory.ItemStack;
+ import org.bukkit.inventory.Merchant;
+ import org.bukkit.inventory.Recipe;
+ import org.bukkit.map.MapView;
++import org.bukkit.block.BlockFactory;
+ import org.bukkit.permissions.Permissible;
+ import org.bukkit.plugin.Plugin;
+ import org.bukkit.plugin.PluginManager;
+@@ -1298,6 +1299,7 @@ public final class Bukkit {
+         return runtime().key(id);
+     }
+ 
++    public static BlockFactory blocks() { return runtime().blocks(); }
+     public static VectorFactory vectors() { return runtime().vectors(); }
+ 
+     public static PotionBrewRegistry potionRegistry() {
+diff --git a/src/main/java/org/bukkit/BukkitRuntime.java b/src/main/java/org/bukkit/BukkitRuntime.java
+index 837b2dd..8a7b3a2 100644
+--- a/src/main/java/org/bukkit/BukkitRuntime.java
++++ b/src/main/java/org/bukkit/BukkitRuntime.java
+@@ -1,9 +1,10 @@
+ package org.bukkit;
+ 
++import org.bukkit.block.BlockFactory;
+ import org.bukkit.inventory.ItemFactory;
+ import org.bukkit.inventory.meta.ItemMeta;
+-import org.bukkit.potion.PotionEffectRegistry;
+ import org.bukkit.potion.PotionBrewRegistry;
++import org.bukkit.potion.PotionEffectRegistry;
+ import org.bukkit.registry.Key;
+ import org.bukkit.geometry.VectorFactory;
+ 
+@@ -15,6 +16,8 @@ public interface BukkitRuntime {
+ 
+     VectorFactory vectors();
+ 
++    BlockFactory blocks();
++
+     /**
+      * Gets the instance of the item factory (for {@link ItemMeta}).
+      *
+diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
+index 6d47a61..deecc6e 100644
+--- a/src/main/java/org/bukkit/Server.java
++++ b/src/main/java/org/bukkit/Server.java
+@@ -1011,12 +1011,12 @@ public interface Server extends PluginMessageRecipient, BukkitRuntime, tc.oc.min
+ 
+     /**
+      * Create a ChunkData for use in a generator.
+-     * 
++     *
+      * See {@link ChunkGenerator#generateChunkData(org.bukkit.World, java.util.Random, int, int, org.bukkit.generator.ChunkGenerator.BiomeGrid)}
+-     * 
++     *
+      * @param world the world to create the ChunkData for
+      * @return a new ChunkData for the world
+-     * 
++     *
+      */
+     public ChunkGenerator.ChunkData createChunkData(World world);
+ 
+diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
+index 0cb6b2d..f7fc037 100644
+--- a/src/main/java/org/bukkit/World.java
++++ b/src/main/java/org/bukkit/World.java
+@@ -1,12 +1,20 @@
+ package org.bukkit;
+ 
+ import java.io.File;
++
++import org.bukkit.block.BlockImage;
++import org.bukkit.geometry.CoarseTransform;
++import org.bukkit.material.MaterialData;
++import org.bukkit.geometry.Vec3;
++import org.bukkit.region.BlockRegion;
+ import org.bukkit.generator.ChunkGenerator;
+ import java.util.Collection;
+ import java.util.HashMap;
+ import java.util.List;
+ import java.util.Map;
++import java.util.Set;
+ import java.util.UUID;
++import java.util.function.Predicate;
+ 
+ import org.bukkit.block.Biome;
+ import org.bukkit.block.Block;
+@@ -35,6 +43,8 @@ public interface World extends PluginMessageRecipient, Metadatable, Physical {
+      */
+     public Block getBlockAt(int x, int y, int z);
+ 
++    Block getBlockAt(Vec3 position);
++
+     /**
+      * Gets the {@link Block} at the given {@link Location}
+      *
+@@ -72,6 +82,30 @@ public interface World extends PluginMessageRecipient, Metadatable, Physical {
+     public int getBlockTypeIdAt(Location location);
+ 
+     /**
++     * Test if the block at the given position in this world is made of the given material.
++     */
++    boolean hasMaterialAt(MaterialData material, Vec3 position);
++
++    /**
++     * Test if the block at the given position in this world is made of any of the given materials.
++     */
++    boolean hasMaterialAt(Set<MaterialData> materials, Vec3 position);
++
++    /**
++     * Return a {@link Predicate} that tests if the block at a given position in this world is made of the given material.
++     *
++     * The returned predicate may be more efficient for repeated use than calling {@link #hasMaterialAt(MaterialData, Vec3)} multiple times.
++     */
++    Predicate<Vec3> hasMaterialAt(MaterialData material);
++
++    /**
++     * Return a {@link Predicate} that tests if the block at a given position in this world is made of the given material.
++     *
++     * The returned predicate may be more efficient for repeated use than calling {@link #hasMaterialAt(Set, Vec3)} multiple times.
++     */
++    Predicate<Vec3> hasMaterialAt(Set<MaterialData> materials);
++
++    /**
+      * Gets the y coordinate of the lowest block at this position such that the
+      * block and all blocks above it are transparent for lighting purposes.
+      *
+@@ -139,6 +173,10 @@ public interface World extends PluginMessageRecipient, Metadatable, Physical {
+      */
+     public Chunk getChunkAt(int x, int z);
+ 
++    default Chunk getChunkAt(Vec3 position) {
++        return getChunkAt(position.coarseX() >> 4, position.coarseZ() >> 4);
++    }
++
+     /**
+      * Gets the {@link Chunk} at the given {@link Location}
+      *
+@@ -897,6 +935,10 @@ public interface World extends PluginMessageRecipient, Metadatable, Physical {
+      */
+     Biome getBiome(int x, int z);
+ 
++    default Biome getBiome(Vec3 position) {
++        return getBiome(position.coarseX(), position.coarseZ());
++    }
++
+     /**
+      * Sets the biome for the given block coordinates
+      *
+@@ -906,6 +948,10 @@ public interface World extends PluginMessageRecipient, Metadatable, Physical {
+      */
+     void setBiome(int x, int z, Biome bio);
+ 
++    default void setBiome(Vec3 position, Biome biome) {
++        setBiome(position.coarseX(), position.coarseZ(), biome);
++    }
++
+     /**
+      * Gets the temperature for the given block coordinates.
+      * <p>
+@@ -918,6 +964,10 @@ public interface World extends PluginMessageRecipient, Metadatable, Physical {
+      */
+     public double getTemperature(int x, int z);
+ 
++    default double getTemperature(Vec3 position) {
++        return getTemperature(position.coarseX(), position.coarseZ());
++    }
++
+     /**
+      * Gets the humidity for the given block coordinates.
+      * <p>
+@@ -930,6 +980,10 @@ public interface World extends PluginMessageRecipient, Metadatable, Physical {
+      */
+     public double getHumidity(int x, int z);
+ 
++    default double getHumidity(Vec3 position) {
++        return getHumidity(position.coarseX(), position.coarseZ());
++    }
++
+     /**
+      * Gets the maximum height of this world.
+      * <p>
+@@ -1490,6 +1544,37 @@ public interface World extends PluginMessageRecipient, Metadatable, Physical {
+      */
+     public <T> void spawnParticle(Particle particle, double x, double y, double z, int count, double offsetX, double offsetY, double offsetZ, double extra, T data);
+ 
++    /**
++     * Copy block states in the specified region to a saved image.
++     * @return A copy of the specified block states
++     */
++    BlockImage copyBlocks(BlockRegion region, boolean includeAir, boolean clearSource);
++
++    default BlockImage copyBlocks(BlockRegion region, boolean includeAir) {
++        return copyBlocks(region, includeAir, false);
++    }
++
++    default BlockImage copyBlocks(BlockRegion region) {
++        return copyBlocks(region, true);
++    }
++
++    int pasteBlocks(BlockImage image, CoarseTransform transform);
++
++    /**
++     * Copy block states in the given saved image to the given position
++     * in this world.
++     * @param image Block image to copy
++     * @param offset Offset of copied blocks from their original position in the image.
++     * @return The number of blocks in this world affected by the operation.
++     */
++    int pasteBlocks(BlockImage image, Vec3 offset);
++
++    /**
++     * Copy block states in the given saved image to their original position.
++     * @param image Block image to copy
++     * @return The number of blocks in this world affected by the operation.
++     */
++    int pasteBlocks(BlockImage image);
+ 
+     /**
+      * Represents various map environment types that a world may be
+diff --git a/src/main/java/org/bukkit/block/Block.java b/src/main/java/org/bukkit/block/Block.java
+index ddd6c65..64af515 100644
+--- a/src/main/java/org/bukkit/block/Block.java
++++ b/src/main/java/org/bukkit/block/Block.java
+@@ -11,6 +11,7 @@ import org.bukkit.inventory.ItemStack;
+ import org.bukkit.material.MaterialData;
+ import org.bukkit.metadata.Metadatable;
+ import org.bukkit.util.RayBlockIntersection;
++import org.bukkit.geometry.Vec3;
+ import org.bukkit.util.Vector;
+ 
+ /**
+@@ -118,6 +119,8 @@ public interface Block extends Metadatable, Physical {
+      */
+     World getWorld();
+ 
++    Vec3 getPosition();
++
+     /**
+      * Gets the x-coordinate of this block
+      *
+diff --git a/src/main/java/org/bukkit/block/BlockFactory.java b/src/main/java/org/bukkit/block/BlockFactory.java
+new file mode 100644
+index 0000000..4968dd1
+--- /dev/null
++++ b/src/main/java/org/bukkit/block/BlockFactory.java
+@@ -0,0 +1,21 @@
++package org.bukkit.block;
++
++import org.bukkit.geometry.BlockRotoflection;
++import org.bukkit.geometry.BlockReflection;
++import org.bukkit.geometry.BlockRotation;
++import org.bukkit.geometry.CoarseTransform;
++import org.bukkit.material.MaterialData;
++
++/**
++ * Construct and transform block {@link MaterialData}
++ */
++public interface BlockFactory {
++
++    MaterialData reflect(MaterialData material, BlockReflection reflection);
++
++    MaterialData rotate(MaterialData material, BlockRotation rotation);
++
++    MaterialData transform(MaterialData material, BlockRotoflection transform);
++
++    MaterialData transform(MaterialData material, CoarseTransform transform);
++}
+diff --git a/src/main/java/org/bukkit/block/BlockImage.java b/src/main/java/org/bukkit/block/BlockImage.java
+new file mode 100644
+index 0000000..defd64c
+--- /dev/null
++++ b/src/main/java/org/bukkit/block/BlockImage.java
+@@ -0,0 +1,65 @@
++package org.bukkit.block;
++
++import org.bukkit.Location;
++import org.bukkit.World;
++import org.bukkit.geometry.BlockRotoflection;
++import org.bukkit.geometry.CoarseTransform;
++import org.bukkit.geometry.Transform;
++import org.bukkit.material.MaterialData;
++import org.bukkit.region.BlockRegion;
++import org.bukkit.geometry.Vec3;
++
++/**
++ * A set of saved block states.
++ *
++ * The blocks do not belong to any world. Block state, tile entity data,
++ * and tile ticks can all be captured in the image.
++ *
++ * TODO: Provide a way to actually get {@link BlockState}s from one of these.
++ */
++public interface BlockImage {
++
++    /**
++     * The set of blocks included in this image. Any blocks excluded from the image
++     * (e.g. air blocks) will also be exlcuded from this region.
++     */
++    BlockRegion region();
++
++    MaterialData materialAt(Vec3 pos);
++
++    int paste(World world, CoarseTransform transform);
++
++    default int paste(World world) {
++        return paste(world, Transform.identity());
++    }
++
++    default boolean pasteBlock(Vec3 pos, World world) {
++        return pasteBlock(pos, world, pos);
++    }
++
++    default boolean pasteBlock(Vec3 pos, World world, CoarseTransform transform) {
++        return pasteBlock(pos, world, transform.apply(pos), transform.orientation());
++    }
++
++    boolean pasteBlock(Vec3 from, World world, Vec3 to, BlockRotoflection orientation);
++
++    default boolean pasteBlock(Vec3 from, World world, Vec3 to) {
++        return pasteBlock(from, world, to, BlockRotoflection.identity());
++    }
++
++    default boolean pasteBlock(Vec3 from, Location to) {
++        return pasteBlock(from, to.getWorld(), to.toVector());
++    }
++
++    default boolean pasteBlock(Vec3 from, Block to) {
++        return pasteBlock(from, to.getWorld(), to.getPosition());
++    }
++
++    default BlockImage transform(CoarseTransform transform) {
++        return new TransformedBlockImage(this, transform);
++    }
++
++    static BlockImage empty() {
++        return EmptyBlockImage.INSTANCE;
++    }
++}
+diff --git a/src/main/java/org/bukkit/block/BlockState.java b/src/main/java/org/bukkit/block/BlockState.java
+index 7899117..967eac0 100644
+--- a/src/main/java/org/bukkit/block/BlockState.java
++++ b/src/main/java/org/bukkit/block/BlockState.java
+@@ -5,8 +5,13 @@ import org.bukkit.Location;
+ import org.bukkit.Material;
+ import org.bukkit.World;
+ import org.bukkit.Physical;
++import org.bukkit.geometry.BlockRotoflection;
++import org.bukkit.geometry.BlockReflection;
++import org.bukkit.geometry.BlockRotation;
++import org.bukkit.geometry.CoarseTransform;
+ import org.bukkit.material.MaterialData;
+ import org.bukkit.metadata.Metadatable;
++import org.bukkit.geometry.Vec3;
+ 
+ /**
+  * Represents a captured state of a block, which will not change
+@@ -54,6 +59,14 @@ public interface BlockState extends Metadatable, Physical {
+      */
+     void setMaterialData(MaterialData materialData);
+ 
++    void reflect(BlockReflection reflection);
++
++    void rotate(BlockRotation rotation);
++
++    void reorient(BlockRotoflection orientation);
++
++    void reorient(CoarseTransform transform);
++
+     /**
+      * Gets the metadata for this block
+      *
+@@ -95,6 +108,12 @@ public interface BlockState extends Metadatable, Physical {
+      */
+     World getWorld();
+ 
++    World tryWorld();
++
++    Vec3 getPosition();
++
++    Vec3 tryPosition();
++
+     /**
+      * Gets the x-coordinate of this block
+      *
+@@ -241,4 +260,6 @@ public interface BlockState extends Metadatable, Physical {
+      *         or 'virtual' (e.g. on an itemstack)
+      */
+     boolean isPlaced();
++
++    boolean hasPosition();
+ }
+diff --git a/src/main/java/org/bukkit/block/EmptyBlockImage.java b/src/main/java/org/bukkit/block/EmptyBlockImage.java
+new file mode 100644
+index 0000000..fc3f166
+--- /dev/null
++++ b/src/main/java/org/bukkit/block/EmptyBlockImage.java
+@@ -0,0 +1,40 @@
++package org.bukkit.block;
++
++import org.bukkit.World;
++import org.bukkit.geometry.BlockRotoflection;
++import org.bukkit.geometry.CoarseTransform;
++import org.bukkit.geometry.Vec3;
++import org.bukkit.material.MaterialData;
++import org.bukkit.region.BlockRegion;
++
++public class EmptyBlockImage implements BlockImage {
++
++    static final EmptyBlockImage INSTANCE = new EmptyBlockImage();
++
++    private EmptyBlockImage() {}
++
++    @Override
++    public BlockRegion region() {
++        return BlockRegion.empty();
++    }
++
++    @Override
++    public MaterialData materialAt(Vec3 pos) {
++        return null;
++    }
++
++    @Override
++    public int paste(World world, CoarseTransform transform) {
++        return 0;
++    }
++
++    @Override
++    public boolean pasteBlock(Vec3 from, World world, Vec3 to, BlockRotoflection orientation) {
++        return false;
++    }
++
++    @Override
++    public BlockImage transform(CoarseTransform transform) {
++        return this;
++    }
++}
+diff --git a/src/main/java/org/bukkit/block/TransformedBlockImage.java b/src/main/java/org/bukkit/block/TransformedBlockImage.java
+new file mode 100644
+index 0000000..db43c72
+--- /dev/null
++++ b/src/main/java/org/bukkit/block/TransformedBlockImage.java
+@@ -0,0 +1,49 @@
++package org.bukkit.block;
++
++import org.bukkit.World;
++import org.bukkit.geometry.BlockRotoflection;
++import org.bukkit.geometry.CoarseTransform;
++import org.bukkit.geometry.Vec3;
++import org.bukkit.material.MaterialData;
++import org.bukkit.region.BlockRegion;
++
++public class TransformedBlockImage implements BlockImage {
++
++    private final BlockImage original;
++    private final CoarseTransform transform;
++    private final CoarseTransform inverse;
++
++    public TransformedBlockImage(BlockImage original, CoarseTransform transform) {
++        this.original = original;
++        this.transform = transform;
++        this.inverse = transform.inverse();
++    }
++
++    @Override
++    public BlockRegion region() {
++        return original.region().transform(transform);
++    }
++
++    @Override
++    public MaterialData materialAt(Vec3 pos) {
++        return original.materialAt(inverse.apply(pos));
++    }
++
++    @Override
++    public int paste(World world, CoarseTransform transform) {
++        return original.paste(world, this.transform.andThen(transform));
++    }
++
++    @Override
++    public boolean pasteBlock(Vec3 from, World world, Vec3 to, BlockRotoflection orientation) {
++        return pasteBlock(from, world, CoarseTransform.translation(to).andThen(orientation.transform()));
++    }
++
++    @Override
++    public BlockImage transform(CoarseTransform transform) {
++        if(transform.isIdentity()) return this;
++        transform = this.transform.andThen(transform);
++        if(transform.isIdentity()) return original;
++        return new TransformedBlockImage(original, transform);
++    }
++}
+diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
+index 35e3af9..6a1b1f3 100644
+--- a/src/main/java/org/bukkit/entity/Entity.java
++++ b/src/main/java/org/bukkit/entity/Entity.java
+@@ -11,6 +11,7 @@ import org.bukkit.Physical;
+ import org.bukkit.event.entity.EntityDamageEvent;
+ import org.bukkit.geometry.Cuboid;
+ import org.bukkit.metadata.Metadatable;
++import org.bukkit.geometry.Cuboid;
+ import org.bukkit.util.Vector;
+ 
+ import java.util.List;
+diff --git a/src/main/java/org/bukkit/material/Alignable.java b/src/main/java/org/bukkit/material/Alignable.java
+index c9ad81e..5759f6c 100644
+--- a/src/main/java/org/bukkit/material/Alignable.java
++++ b/src/main/java/org/bukkit/material/Alignable.java
+@@ -1,6 +1,6 @@
+ package org.bukkit.material;
+ 
+-import org.bukkit.util.Axis;
++import org.bukkit.geometry.Axis;
+ 
+ public interface Alignable {
+ 
+diff --git a/src/main/java/org/bukkit/material/Lever.java b/src/main/java/org/bukkit/material/Lever.java
+index 3b76ed0..706b514 100644
+--- a/src/main/java/org/bukkit/material/Lever.java
++++ b/src/main/java/org/bukkit/material/Lever.java
+@@ -2,7 +2,7 @@ package org.bukkit.material;
+ 
+ import org.bukkit.block.BlockFace;
+ import org.bukkit.Material;
+-import org.bukkit.util.Axis;
++import org.bukkit.geometry.Axis;
+ 
+ /**
+  * Represents a lever
+-- 
+1.9.0
+

--- a/Bukkit/0084-New-event-API.patch
+++ b/Bukkit/0084-New-event-API.patch
@@ -1,0 +1,3282 @@
+From 77ae9399a55a1f9763fe7c1ad50158aa453355a0 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Sat, 9 Jul 2016 05:27:03 -0400
+Subject: [PATCH] New event API
+
+
+diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
+index b3837d9..867f2d0 100644
+--- a/src/main/java/org/bukkit/Bukkit.java
++++ b/src/main/java/org/bukkit/Bukkit.java
+@@ -24,6 +24,7 @@ import org.bukkit.command.ConsoleCommandSender;
+ import org.bukkit.command.PluginCommand;
+ import org.bukkit.entity.Entity;
+ import org.bukkit.entity.Player;
++import org.bukkit.event.EventBus;
+ import org.bukkit.event.inventory.InventoryType;
+ import org.bukkit.event.server.ServerListPingEvent;
+ import org.bukkit.help.HelpMap;
+@@ -556,6 +557,10 @@ public final class Bukkit {
+         return server.getServicesManager();
+     }
+ 
++    public static EventBus eventBus() {
++        return server.eventBus();
++    }
++
+     /**
+      * Gets a list of all worlds on this server.
+      *
+@@ -1142,6 +1147,10 @@ public final class Bukkit {
+         return server.getWarningState();
+     }
+ 
++    public static boolean pluginProfiling() {
++        return server.pluginProfiling();
++    }
++
+     /**
+      * Gets the instance of the item factory (for {@link ItemMeta}).
+      *
+diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
+index deecc6e..c1a982f 100644
+--- a/src/main/java/org/bukkit/Server.java
++++ b/src/main/java/org/bukkit/Server.java
+@@ -24,6 +24,7 @@ import org.bukkit.command.ConsoleCommandSender;
+ import org.bukkit.command.PluginCommand;
+ import org.bukkit.entity.Entity;
+ import org.bukkit.entity.Player;
++import org.bukkit.event.EventBus;
+ import org.bukkit.event.inventory.InventoryType;
+ import org.bukkit.event.server.ServerListPingEvent;
+ import org.bukkit.help.HelpMap;
+@@ -440,6 +441,11 @@ public interface Server extends PluginMessageRecipient, BukkitRuntime, tc.oc.min
+     public ServicesManager getServicesManager();
+ 
+     /**
++     * Get the server event bus
++     */
++    EventBus eventBus();
++
++    /**
+      * Gets a list of all worlds on this server.
+      *
+      * @return a list of worlds
+@@ -928,6 +934,8 @@ public interface Server extends PluginMessageRecipient, BukkitRuntime, tc.oc.min
+      */
+     public WarningState getWarningState();
+ 
++    boolean pluginProfiling();
++
+     /**
+      * Gets the instance of the item factory (for {@link ItemMeta}).
+      *
+diff --git a/src/main/java/org/bukkit/command/defaults/TimingsCommand.java b/src/main/java/org/bukkit/command/defaults/TimingsCommand.java
+index a39ea5d..09554e4 100644
+--- a/src/main/java/org/bukkit/command/defaults/TimingsCommand.java
++++ b/src/main/java/org/bukkit/command/defaults/TimingsCommand.java
+@@ -12,6 +12,7 @@ import org.bukkit.ChatColor;
+ import org.bukkit.command.CommandSender;
+ import org.bukkit.event.Event;
+ import org.bukkit.event.HandlerList;
++import org.bukkit.event.RegisteredHandler;
+ import org.bukkit.plugin.Plugin;
+ import org.bukkit.plugin.RegisteredListener;
+ import org.bukkit.plugin.TimedRegisteredListener;
+@@ -36,7 +37,7 @@ public class TimingsCommand extends BukkitCommand {
+             sender.sendMessage(ChatColor.RED + "Usage: " + usageMessage);
+             return false;
+         }
+-        if (!sender.getServer().getPluginManager().useTimings()) {
++        if (!sender.getServer().pluginProfiling()) {
+             sender.sendMessage("Please enable timings by setting \"settings.plugin-profiling\" to true in bukkit.yml");
+             return true;
+         }
+@@ -44,7 +45,7 @@ public class TimingsCommand extends BukkitCommand {
+         boolean separate = "separate".equalsIgnoreCase(args[0]);
+         if ("reset".equalsIgnoreCase(args[0])) {
+             for (HandlerList handlerList : HandlerList.getHandlerLists()) {
+-                for (RegisteredListener listener : handlerList.getRegisteredListeners()) {
++                for (RegisteredHandler listener : handlerList.getRegisteredListeners()) {
+                     if (listener instanceof TimedRegisteredListener) {
+                         ((TimedRegisteredListener)listener).reset();
+                     }
+diff --git a/src/main/java/org/bukkit/event/BoundEventHandler.java b/src/main/java/org/bukkit/event/BoundEventHandler.java
+new file mode 100644
+index 0000000..2c70a55
+--- /dev/null
++++ b/src/main/java/org/bukkit/event/BoundEventHandler.java
+@@ -0,0 +1,74 @@
++package org.bukkit.event;
++
++import java.util.Objects;
++
++import org.bukkit.plugin.EventExecutor;
++
++import static com.google.common.base.Preconditions.checkNotNull;
++
++/**
++ * A {@link RegisteredHandler} associated with a {@link Listener}, that passes events
++ * to an {@link EventExecutor}, along with that listener.
++ */
++public class BoundEventHandler<T extends Event> implements RegisteredHandler<T> {
++
++    private final EventHandlerMeta<T> meta;
++    private final EventExecutor<T> executor;
++    private final Listener listener;
++
++    public BoundEventHandler(EventMethodExecutor<T> executor, Listener listener) {
++        this(executor.meta(), executor, listener);
++
++        if(!executor.method().getDeclaringClass().isInstance(listener)) {
++            throw new IllegalArgumentException(
++                "Cannot bind event handler method " + executor +
++                " to listener of type " + listener.getClass().getName() +
++                " because it is not assignable to " + executor.method().getDeclaringClass().getName()
++            );
++        }
++    }
++
++    public BoundEventHandler(EventHandlerMeta<T> meta, EventExecutor<T> executor, Listener listener) {
++        this.meta = checkNotNull(meta);
++        this.executor = checkNotNull(executor);
++        this.listener = checkNotNull(listener);
++    }
++
++    @Override
++    public EventHandlerMeta<T> meta() {
++        return meta;
++    }
++
++    public Listener listener() {
++        return listener;
++    }
++
++    @Override
++    public void callEvent(T event) throws EventException {
++        executor.execute(listener, event);
++    }
++
++    @Override
++    final public int hashCode() {
++        return Objects.hash(meta, executor, listener);
++    }
++
++    @Override
++    final public boolean equals(Object obj) {
++        if(this == obj) return true;
++        if(!(obj instanceof BoundEventHandler)) return false;
++        final BoundEventHandler that = (BoundEventHandler) obj;
++        return this.meta.equals(that.meta) &&
++               this.executor.equals(that.executor) &&
++               this.listener == that.listener;
++    }
++
++    @Override
++    public String toString() {
++        return getClass().getSimpleName() +
++               "{meta=" + meta +
++               " executor=" + executor +
++               " listener=" + listener +
++               "}";
++    }
++}
+diff --git a/src/main/java/org/bukkit/event/CallableEventHandler.java b/src/main/java/org/bukkit/event/CallableEventHandler.java
+new file mode 100644
+index 0000000..52d6df8
+--- /dev/null
++++ b/src/main/java/org/bukkit/event/CallableEventHandler.java
+@@ -0,0 +1,101 @@
++package org.bukkit.event;
++
++import org.bukkit.exception.ExceptionHandler;
++import org.bukkit.exception.LoggingExceptionHandler;
++
++import static com.google.common.base.Preconditions.checkNotNull;
++
++/**
++ * A general {@link RegisteredHandler} that passes events to a {@link EventCallable},
++ * and reports uncaught exceptions to a {@link ExceptionHandler}.
++ */
++public class CallableEventHandler<T extends Event> implements RegisteredHandler<T> {
++
++    private final EventHandlerMeta<T> meta;
++    private final EventCallable<? super T> callable;
++    private final ExceptionHandler exceptionHandler;
++
++    public CallableEventHandler(EventHandlerMeta<T> meta, EventCallable<? super T> callable, ExceptionHandler exceptionHandler) {
++        this.meta = checkNotNull(meta);
++        this.callable = checkNotNull(callable);
++        this.exceptionHandler = checkNotNull(exceptionHandler);
++    }
++
++    @Override
++    public EventHandlerMeta<T> meta() {
++        return meta;
++    }
++
++    @Override
++    public void callEvent(T event) throws EventException {
++        try {
++            callable.callEvent(event);
++        } catch(EventException ex) {
++            throw ex;
++        } catch(Throwable ex) {
++            exceptionHandler.handleException(
++                ex,
++                "Exception dispatching " + event.getEventName() +
++                " to " + callable.getClass().getSimpleName()
++            );
++        }
++    }
++
++    @Override
++    public String toString() {
++        return getClass().getSimpleName() +
++               "{meta=" + meta +
++               " callable=" + callable +
++               "}";
++    }
++
++    public static <T extends Event> CallableEventHandler<T> create(Class<T> eventClass, EventPriority priority, boolean ignoreCancelled, EventCallable<? super T> handler, ExceptionHandler exceptionHandler) {
++        return new CallableEventHandler<>(new EventHandlerMeta<>(eventClass, priority, ignoreCancelled), handler, exceptionHandler);
++    }
++
++    public static <T extends Event> CallableEventHandler<T> create(Class<T> eventClass, EventPriority priority, EventCallable<? super T> handler, ExceptionHandler exceptionHandler) {
++        return create(eventClass, priority, false, handler, exceptionHandler);
++    }
++
++    public static <T extends Event> CallableEventHandler<T> create(Class<T> eventClass, EventCallable<? super T> handler, ExceptionHandler exceptionHandler) {
++        return create(eventClass, EventPriority.NORMAL, handler, exceptionHandler);
++    }
++
++    public static <T extends Event> CallableEventHandler<T> create(Class<T> eventClass, EventPriority priority, boolean ignoreCancelled, EventCallable<? super T> handler) {
++        return create(eventClass, priority, ignoreCancelled, handler, LoggingExceptionHandler.forGlobalLogger());
++    }
++
++    public static <T extends Event> CallableEventHandler<T> create(Class<T> eventClass, EventPriority priority, EventCallable<? super T> handler) {
++        return create(eventClass, priority, false, handler);
++    }
++
++    public static <T extends Event> CallableEventHandler<T> create(Class<T> eventClass, EventCallable<? super T> handler) {
++        return create(eventClass, EventPriority.NORMAL, handler);
++    }
++
++    public static <T extends Event> CallableEventHandler<T> register(Class<T> eventClass, EventPriority priority, boolean ignoreCancelled, EventCallable<? super T> handler, ExceptionHandler exceptionHandler) {
++        final CallableEventHandler<T> registeredHandler = create(eventClass, priority, ignoreCancelled, handler, exceptionHandler);
++        Event.register(eventClass, registeredHandler);
++        return registeredHandler;
++    }
++
++    public static <T extends Event> CallableEventHandler<T> register(Class<T> eventClass, EventPriority priority, EventCallable<? super T> handler, ExceptionHandler exceptionHandler) {
++        return register(eventClass, priority, false, handler, exceptionHandler);
++    }
++
++    public static <T extends Event> CallableEventHandler<T> register(Class<T> eventClass, EventCallable<? super T> handler, ExceptionHandler exceptionHandler) {
++        return register(eventClass, EventPriority.NORMAL, handler, exceptionHandler);
++    }
++
++    public static <T extends Event> CallableEventHandler<T> register(Class<T> eventClass, EventPriority priority, boolean ignoreCancelled, EventCallable<? super T> handler) {
++        return register(eventClass, priority, ignoreCancelled, handler, LoggingExceptionHandler.forGlobalLogger());
++    }
++
++    public static <T extends Event> CallableEventHandler<T> register(Class<T> eventClass, EventPriority priority, EventCallable<? super T> handler) {
++        return register(eventClass, priority, false, handler);
++    }
++
++    public static <T extends Event> CallableEventHandler<T> register(Class<T> eventClass, EventCallable<? super T> handler) {
++        return register(eventClass, EventPriority.NORMAL, handler);
++    }
++}
+diff --git a/src/main/java/org/bukkit/event/Event.java b/src/main/java/org/bukkit/event/Event.java
+index 6677e1b..7f6af67 100644
+--- a/src/main/java/org/bukkit/event/Event.java
++++ b/src/main/java/org/bukkit/event/Event.java
+@@ -1,5 +1,17 @@
+ package org.bukkit.event;
+ 
++import java.lang.reflect.Field;
++import java.lang.reflect.Method;
++import java.lang.reflect.Modifier;
++import java.util.concurrent.ExecutionException;
++import javax.annotation.Nullable;
++
++import com.google.common.base.Throwables;
++import com.google.common.cache.CacheBuilder;
++import com.google.common.cache.CacheLoader;
++import com.google.common.cache.LoadingCache;
++import com.google.common.util.concurrent.UncheckedExecutionException;
++import org.bukkit.plugin.Plugin;
+ import org.bukkit.plugin.PluginManager;
+ 
+ /**
+@@ -47,7 +59,133 @@ public abstract class Event {
+         return name;
+     }
+ 
+-    public abstract HandlerList getHandlers();
++    public boolean isCancelled() {
++        return false;
++    }
++
++    boolean dispatching;
++    @Nullable EventCallable yielder = null;
++
++    /**
++     * Can this event be yielded to right now?
++     */
++    public boolean canYield() {
++        return yielder != null;
++    }
++
++    /**
++     * Continue dispatch of this event, returning after higher priority handlers,
++     * and the "body" (primary functionality) of the event, have executed.
++     *
++     * This method can only be called from within a handler for this event, and no
++     * more than once per handler. If a handler does not yield, dispatch will
++     * continue when the handler returns.
++     *
++     * @throws EventException if any exception is thrown from the event body.
++     *                        Handlers must NOT prevent the propagation of this
++     *                        exception, as it is used to propagate the causing
++     *                        exception to the event call site.
++     *
++     * @throws IllegalStateException if this event is not currently being dispatched,
++     *                               or if the current handler has already yielded to
++     *                               this event.
++     */
++    public void yield() throws EventException {
++        if(!canYield()) {
++            throw new IllegalStateException(
++                "This event has already been yielded to, or is not currently being dispatched"
++            );
++        }
++
++        try {
++            final EventCallable yielder = this.yielder;
++            this.yielder = null;
++            yielder.callEvent(this);
++        } catch(EventException e) {
++            throw e;
++        } catch(Throwable e) {
++            throw new EventException(e, this);
++        }
++    }
++
++    public static <T extends Event> void register(RegisteredHandler<T> handler) {
++        getHandlerList(handler.meta().event()).register(handler);
++    }
++
++    public static <T extends Event> void register(Class<T> eventClass, RegisteredHandler<? super T> handler) {
++        getHandlerList(eventClass).register(handler);
++    }
++
++    public static <T extends Event> void unregister(RegisteredHandler<T> handler) {
++        getHandlerList(handler.meta().event()).unregister(handler);
++    }
++
++    /**
++     * Return the {@link HandlerList} for the given {@link Event} subtype
++     *
++     * This will search for an ancestor class containing a static method with this name and signature:
++     *
++     *     HandlerList getHandlerList();
++     *
++     * Or a static field with this name and type:
++     *
++     *     HandlerList handlers;
++     *
++     * The accessibility of the method/field does not matter.
++     *
++     * Results are cached per event type, so searches after the first are fairly quick
++     * and do not perform any reflective operations.
++     *
++     * @throws IllegalArgumentException if no HandlerList can be found for the event class
++     */
++    public static <T extends Event> HandlerList<T> getHandlerList(Class<T> type) {
++        try {
++            return HANDLER_LISTS.get(type);
++        } catch(ExecutionException | UncheckedExecutionException e) {
++            throw Throwables.propagate(e.getCause());
++        }
++    }
++
++    private static final LoadingCache<Class<? extends Event>, HandlerList> HANDLER_LISTS = CacheBuilder.newBuilder().build(new CacheLoader<Class<? extends Event>, HandlerList>() {
++        @Override
++        public HandlerList load(Class<? extends Event> clazz) throws Exception {
++            Method method = null;
++            try {
++                method = clazz.getDeclaredMethod("getHandlerList");
++            } catch(NoSuchMethodException ignored) {}
++            if(method != null && Modifier.isStatic(method.getModifiers()) && HandlerList.class.isAssignableFrom(method.getReturnType())) {
++                method.setAccessible(true);
++                return (HandlerList) method.invoke(null);
++            }
++
++            Field field = null;
++            try {
++                field = clazz.getDeclaredField("handlers");
++            } catch(NoSuchFieldException ignored) {}
++            if(field != null && Modifier.isStatic(field.getModifiers()) && HandlerList.class.isAssignableFrom(field.getType())) {
++                field.setAccessible(true);
++                return (HandlerList) field.get(null);
++            }
++
++            final Class<?> up = clazz.getSuperclass();
++            if(up != null && !up.equals(Event.class) && Event.class.isAssignableFrom(up)) {
++                return HANDLER_LISTS.get(up.asSubclass(Event.class));
++            }
++
++            throw new IllegalArgumentException("Unable to find HandlerList for event type " + clazz.getName());
++        }
++    });
++
++    /**
++     * Return the {@link HandlerList} for this event.
++     *
++     * By default, this calls {@link #getHandlerList(Class)} with this object's class.
++     * Since this method is called every time the event is dispatched, it may be a
++     * worthwhile optimization to override it and return the list directly.
++     */
++    public HandlerList getHandlers() {
++        return getHandlerList(getClass());
++    }
+ 
+     /**
+      * Any custom event that should not by synchronized with other events must
+diff --git a/src/main/java/org/bukkit/event/EventBody.java b/src/main/java/org/bukkit/event/EventBody.java
+new file mode 100644
+index 0000000..7abbbbb
+--- /dev/null
++++ b/src/main/java/org/bukkit/event/EventBody.java
+@@ -0,0 +1,11 @@
++package org.bukkit.event;
++
++/**
++ * Encapsulates the primary functionality of an event.
++ *
++ * @see EventBus#callEvent
++ */
++public interface EventBody<T extends Event, X extends Throwable> extends EventCallable<T> {
++    @Override
++    void callEvent(T event) throws X;
++}
+diff --git a/src/main/java/org/bukkit/event/EventBus.java b/src/main/java/org/bukkit/event/EventBus.java
+new file mode 100644
+index 0000000..91383e1
+--- /dev/null
++++ b/src/main/java/org/bukkit/event/EventBus.java
+@@ -0,0 +1,55 @@
++package org.bukkit.event;
++
++import javax.annotation.Nullable;
++
++import org.bukkit.exception.ExceptionHandler;
++
++public interface EventBus {
++
++    void callEvent(Event event) throws IllegalStateException;
++
++    void callEvent(Event event, @Nullable EventPriority priority);
++
++    <T extends Event, X extends Throwable> void callEvent(T event, @Nullable EventBody<? super T, X> body) throws X;
++
++    /**
++     * Dispatch the given event to all applicable {@link RegisteredHandler}s,
++     * then (optionally) to the given {@link EventBody}.
++     *
++     * Event handlers are usually created from an {@link EventRegistry}, and registered with a {@link HandlerList}.
++     *
++     * Event handlers are called in order of their {@link EventPriority}, from lowest to highest,
++     * before the body of the event is executed. If an event handler calls {@link Event#yield()},
++     * the following handlers, and the event body, will run before it returns. If a handler does
++     * not yield, dispatch of the event will continue after the handler returns.
++     *
++     * Exceptions thrown from event handlers are reported to an {@link ExceptionHandler}.
++     * The exception does NOT prevent other handlers, or the event body, from running.
++     *
++     * Exceptions thrown from the event body are propagated out of this method
++     * (provided that yielding handlers propagate the {@link EventException} wrapping it).
++     *
++     * @param event         Event object passed to handlers
++     * @param priority      If non-null, only call handlers at this priority level
++     * @param body          Body of the actual event, or null for a no-op event
++     *
++     * @throws IllegalStateException Thrown when an asynchronous event is
++     *     fired from synchronous code.
++     *     <p>
++     *     <i>Note: This is best-effort basis, and should not be used to test
++     *     synchronized state. This is an indicator for flawed flow logic.</i>
++     */
++    <T extends Event, X extends Throwable> void callEvent(T event, @Nullable EventPriority priority, @Nullable EventBody<? super T, X> body) throws X;
++
++    /**
++     * Dispatch the given event to a single {@link RegisteredHandler}.
++     *
++     * If the handler yields, the given body is called (if it's non-null), and this method returns true.
++     * If the handler does not yield, the body is NOT called, and this method returns false.
++     * If the handler returns false from {@link RegisteredHandler#canHandle}, then it is not called, and the method returns false.
++     *
++     * Exceptions thrown from the event body are propagated out of this method
++     * (provided that yielding handlers propagate the {@link EventException} wrapping it).
++     */
++    <T extends Event, X extends Throwable> boolean callEventHandler(T event, @Nullable EventPriority priority, RegisteredHandler<? super T> handler, @Nullable EventBody<? super T, X> body) throws X;
++}
+diff --git a/src/main/java/org/bukkit/event/EventCallable.java b/src/main/java/org/bukkit/event/EventCallable.java
+new file mode 100644
+index 0000000..e56fcf6
+--- /dev/null
++++ b/src/main/java/org/bukkit/event/EventCallable.java
+@@ -0,0 +1,11 @@
++package org.bukkit.event;
++
++/**
++ * Something that is called with an {@link Event}, has several uses.
++ */
++public interface EventCallable<T extends Event> {
++
++    void callEvent(T event) throws Throwable;
++
++    EventCallable<?> EMPTY = event -> {};
++}
+diff --git a/src/main/java/org/bukkit/event/EventException.java b/src/main/java/org/bukkit/event/EventException.java
+index aef8d49..d34096e 100644
+--- a/src/main/java/org/bukkit/event/EventException.java
++++ b/src/main/java/org/bukkit/event/EventException.java
+@@ -1,5 +1,8 @@
+ package org.bukkit.event;
+ 
++/**
++ * A wrapper used to propagate exceptions thrown from {@link EventBody}s
++ */
+ public class EventException extends Exception {
+     private static final long serialVersionUID = 3532808232324183999L;
+     private final Event event;
+diff --git a/src/main/java/org/bukkit/event/EventHandlerMeta.java b/src/main/java/org/bukkit/event/EventHandlerMeta.java
+new file mode 100644
+index 0000000..54f89ac
+--- /dev/null
++++ b/src/main/java/org/bukkit/event/EventHandlerMeta.java
+@@ -0,0 +1,120 @@
++package org.bukkit.event;
++
++import java.lang.reflect.Method;
++import java.util.Objects;
++import javax.annotation.Nullable;
++
++import static com.google.common.base.Preconditions.checkNotNull;
++
++/**
++ * Parameters for event handler registration
++ */
++public class EventHandlerMeta<T extends Event> {
++
++    private final Class<T> event;
++    private final EventPriority priority;
++    private final boolean ignoreCancelled;
++
++    public EventHandlerMeta(Class<T> event, EventPriority priority, boolean ignoreCancelled) {
++        this.event = checkNotNull(event);
++        this.priority = checkNotNull(priority);
++        this.ignoreCancelled = ignoreCancelled;
++    }
++
++    /**
++     * Base {@link Event} type that this handler can handle
++     */
++    public Class<T> event() {
++        return event;
++    }
++
++    /**
++     * Priority level at which this handler should be called
++     */
++    public EventPriority priority() {
++        return priority;
++    }
++
++    /**
++    * Whether this handler accepts cancelled events
++    */
++    public boolean ignoreCancelled() {
++        return ignoreCancelled;
++    }
++
++    public boolean canHandle(Event event, @Nullable EventPriority priority) {
++        return this.event.isInstance(event) &&
++               (priority == null || priority.equals(this.priority)) &&
++               !(event.isCancelled() && this.ignoreCancelled);
++    }
++
++    public boolean canCall(Method method) {
++        return method.getParameterTypes().length == 1 &&
++               method.getParameterTypes()[0].isAssignableFrom(event());
++    }
++
++    public void assertCanCall(Method method) {
++        if(!canCall(method)) {
++            throw new IllegalArgumentException(
++                "Invalid event handler method signature " + method.toGenericString() +
++                " in " + method.getDeclaringClass().getName()
++            );
++        }
++    }
++
++    @Override
++    public int hashCode() {
++        return Objects.hash(event, priority, ignoreCancelled);
++    }
++
++    @Override
++    public boolean equals(Object obj) {
++        if(this == obj) return true;
++        if(!(obj instanceof EventHandlerMeta)) return false;
++        final EventHandlerMeta that = (EventHandlerMeta) obj;
++        return this.event.equals(that.event()) &&
++               this.priority.equals(that.priority()) &&
++               this.ignoreCancelled == that.ignoreCancelled();
++    }
++
++    @Override
++    public String toString() {
++        return getClass().getSimpleName() +
++               "{event=" + event.getSimpleName() +
++               " priority=" + priority.name() +
++               " ignoreCancelled=" + ignoreCancelled +
++               "}";
++    }
++
++    /**
++     * Create an {@link EventHandlerMeta} for the given event class, copying other
++     * parameters from the given {@link EventHandler} annotation.
++     */
++    public static <T extends Event> EventHandlerMeta<T> forAnnotation(Class<T> event, EventHandler annotation) {
++        return new EventHandlerMeta<>(event, annotation.priority(), annotation.ignoreCancelled());
++    }
++
++    /**
++     * Reflect on the given {@link Method} and create a {@link EventHandlerMeta} for it,
++     * using the method's signature and annotations.
++     *
++     * If the method is not annotated as an {@link EventHandler}, return null.
++     */
++    public static @Nullable EventHandlerMeta<?> forMethod(Method method) {
++        if(method.isBridge() || method.isSynthetic()) return null;
++
++        final EventHandler annotation = method.getAnnotation(EventHandler.class);
++        if(annotation == null) return null;
++
++        final Class<?> eventClass;
++        if (method.getParameterTypes().length != 1 || !Event.class.isAssignableFrom(eventClass = method.getParameterTypes()[0])) {
++            throw new IllegalArgumentException("Invalid @EventHandler method " + method.toGenericString() +
++                                               " in " + method.getDeclaringClass().getName());
++        }
++
++        // Make sure the event has a HandlerList
++        Event.getHandlerList((Class<? extends Event>) eventClass);
++
++        return forAnnotation(eventClass.asSubclass(Event.class), annotation);
++    }
++}
+diff --git a/src/main/java/org/bukkit/event/EventMethodExecutor.java b/src/main/java/org/bukkit/event/EventMethodExecutor.java
+new file mode 100644
+index 0000000..05ba959
+--- /dev/null
++++ b/src/main/java/org/bukkit/event/EventMethodExecutor.java
+@@ -0,0 +1,120 @@
++package org.bukkit.event;
++
++import java.lang.reflect.InvocationTargetException;
++import java.lang.reflect.Method;
++import java.util.Objects;
++import java.util.stream.Stream;
++import javax.annotation.Nullable;
++
++import org.bukkit.exception.ExceptionHandler;
++import org.bukkit.plugin.EventExecutor;
++
++import static com.google.common.base.Preconditions.checkNotNull;
++
++/**
++ * An {@link EventExecutor} that reflectively calls an instance {@link Method}
++ * on the {@link Listener} passed to it with the event.
++ *
++ * Events that do not match the provided {@link EventHandlerMeta} are silently ignored.
++ *
++ * Exceptions thrown by the method are passed to the provided {@link ExceptionHandler},
++ * except for {@link EventException}, which is propagated.
++ */
++public class EventMethodExecutor<T extends Event> implements EventExecutor<T> {
++
++    private final EventHandlerMeta<T> meta;
++    private final Method method;
++    private final ExceptionHandler exceptionHandler;
++
++    public EventMethodExecutor(EventHandlerMeta<T> meta, Method method, ExceptionHandler exceptionHandler) {
++        this.meta = checkNotNull(meta);
++        this.method = checkNotNull(method);
++        this.exceptionHandler = checkNotNull(exceptionHandler);
++
++        this.meta.assertCanCall(this.method);
++        this.method.setAccessible(true);
++    }
++
++    public EventHandlerMeta<T> meta() {
++        return meta;
++    }
++
++    public Method method() {
++        return method;
++    }
++
++    public BoundEventHandler<T> bind(Listener listener) {
++        return new BoundEventHandler<>(meta, this, listener);
++    }
++
++    @Override
++    public void execute(Listener listener, T event) throws EventException {
++        if(meta.canHandle(event, null)) {
++            try {
++                method.invoke(listener, event);
++            } catch(InvocationTargetException ex) {
++                if(ex.getCause() instanceof EventException) {
++                    throw (EventException) ex.getCause();
++                }
++                handleException(listener, event, ex.getCause());
++            } catch(Throwable ex) {
++                handleException(listener, event, ex);
++            }
++        }
++    }
++
++    protected void handleException(Listener listener, T event, Throwable ex) {
++        exceptionHandler.handleException(ex, "Exception dispatching event " + event.getEventName() + " to " + listener);
++    }
++
++    @Override
++    final public int hashCode() {
++        return Objects.hash(meta, method);
++    }
++
++    @Override
++    final public boolean equals(Object obj) {
++        if(this == obj) return true;
++        if(!(obj instanceof EventMethodExecutor)) return false;
++        final EventMethodExecutor that = (EventMethodExecutor) obj;
++        return this.meta.equals(that.meta) &&
++               this.method.equals(that.method);
++    }
++
++    @Override
++    public String toString() {
++        return getClass().getSimpleName() +
++               "{meta=" + meta +
++               " method=" + method +
++               "}";
++    }
++
++    /**
++     * Reflect on the given {@link Method} and create a {@link EventMethodExecutor} for it,
++     * using the method's signature and annotations.
++     *
++     * If the method is not annotated as an {@link EventHandler}, return null.
++     */
++    public static @Nullable EventMethodExecutor forMethod(Method method, ExceptionHandler exceptionHandler) {
++        final EventHandlerMeta<?> meta = EventHandlerMeta.forMethod(method);
++        if(meta == null) return null;
++        return new EventMethodExecutor<>(meta, method, exceptionHandler);
++    }
++
++    /**
++     * Create {@link EventMethodExecutor}s for all event handler methods found in the given {@link Listener} class.
++     *
++     * This includes any methods inherited from superclasses or interfaces.
++     */
++    public static Stream<EventMethodExecutor<?>> forMethods(Class<? extends Listener> listener, ExceptionHandler exceptionHandler) {
++        return Stream.concat(
++            Stream.of(listener.getDeclaredMethods())
++                  .map(method -> forMethod(method, exceptionHandler))
++                  .filter(Objects::nonNull),
++            Stream.concat(Stream.of(listener.getSuperclass()),
++                          Stream.of(listener.getInterfaces()))
++                  .filter(ancestor -> ancestor != null && Listener.class.isAssignableFrom(ancestor))
++                  .flatMap(ancestor -> forMethods((Class<? extends Listener>) ancestor, exceptionHandler))
++        );
++    }
++}
+diff --git a/src/main/java/org/bukkit/event/EventRegistry.java b/src/main/java/org/bukkit/event/EventRegistry.java
+new file mode 100644
+index 0000000..d10b10d
+--- /dev/null
++++ b/src/main/java/org/bukkit/event/EventRegistry.java
+@@ -0,0 +1,98 @@
++package org.bukkit.event;
++
++import java.lang.reflect.Method;
++import java.util.stream.Stream;
++import javax.annotation.Nullable;
++
++import org.bukkit.exception.ExceptionHandler;
++import org.bukkit.plugin.EventExecutor;
++
++/**
++ * Service used to reflectively create and register {@link RegisteredHandler}s for {@link Listener}s.
++ *
++ * Handlers created through an {@link EventRegistry} retain a reference to that registry,
++ * allowing them to be unregistered all at once.
++ *
++ * An {@link EventRegistry} has an implicit {@link ExceptionHandler} that it uses to
++ * construct handlers, though this is not exposed in the base API.
++ */
++public interface EventRegistry {
++
++    /**
++     * Create a {@link EventMethodExecutor} wrapping the given method.
++     *
++     * The method is not checked for annotations. The handler parameters
++     * are derived exclusively from the given {@link EventHandlerMeta}.
++     *
++     * @throws IllegalArgumentException if the method signature is not
++     *         compatible with the event parameters.
++     */
++    <T extends Event> EventMethodExecutor<T> createHandler(EventHandlerMeta<T> meta, Method method);
++
++    /**
++     * Reflect on the given {@link Method} and create a {@link EventMethodExecutor} for it,
++     * using the method's signature and annotations.
++     *
++     * If the method is not annotated as an {@link EventHandler}, return null.
++     *
++     * @throws IllegalArgumentException if the method signature is not
++     *         compatible with the event parameters.
++     */
++    @Nullable EventMethodExecutor<?> createHandler(Method method);
++
++    /**
++     * Create a {@link BoundEventHandler} binding the given {@link EventExecutor} to the given {@link Listener}.
++     *
++     * This only creates the handler, it does not register it to receive any events.
++     *
++     * TODO: The executor could be created from a different registry.
++     * It's hard to prevent this while still supporting the old API.
++     */
++    <T extends Event> BoundEventHandler<T> bindHandler(EventHandlerMeta<T> meta, EventExecutor<T> executor, Listener listener);
++
++    /**
++     * Create a {@link BoundEventHandler} binding the given {@link EventMethodExecutor} to the given {@link Listener}.
++     *
++     * This only creates the handler, it does not register it to receive any events.
++     *
++     * @throws IllegalArgumentException if the method does not belong to the listener
++     *
++     * TODO: The executor could be created from a different registry.
++     * It's hard to prevent this while still supporting the old API.
++     */
++    <T extends Event> BoundEventHandler<T> bindHandler(EventMethodExecutor<T> executor, Listener listener);
++
++    /**
++     * Create {@link EventMethodExecutor}s for all event handler methods found in the given {@link Listener} class.
++     *
++     * This includes any methods inherited from superclasses or interfaces.
++     */
++    Stream<EventMethodExecutor<?>> createHandlers(Class<? extends Listener> listener);
++
++    /**
++     * Create {@link BoundEventHandler}s for all event handler methods found in the given {@link Listener}.
++     *
++     * This includes any methods inherited from superclasses or interfaces.
++     *
++     * @see #createHandlers
++     */
++    Stream<BoundEventHandler<?>> bindHandlers(Listener listener);
++
++    /**
++     * Register all event handler methods found in the given {@link Listener} to receive events.
++     *
++     * @see #createHandlers
++     */
++    void registerListener(Listener listener);
++
++    /**
++     * Unregister all event handlers created from this {@link EventRegistry}
++     * that belong to the given {@link Listener}.
++     */
++    void unregisterListener(Listener listener);
++
++    /**
++     * Unregister all event handlers created from this {@link EventRegistry}.
++     */
++    void unregisterAll();
++}
+diff --git a/src/main/java/org/bukkit/event/HandlerList.java b/src/main/java/org/bukkit/event/HandlerList.java
+index 7d5efff..821220a 100644
+--- a/src/main/java/org/bukkit/event/HandlerList.java
++++ b/src/main/java/org/bukkit/event/HandlerList.java
+@@ -1,33 +1,33 @@
+ package org.bukkit.event;
+ 
+-import org.bukkit.plugin.Plugin;
+-import org.bukkit.plugin.RegisteredListener;
++import org.bukkit.plugin.*;
+ 
+ import java.util.*;
+ import java.util.Map.Entry;
++import java.util.function.Predicate;
+ 
+ /**
+  * A list of event handlers, stored per-event. Based on lahwran's fevents.
+  */
+-public class HandlerList {
++public class HandlerList<T extends Event> {
+ 
+     /**
+      * Handler array. This field being an array is the key to this system's
+      * speed.
+      */
+-    private volatile RegisteredListener[] handlers = null;
++    private volatile RegisteredHandler<? super T>[] handlers = null;
+ 
+     /**
+      * Dynamic handler lists. These are changed using register() and
+      * unregister() and are automatically baked to the handlers array any time
+      * they have changed.
+      */
+-    private final EnumMap<EventPriority, ArrayList<RegisteredListener>> handlerslots;
++    private final EnumMap<EventPriority, List<RegisteredHandler<? super T>>> handlerslots;
+ 
+     /**
+      * List of all HandlerLists which have been created, for use in bakeAll()
+      */
+-    private static ArrayList<HandlerList> allLists = new ArrayList<HandlerList>();
++    private static final ArrayList<HandlerList<?>> allLists = new ArrayList<>();
+ 
+     /**
+      * Bake all handler lists. Best used just after all normal event
+@@ -47,11 +47,9 @@ public class HandlerList {
+      */
+     public static void unregisterAll() {
+         synchronized (allLists) {
+-            for (HandlerList h : allLists) {
++            for (HandlerList<?> h : allLists) {
+                 synchronized (h) {
+-                    for (List<RegisteredListener> list : h.handlerslots.values()) {
+-                        list.clear();
+-                    }
++                    h.handlerslots.values().forEach(List::clear);
+                     h.handlers = null;
+                 }
+             }
+@@ -64,11 +62,8 @@ public class HandlerList {
+      * @param plugin plugin to unregister
+      */
+     public static void unregisterAll(Plugin plugin) {
+-        synchronized (allLists) {
+-            for (HandlerList h : allLists) {
+-                h.unregister(plugin);
+-            }
+-        }
++        unregisterAll(handler -> handler instanceof RegisteredListener &&
++                                 plugin == ((RegisteredListener) handler).getPlugin());
+     }
+ 
+     /**
+@@ -77,9 +72,14 @@ public class HandlerList {
+      * @param listener listener to unregister
+      */
+     public static void unregisterAll(Listener listener) {
+-        synchronized (allLists) {
+-            for (HandlerList h : allLists) {
+-                h.unregister(listener);
++        unregisterAll(handler -> handler instanceof BoundEventHandler &&
++                                 listener == ((BoundEventHandler) handler).listener());
++    }
++
++    public static void unregisterAll(Predicate<RegisteredHandler<?>> filter) {
++        synchronized(allLists) {
++            for(HandlerList<?> list : allLists) {
++                list.unregister(filter);
+             }
+         }
+     }
+@@ -90,9 +90,9 @@ public class HandlerList {
+      * The HandlerList is then added to meta-list for use in bakeAll()
+      */
+     public HandlerList() {
+-        handlerslots = new EnumMap<EventPriority, ArrayList<RegisteredListener>>(EventPriority.class);
++        handlerslots = new EnumMap<>(EventPriority.class);
+         for (EventPriority o : EventPriority.values()) {
+-            handlerslots.put(o, new ArrayList<RegisteredListener>());
++            handlerslots.put(o, new ArrayList<>());
+         }
+         synchronized (allLists) {
+             allLists.add(this);
+@@ -102,22 +102,30 @@ public class HandlerList {
+     /**
+      * Register a new listener in this handler list
+      *
+-     * @param listener listener to register
++     * @param handler listener to register
+      */
+-    public synchronized void register(RegisteredListener listener) {
+-        if (handlerslots.get(listener.getPriority()).contains(listener))
+-            throw new IllegalStateException("This listener is already registered to priority " + listener.getPriority().toString());
++    public synchronized void register(RegisteredHandler<? super T> handler) {
++        final EventPriority priority = handler.meta().priority();
++        if(handlerslots.get(priority).contains(handler)) {
++            throw new IllegalStateException("Event handler " + handler +
++                                            " is already registered at priority " + priority);
++        }
+         handlers = null;
+-        handlerslots.get(listener.getPriority()).add(listener);
++        handlerslots.get(priority).add(handler);
++    }
++
++    // For legacy binary compatibility
++    public synchronized void register(RegisteredListener listener) {
++        register((RegisteredHandler) listener);
+     }
+ 
+     /**
+      * Register a collection of new listeners in this handler list
+      *
+-     * @param listeners listeners to register
++     * @param handlers listeners to register
+      */
+-    public void registerAll(Collection<RegisteredListener> listeners) {
+-        for (RegisteredListener listener : listeners) {
++    public void registerAll(Collection<RegisteredHandler<? super T>> handlers) {
++        for(RegisteredHandler<? super T> listener : handlers) {
+             register(listener);
+         }
+     }
+@@ -125,10 +133,10 @@ public class HandlerList {
+     /**
+      * Remove a listener from a specific order slot
+      *
+-     * @param listener listener to remove
++     * @param handler listener to remove
+      */
+-    public synchronized void unregister(RegisteredListener listener) {
+-        if (handlerslots.get(listener.getPriority()).remove(listener)) {
++    public synchronized void unregister(RegisteredHandler<? super T> handler) {
++        if(handlerslots.get(handler.meta().priority()).remove(handler)) {
+             handlers = null;
+         }
+     }
+@@ -139,16 +147,20 @@ public class HandlerList {
+      * @param plugin plugin to remove
+      */
+     public synchronized void unregister(Plugin plugin) {
++        unregister(el -> el instanceof RegisteredListener && ((RegisteredListener) el).getPlugin().equals(plugin));
++    }
++
++    public synchronized void unregister(Predicate<? super RegisteredHandler<? super T>> filter) {
+         boolean changed = false;
+-        for (List<RegisteredListener> list : handlerslots.values()) {
+-            for (ListIterator<RegisteredListener> i = list.listIterator(); i.hasNext();) {
+-                if (i.next().getPlugin().equals(plugin)) {
++        for(List<RegisteredHandler<? super T>> list : handlerslots.values()) {
++            for(ListIterator<RegisteredHandler<? super T>> i = list.listIterator(); i.hasNext();) {
++                if (filter.test(i.next())) {
+                     i.remove();
+                     changed = true;
+                 }
+             }
+         }
+-        if (changed) handlers = null;
++        if(changed) handlers = null;
+     }
+ 
+     /**
+@@ -157,28 +169,15 @@ public class HandlerList {
+      * @param listener listener to remove
+      */
+     public synchronized void unregister(Listener listener) {
+-        boolean changed = false;
+-        for (List<RegisteredListener> list : handlerslots.values()) {
+-            for (ListIterator<RegisteredListener> i = list.listIterator(); i.hasNext();) {
+-                if (i.next().getListener().equals(listener)) {
+-                    i.remove();
+-                    changed = true;
+-                }
+-            }
+-        }
+-        if (changed) handlers = null;
++        unregister(handler -> handler instanceof BoundEventHandler &&
++                              listener == ((BoundEventHandler) handler).listener());
+     }
+ 
+     /**
+      * Bake HashMap and ArrayLists to 2d array - does nothing if not necessary
+      */
+-    public synchronized void bake() {
+-        if (handlers != null) return; // don't re-bake when still valid
+-        List<RegisteredListener> entries = new ArrayList<RegisteredListener>();
+-        for (Entry<EventPriority, ArrayList<RegisteredListener>> entry : handlerslots.entrySet()) {
+-            entries.addAll(entry.getValue());
+-        }
+-        handlers = entries.toArray(new RegisteredListener[entries.size()]);
++    public void bake() {
++        getRegisteredListeners();
+     }
+ 
+     /**
+@@ -186,10 +185,25 @@ public class HandlerList {
+      *
+      * @return the array of registered listeners
+      */
+-    public RegisteredListener[] getRegisteredListeners() {
+-        RegisteredListener[] handlers;
+-        while ((handlers = this.handlers) == null) bake(); // This prevents fringe cases of returning null
+-        return handlers;
++    public RegisteredHandler<? super T>[] getRegisteredListeners() {
++        // Try without locking first
++        RegisteredHandler<? super T>[] handlers = this.handlers;
++        if(handlers != null) return handlers;
++
++        synchronized(this) {
++            handlers = this.handlers;
++            if(handlers != null) return handlers;
++
++            handlers = new RegisteredHandler[handlerslots.values().stream().mapToInt(List::size).sum()];
++            int i = 0;
++            for (Entry<EventPriority, List<RegisteredHandler<? super T>>> entry : handlerslots.entrySet()) {
++                for(RegisteredHandler<? super T> handler : entry.getValue()) {
++                    handlers[i++] = handler;
++                }
++            }
++            this.handlers = handlers;
++            return handlers;
++        }
+     }
+ 
+     /**
+@@ -200,21 +214,26 @@ public class HandlerList {
+      * @return the list of registered listeners
+      */
+     public static ArrayList<RegisteredListener> getRegisteredListeners(Plugin plugin) {
+-        ArrayList<RegisteredListener> listeners = new ArrayList<RegisteredListener>();
+-        synchronized (allLists) {
+-            for (HandlerList h : allLists) {
+-                synchronized (h) {
+-                    for (List<RegisteredListener> list : h.handlerslots.values()) {
+-                        for (RegisteredListener listener : list) {
+-                            if (listener.getPlugin().equals(plugin)) {
+-                                listeners.add(listener);
+-                            }
+-                        }
++        final ArrayList<RegisteredListener> results = new ArrayList<RegisteredListener>();
++        synchronized(allLists) {
++            for(HandlerList<?> list : allLists) {
++                list.collectRegisteredListeners(plugin, results);
++            }
++        }
++        return results;
++    }
++
++    private synchronized void collectRegisteredListeners(Plugin plugin, List<RegisteredListener> results) {
++        for(List<RegisteredHandler<? super T>> handlers : handlerslots.values()) {
++            for(RegisteredHandler<? super T> handler : handlers) {
++                if(handler instanceof RegisteredListener) {
++                    final RegisteredListener rl = (RegisteredListener) handler;
++                    if(plugin.equals(rl.getPlugin())) {
++                        results.add(rl);
+                     }
+                 }
+             }
+         }
+-        return listeners;
+     }
+ 
+     /**
+diff --git a/src/main/java/org/bukkit/event/RegisteredHandler.java b/src/main/java/org/bukkit/event/RegisteredHandler.java
+new file mode 100644
+index 0000000..bd0a7be
+--- /dev/null
++++ b/src/main/java/org/bukkit/event/RegisteredHandler.java
+@@ -0,0 +1,22 @@
++package org.bukkit.event;
++
++import javax.annotation.Nullable;
++
++/**
++ * An event handler, i.e. an {@link EventCallable} that intercepts {@link Event}s.
++ */
++public interface RegisteredHandler<T extends Event> extends EventCallable<T> {
++
++    EventHandlerMeta<T> meta();
++
++    @Override
++    void callEvent(T event) throws EventException;
++
++    default boolean isEnabled() {
++        return true;
++    }
++
++    default boolean canHandle(Event event, @Nullable EventPriority priority) {
++        return isEnabled() && meta().canHandle(event, priority);
++    }
++}
+diff --git a/src/main/java/org/bukkit/event/SimpleEventBus.java b/src/main/java/org/bukkit/event/SimpleEventBus.java
+new file mode 100644
+index 0000000..5d1149d
+--- /dev/null
++++ b/src/main/java/org/bukkit/event/SimpleEventBus.java
+@@ -0,0 +1,126 @@
++package org.bukkit.event;
++
++import javax.annotation.Nullable;
++
++public class SimpleEventBus implements EventBus {
++
++    private final Thread primaryThread;
++    private final Object lock;
++
++    public SimpleEventBus() {
++        this(null, null);
++    }
++
++    public SimpleEventBus(@Nullable Thread primaryThread, @Nullable Object lock) {
++        this.primaryThread = primaryThread != null ? primaryThread : Thread.currentThread();
++        this.lock = lock != null ? lock : new Object();
++    }
++
++    public Object lock() {
++        return lock;
++    }
++
++    @Override
++    public void callEvent(Event event) {
++        callEvent(event, null, null);
++    }
++
++    @Override
++    public void callEvent(Event event, @Nullable EventPriority priority) {
++        callEvent(event, priority, null);
++    }
++
++    @Override
++    public <T extends Event, X extends Throwable> void callEvent(T event, @Nullable EventBody<? super T, X> body) throws X {
++        callEvent(event, null, body);
++    }
++
++    @Override
++    public <T extends Event, X extends Throwable> void callEvent(T event, @Nullable EventPriority priority, @Nullable EventBody<? super T, X> body) throws X {
++        if(event.isAsynchronous()) {
++            if(Thread.holdsLock(lock)) {
++                throw new IllegalStateException(event.getEventName() + " cannot be called asynchronously from inside synchronized code.");
++            }
++            if(Thread.currentThread().equals(primaryThread)) {
++                throw new IllegalStateException(event.getEventName() + " cannot be called asynchronously from primary thread.");
++            }
++            callEvent0(event, priority, body);
++        } else {
++            synchronized(this) {
++                callEvent0(event, priority, body);
++            }
++        }
++    }
++
++    public <T extends Event, X extends Throwable> void callEvent0(T event, @Nullable EventPriority priority, @Nullable EventBody<? super T, X> body) throws X {
++        if(event.dispatching) {
++            throw new IllegalStateException(event.getEventName() + " is already being called");
++        }
++
++        event.dispatching = true;
++        try {
++            callEvent0(event, priority, event.getHandlers().getRegisteredListeners(), 0, body);
++        } catch(EventException e) {
++            throw (X) e.getCause();
++        } finally {
++            event.dispatching = false;
++        }
++    }
++
++    private <T extends Event, X extends Throwable> void callEvent0(T event, @Nullable EventPriority priority, RegisteredHandler<? super T>[] handlers, int index, @Nullable EventBody<? super T, X> body) throws EventException {
++        for(int i = index; i < handlers.length; i++) {
++            final RegisteredHandler<? super T> handler = handlers[i];
++            if(handler.canHandle(event, priority)) {
++                // When calling a handler, pass a continuation that recurses into this method
++                // with the current index, which will continue the loop. If the handler yields
++                // (which makes callEventHandler0 return true), then return immediately, since
++                // the nested call will have already finished the entire dispatch process.
++
++                // By only recursing when the handler yields, we avoid unnecessary stack growth,
++                // which can be appreciated when reading stack traces.
++
++                final int nextIndex = i + 1;
++                if(callEventHandler0(event, handler, ev -> callEvent0(event, priority, handlers, nextIndex, body))) return;
++            }
++        }
++
++        // If we get here, it means we got to the end of the handler array without any handler yielding.
++        // This will happen exactly once per event, in the inner-most call to this method. Any outer calls
++        // will return early in the loop above.
++        if(body != null) {
++            try {
++                body.callEvent(event);
++            } catch(Throwable ex) {
++                // Exceptions from the event body are wrapped and thrown all the way back
++                // to the start of the dispatch, where they are unwrapped and rethrown.
++                // For this to work, any yielding handlers need to let the EventException
++                // propagate from the yield() method.
++                throw new EventException(ex, event);
++            }
++        }
++    }
++
++    @Override
++    public <T extends Event, X extends Throwable> boolean callEventHandler(T event, @Nullable EventPriority priority, RegisteredHandler<? super T> handler, @Nullable EventBody<? super T, X> body) throws X {
++        if(handler.canHandle(event, priority)) {
++            try {
++                return callEventHandler0(event, handler, body);
++            } catch(EventException e) {
++                throw (X) e.getCause();
++            }
++        }
++        return false;
++    }
++
++    private <T extends Event> boolean callEventHandler0(T event, RegisteredHandler<? super T> handler, @Nullable EventCallable yielder) throws EventException {
++        final EventCallable oldYielder = event.yielder;
++        if(yielder == null) yielder = EventCallable.EMPTY;
++        event.yielder = yielder;
++        try {
++            handler.callEvent(event);
++            return event.yielder != yielder;
++        } finally {
++            event.yielder = oldYielder;
++        }
++    }
++}
+diff --git a/src/main/java/org/bukkit/event/SimpleEventRegistry.java b/src/main/java/org/bukkit/event/SimpleEventRegistry.java
+new file mode 100644
+index 0000000..94a7b90
+--- /dev/null
++++ b/src/main/java/org/bukkit/event/SimpleEventRegistry.java
+@@ -0,0 +1,87 @@
++package org.bukkit.event;
++
++import java.lang.reflect.Method;
++import java.util.stream.Stream;
++import javax.annotation.Nullable;
++
++import org.bukkit.exception.ExceptionHandler;
++import org.bukkit.exception.LoggingExceptionHandler;
++import org.bukkit.plugin.EventExecutor;
++
++public class SimpleEventRegistry implements EventRegistry {
++
++    private final ExceptionHandler exceptionHandler;
++
++    public SimpleEventRegistry() {
++        this(null);
++    }
++
++    public SimpleEventRegistry(@Nullable ExceptionHandler exceptionHandler) {
++        this.exceptionHandler = exceptionHandler != null ? exceptionHandler
++                                                         : LoggingExceptionHandler.forGlobalLogger();
++    }
++
++    @Override
++    public <T extends Event> BoundEventHandler<T> bindHandler(EventHandlerMeta<T> meta, EventExecutor<T> executor, Listener listener) {
++        return new OwnedEventHandler<>(meta, executor, listener);
++    }
++
++    @Override
++    public <T extends Event> BoundEventHandler<T> bindHandler(EventMethodExecutor<T> executor, Listener listener) {
++        return new OwnedEventHandler<>(executor, listener);
++    }
++
++    @Override
++    public <T extends Event> EventMethodExecutor<T> createHandler(EventHandlerMeta<T> meta, Method method) {
++        return new EventMethodExecutor<>(meta, method, exceptionHandler);
++    }
++
++    @Override
++    public EventMethodExecutor<?> createHandler(Method method) {
++        return EventMethodExecutor.forMethod(method, exceptionHandler);
++    }
++
++    @Override
++    public Stream<EventMethodExecutor<?>> createHandlers(Class<? extends Listener> listener) {
++        return EventMethodExecutor.forMethods(listener, exceptionHandler);
++    }
++
++    @Override
++    public Stream<BoundEventHandler<?>> bindHandlers(Listener listener) {
++        return createHandlers(listener.getClass())
++            .map(unbound -> bindHandler(unbound, listener));
++    }
++
++    @Override
++    public void registerListener(Listener listener) {
++        bindHandlers(listener).forEach(handler -> Event.register(handler));
++    }
++
++    @Override
++    public void unregisterListener(Listener listener) {
++        HandlerList.unregisterAll(handler -> handler instanceof OwnedEventHandler &&
++                                             this == ((OwnedEventHandler) handler).registry() &&
++                                             listener == ((OwnedEventHandler) handler).listener());
++    }
++
++    @Override
++    public void unregisterAll() {
++        HandlerList.unregisterAll(handler -> handler instanceof OwnedEventHandler &&
++                                             this == ((OwnedEventHandler) handler).registry());
++    }
++
++    private class OwnedEventHandler<T extends Event> extends BoundEventHandler<T> {
++
++        public OwnedEventHandler(EventMethodExecutor<T> executor, Listener listener) {
++            super(executor, listener);
++        }
++
++        public OwnedEventHandler(EventHandlerMeta<T> meta, EventExecutor<T> executor, Listener listener) {
++            super(meta, executor, listener);
++        }
++
++        SimpleEventRegistry registry() {
++            return SimpleEventRegistry.this;
++        }
++    }
++}
+diff --git a/src/main/java/org/bukkit/exception/ExceptionHandler.java b/src/main/java/org/bukkit/exception/ExceptionHandler.java
+new file mode 100644
+index 0000000..fc1acc1
+--- /dev/null
++++ b/src/main/java/org/bukkit/exception/ExceptionHandler.java
+@@ -0,0 +1,15 @@
++package org.bukkit.exception;
++
++/**
++ * An object that encapsulates the handling of exceptions.
++ *
++ * Think of it as a catch block wrapper.
++ */
++public interface ExceptionHandler {
++
++    void handleException(Throwable exception, String message);
++
++    default void handleException(Throwable exception) {
++        handleException(exception, "Uncaught exception");
++    }
++}
+diff --git a/src/main/java/org/bukkit/exception/LoggingExceptionHandler.java b/src/main/java/org/bukkit/exception/LoggingExceptionHandler.java
+new file mode 100644
+index 0000000..a446e2f
+--- /dev/null
++++ b/src/main/java/org/bukkit/exception/LoggingExceptionHandler.java
+@@ -0,0 +1,29 @@
++package org.bukkit.exception;
++
++import java.util.logging.Level;
++import java.util.logging.Logger;
++
++import static com.google.common.base.Preconditions.checkNotNull;
++
++public class LoggingExceptionHandler implements ExceptionHandler {
++
++    private final Logger logger;
++
++    public LoggingExceptionHandler(Logger logger) {
++        this.logger = checkNotNull(logger);
++    }
++
++    @Override
++    public void handleException(Throwable exception, String message) {
++        logger.log(Level.SEVERE, message, exception);
++    }
++
++    public static LoggingExceptionHandler forGlobalLogger() {
++        if(GLOBAL == null) {
++            GLOBAL = new LoggingExceptionHandler(Logger.getGlobal());
++        }
++        return GLOBAL;
++    }
++
++    private static LoggingExceptionHandler GLOBAL;
++}
+diff --git a/src/main/java/org/bukkit/exception/PluginExceptionHandler.java b/src/main/java/org/bukkit/exception/PluginExceptionHandler.java
+new file mode 100644
+index 0000000..b51c190
+--- /dev/null
++++ b/src/main/java/org/bukkit/exception/PluginExceptionHandler.java
+@@ -0,0 +1,33 @@
++package org.bukkit.exception;
++
++import java.util.logging.Level;
++
++import org.bukkit.plugin.AuthorNagException;
++import org.bukkit.plugin.Plugin;
++
++public class PluginExceptionHandler extends LoggingExceptionHandler {
++
++    private final Plugin plugin;
++
++    public PluginExceptionHandler(Plugin plugin) {
++        super(plugin.getLogger());
++        this.plugin = plugin;
++    }
++
++    @Override
++    public void handleException(Throwable exception, String message) {
++        if(exception instanceof AuthorNagException) {
++            if (plugin.isNaggable()) {
++                plugin.setNaggable(false);
++
++                plugin.getLogger().log(Level.SEVERE, String.format(
++                    "Nag author(s): '%s' of '%s' about the following: %s",
++                    plugin.getDescription().getAuthors(),
++                    plugin.getDescription().getFullName(),
++                    exception.getMessage()
++                ));
++            }
++        }
++        super.handleException(exception, message);
++    }
++}
+diff --git a/src/main/java/org/bukkit/plugin/EventExecutor.java b/src/main/java/org/bukkit/plugin/EventExecutor.java
+index 3b2c99e..b21e408 100644
+--- a/src/main/java/org/bukkit/plugin/EventExecutor.java
++++ b/src/main/java/org/bukkit/plugin/EventExecutor.java
+@@ -5,8 +5,9 @@ import org.bukkit.event.EventException;
+ import org.bukkit.event.Listener;
+ 
+ /**
+- * Interface which defines the class for event call backs to plugins
++ * An event handler that belongs to a {@link Listener}, and must be passed an
++ * instance of the listener when handling an event.
+  */
+-public interface EventExecutor {
+-    public void execute(Listener listener, Event event) throws EventException;
++public interface EventExecutor<T extends Event> {
++    void execute(Listener listener, T event) throws EventException;
+ }
+diff --git a/src/main/java/org/bukkit/plugin/Plugin.java b/src/main/java/org/bukkit/plugin/Plugin.java
+index 0d21654..08e434c 100644
+--- a/src/main/java/org/bukkit/plugin/Plugin.java
++++ b/src/main/java/org/bukkit/plugin/Plugin.java
+@@ -7,6 +7,8 @@ import java.util.logging.Logger;
+ import org.bukkit.Server;
+ import org.bukkit.command.TabExecutor;
+ import org.bukkit.configuration.file.FileConfiguration;
++import org.bukkit.event.EventRegistry;
++import org.bukkit.exception.ExceptionHandler;
+ import org.bukkit.generator.ChunkGenerator;
+ 
+ import com.avaje.ebean.EbeanServer;
+@@ -93,6 +95,17 @@ public interface Plugin extends TabExecutor, tc.oc.minecraft.api.plugin.Plugin,
+     public PluginLoader getPluginLoader();
+ 
+     /**
++     * @return The {@link EventRegistry} belonging to this plugin.
++     */
++    EventRegistry eventRegistry();
++
++    /**
++     * @return An {@link ExceptionHandler} that canbe used to report
++     *         exceptions related to this plugin.
++     */
++    ExceptionHandler exceptionHandler();
++
++    /**
+      * Returns the Server instance currently running this plugin
+      *
+      * @return Server running this plugin
+diff --git a/src/main/java/org/bukkit/plugin/PluginEventRegistry.java b/src/main/java/org/bukkit/plugin/PluginEventRegistry.java
+new file mode 100644
+index 0000000..dcec1fb
+--- /dev/null
++++ b/src/main/java/org/bukkit/plugin/PluginEventRegistry.java
+@@ -0,0 +1,54 @@
++package org.bukkit.plugin;
++
++import org.bukkit.event.Event;
++import org.bukkit.event.EventHandlerMeta;
++import org.bukkit.event.EventMethodExecutor;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.Listener;
++import org.bukkit.event.SimpleEventRegistry;
++
++public class PluginEventRegistry extends SimpleEventRegistry {
++
++    private final Plugin plugin;
++
++    public PluginEventRegistry(Plugin plugin) {
++        super(plugin.exceptionHandler());
++        this.plugin = plugin;
++    }
++
++    @Override
++    public void registerListener(Listener listener) {
++        if(!plugin.isEnabled()) {
++            throw new IllegalPluginAccessException(
++                "Plugin " + plugin.getDescription().getFullName() +
++                " attempted to register event listener while not enabled"
++            );
++        }
++        super.registerListener(listener);
++    }
++
++    @Override
++    public <T extends Event> RegisteredListener bindHandler(EventHandlerMeta<T> meta, EventExecutor<T> executor, Listener listener) {
++        return plugin.getServer().pluginProfiling()
++               ? new TimedRegisteredListener(meta, executor, listener, plugin, this)
++               : new RegisteredListener(meta, executor, listener, plugin, this);
++    }
++
++    @Override
++    public <T extends Event> RegisteredListener bindHandler(EventMethodExecutor<T> executor, Listener listener) {
++        return bindHandler(executor.meta(), executor, listener);
++    }
++
++    @Override
++    public void unregisterListener(Listener listener) {
++        HandlerList.unregisterAll(handler -> handler instanceof RegisteredListener &&
++                                             this == ((RegisteredListener) handler).registry &&
++                                             listener == ((RegisteredListener) handler).listener());
++    }
++
++    @Override
++    public void unregisterAll() {
++        HandlerList.unregisterAll(handler -> handler instanceof RegisteredListener &&
++                                             this == ((RegisteredListener) handler).registry);
++    }
++}
+diff --git a/src/main/java/org/bukkit/plugin/PluginManager.java b/src/main/java/org/bukkit/plugin/PluginManager.java
+index 15f6218..d52a971 100644
+--- a/src/main/java/org/bukkit/plugin/PluginManager.java
++++ b/src/main/java/org/bukkit/plugin/PluginManager.java
+@@ -5,16 +5,16 @@ import java.util.Set;
+ 
+ import org.bukkit.event.Event;
+ import org.bukkit.event.EventPriority;
++import org.bukkit.event.HandlerList;
+ import org.bukkit.event.Listener;
+ import org.bukkit.permissions.Permissible;
+ import org.bukkit.permissions.Permission;
+-import tc.oc.minecraft.api.event.EventBus;
+ import tc.oc.minecraft.api.plugin.PluginFinder;
+ 
+ /**
+  * Handles all plugin management from the Server
+  */
+-public interface PluginManager extends PluginFinder, EventBus {
++public interface PluginManager extends PluginFinder, tc.oc.minecraft.api.event.EventBus {
+ 
+     /**
+      * Registers the specified plugin loader
+@@ -137,6 +137,21 @@ public interface PluginManager extends PluginFinder, EventBus {
+      */
+     public void registerEvent(Class<? extends Event> event, Listener listener, EventPriority priority, EventExecutor executor, Plugin plugin, boolean ignoreCancelled);
+ 
++    @Override
++    default void registerListener(tc.oc.minecraft.api.plugin.Plugin plugin, tc.oc.minecraft.api.event.Listener listener) {
++        registerEvents((Listener) listener, (Plugin) plugin);
++    }
++
++    @Override
++    default void unregisterListener(tc.oc.minecraft.api.event.Listener listener) {
++        HandlerList.unregisterAll((Listener) listener);
++    }
++
++    @Override
++    default void unregisterListeners(tc.oc.minecraft.api.plugin.Plugin plugin) {
++        HandlerList.unregisterAll((Plugin) plugin);
++    }
++
+     /**
+      * Enables the specified plugin
+      * <p>
+diff --git a/src/main/java/org/bukkit/plugin/RegisteredListener.java b/src/main/java/org/bukkit/plugin/RegisteredListener.java
+index 9dd0b7a..66092a7 100644
+--- a/src/main/java/org/bukkit/plugin/RegisteredListener.java
++++ b/src/main/java/org/bukkit/plugin/RegisteredListener.java
+@@ -1,32 +1,31 @@
+ package org.bukkit.plugin;
+ 
++import javax.annotation.Nullable;
++
+ import org.bukkit.event.*;
+ 
+ /**
+- * Stores relevant information for plugin listeners
++ * A {@link BoundEventHandler} belonging to a particular {@link Plugin}.
++ *
++ * @deprecated legacy compatibility
+  */
+-public class RegisteredListener {
+-    private final Listener listener;
+-    private final EventPriority priority;
++@Deprecated
++public class RegisteredListener extends BoundEventHandler {
++
+     private final Plugin plugin;
+-    private final EventExecutor executor;
+-    private final boolean ignoreCancelled;
++    final @Nullable PluginEventRegistry registry;
+ 
++    // This constructor is for upstream compatibility
+     public RegisteredListener(final Listener listener, final EventExecutor executor, final EventPriority priority, final Plugin plugin, final boolean ignoreCancelled) {
+-        this.listener = listener;
+-        this.priority = priority;
++        super(new EventHandlerMeta<>(Event.class, priority, ignoreCancelled), executor, listener);
+         this.plugin = plugin;
+-        this.executor = executor;
+-        this.ignoreCancelled = ignoreCancelled;
++        this.registry = null;
+     }
+ 
+-    /**
+-     * Gets the listener for this registration
+-     *
+-     * @return Registered Listener
+-     */
+-    public Listener getListener() {
+-        return listener;
++    RegisteredListener(EventHandlerMeta meta, EventExecutor executor, Listener listener, Plugin plugin, PluginEventRegistry registry) {
++        super(meta, executor, listener);
++        this.plugin = plugin;
++        this.registry = registry;
+     }
+ 
+     /**
+@@ -38,36 +37,13 @@ public class RegisteredListener {
+         return plugin;
+     }
+ 
+-    /**
+-     * Gets the priority for this registration
+-     *
+-     * @return Registered Priority
+-     */
+-    public EventPriority getPriority() {
+-        return priority;
++    @Override
++    public boolean isEnabled() {
++        return getPlugin().isEnabled();
+     }
+ 
+-    /**
+-     * Calls the event executor
+-     *
+-     * @param event The event
+-     * @throws EventException If an event handler throws an exception.
+-     */
+-    public void callEvent(final Event event) throws EventException {
+-        if (event instanceof Cancellable){
+-            if (((Cancellable) event).isCancelled() && isIgnoringCancelled()){
+-                return;
+-            }
+-        }
+-        executor.execute(listener, event);
+-    }
+-
+-     /**
+-     * Whether this listener accepts cancelled events
+-     *
+-     * @return True when ignoring cancelled events
+-     */
+-    public boolean isIgnoringCancelled() {
+-        return ignoreCancelled;
+-    }
++    // These aliases provided for legacy binary compatibility
++    public Listener getListener() { return listener(); }
++    public EventPriority getPriority() { return meta().priority(); }
++    public boolean isIgnoringCancelled() { return meta().ignoreCancelled(); }
+ }
+diff --git a/src/main/java/org/bukkit/plugin/SimplePluginManager.java b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
+index c4adbd8..877e6d6 100644
+--- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
++++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
+@@ -2,7 +2,6 @@ package org.bukkit.plugin;
+ 
+ import java.io.File;
+ import java.lang.reflect.Constructor;
+-import java.lang.reflect.Method;
+ import java.util.ArrayList;
+ import java.util.Collection;
+ import java.util.HashMap;
+@@ -25,6 +24,7 @@ import org.bukkit.command.PluginCommandYamlParser;
+ import org.bukkit.command.SimpleCommandMap;
+ import org.bukkit.configuration.serialization.ConfigurationSerialization;
+ import org.bukkit.event.Event;
++import org.bukkit.event.EventHandlerMeta;
+ import org.bukkit.event.EventPriority;
+ import org.bukkit.event.HandlerList;
+ import org.bukkit.event.Listener;
+@@ -49,7 +49,6 @@ public final class SimplePluginManager implements PluginManager {
+     private final Map<Boolean, Set<Permission>> defaultPerms = new LinkedHashMap<Boolean, Set<Permission>>();
+     private final Map<String, Map<Permissible, Boolean>> permSubs = new HashMap<String, Map<Permissible, Boolean>>();
+     private final Map<Boolean, Map<Permissible, Boolean>> defSubs = new HashMap<Boolean, Map<Permissible, Boolean>>();
+-    private boolean useTimings = false;
+ 
+     public SimplePluginManager(Server instance, SimpleCommandMap commandMap) {
+         server = instance;
+@@ -489,83 +488,13 @@ public final class SimplePluginManager implements PluginManager {
+         }
+     }
+ 
+-    /**
+-     * Calls an event with the given details.
+-     * <p>
+-     * This method only synchronizes when the event is not asynchronous.
+-     *
+-     * @param event Event details
+-     */
+-    public void callEvent(Event event) {
+-        if (event.isAsynchronous()) {
+-            if (Thread.holdsLock(this)) {
+-                throw new IllegalStateException(event.getEventName() + " cannot be triggered asynchronously from inside synchronized code.");
+-            }
+-            if (server.isPrimaryThread()) {
+-                throw new IllegalStateException(event.getEventName() + " cannot be triggered asynchronously from primary server thread.");
+-            }
+-            fireEvent(event);
+-        } else {
+-            synchronized (this) {
+-                fireEvent(event);
+-            }
+-        }
+-    }
+-
+-    private void fireEvent(Event event) {
+-        HandlerList handlers = event.getHandlers();
+-        RegisteredListener[] listeners = handlers.getRegisteredListeners();
+-
+-        for (RegisteredListener registration : listeners) {
+-            if (!registration.getPlugin().isEnabled()) {
+-                continue;
+-            }
+-
+-            try {
+-                registration.callEvent(event);
+-            } catch (AuthorNagException ex) {
+-                Plugin plugin = registration.getPlugin();
+-
+-                if (plugin.isNaggable()) {
+-                    plugin.setNaggable(false);
+-
+-                    server.getLogger().log(Level.SEVERE, String.format(
+-                            "Nag author(s): '%s' of '%s' about the following: %s",
+-                            plugin.getDescription().getAuthors(),
+-                            plugin.getDescription().getFullName(),
+-                            ex.getMessage()
+-                            ));
+-                }
+-            } catch (Throwable ex) {
+-                server.getLogger().log(Level.SEVERE, "Could not pass event " + event.getEventName() + " to " + registration.getPlugin().getDescription().getFullName(), ex);
+-            }
+-        }
+-    }
+-
+-    @Override
+-    public void registerListener(tc.oc.minecraft.api.plugin.Plugin plugin, tc.oc.minecraft.api.event.Listener listener) {
+-        registerEvents((Listener) listener, (Plugin) plugin);
+-    }
+-
+     @Override
+-    public void unregisterListener(tc.oc.minecraft.api.event.Listener listener) {
+-        HandlerList.unregisterAll((Listener) listener);
+-    }
+-
+-    @Override
+-    public void unregisterListeners(tc.oc.minecraft.api.plugin.Plugin plugin) {
+-        HandlerList.unregisterAll((Plugin) plugin);
++    public void callEvent(Event event) {
++        server.eventBus().callEvent(event);
+     }
+ 
+     public void registerEvents(Listener listener, Plugin plugin) {
+-        if (!plugin.isEnabled()) {
+-            throw new IllegalPluginAccessException("Plugin attempted to register " + listener + " while not enabled");
+-        }
+-
+-        for (Map.Entry<Class<? extends Event>, Set<RegisteredListener>> entry : plugin.getPluginLoader().createRegisteredListeners(listener, plugin).entrySet()) {
+-            getEventListeners(getRegistrationClass(entry.getKey())).registerAll(entry.getValue());
+-        }
+-
++        plugin.eventRegistry().registerListener(listener);
+     }
+ 
+     public void registerEvent(Class<? extends Event> event, Listener listener, EventPriority priority, EventExecutor executor, Plugin plugin) {
+@@ -585,45 +514,7 @@ public final class SimplePluginManager implements PluginManager {
+      *     cancelled
+      */
+     public void registerEvent(Class<? extends Event> event, Listener listener, EventPriority priority, EventExecutor executor, Plugin plugin, boolean ignoreCancelled) {
+-        Validate.notNull(listener, "Listener cannot be null");
+-        Validate.notNull(priority, "Priority cannot be null");
+-        Validate.notNull(executor, "Executor cannot be null");
+-        Validate.notNull(plugin, "Plugin cannot be null");
+-
+-        if (!plugin.isEnabled()) {
+-            throw new IllegalPluginAccessException("Plugin attempted to register " + event + " while not enabled");
+-        }
+-
+-        if (useTimings) {
+-            getEventListeners(event).register(new TimedRegisteredListener(listener, executor, priority, plugin, ignoreCancelled));
+-        } else {
+-            getEventListeners(event).register(new RegisteredListener(listener, executor, priority, plugin, ignoreCancelled));
+-        }
+-    }
+-
+-    private HandlerList getEventListeners(Class<? extends Event> type) {
+-        try {
+-            Method method = getRegistrationClass(type).getDeclaredMethod("getHandlerList");
+-            method.setAccessible(true);
+-            return (HandlerList) method.invoke(null);
+-        } catch (Exception e) {
+-            throw new IllegalPluginAccessException(e.toString());
+-        }
+-    }
+-
+-    private Class<? extends Event> getRegistrationClass(Class<? extends Event> clazz) {
+-        try {
+-            clazz.getDeclaredMethod("getHandlerList");
+-            return clazz;
+-        } catch (NoSuchMethodException e) {
+-            if (clazz.getSuperclass() != null
+-                    && !clazz.getSuperclass().equals(Event.class)
+-                    && Event.class.isAssignableFrom(clazz.getSuperclass())) {
+-                return getRegistrationClass(clazz.getSuperclass().asSubclass(Event.class));
+-            } else {
+-                throw new IllegalPluginAccessException("Unable to find handler list for event " + clazz.getName() + ". Static getHandlerList method required!");
+-            }
+-        }
++        plugin.eventRegistry().bindHandler(new EventHandlerMeta<>(event, priority, ignoreCancelled), executor, listener);
+     }
+ 
+     public Permission getPermission(String name) {
+@@ -755,15 +646,6 @@ public final class SimplePluginManager implements PluginManager {
+     }
+ 
+     public boolean useTimings() {
+-        return useTimings;
+-    }
+-
+-    /**
+-     * Sets whether or not per event timing code should be used
+-     *
+-     * @param use True if per event timing code should be used
+-     */
+-    public void useTimings(boolean use) {
+-        useTimings = use;
++        return server.pluginProfiling();
+     }
+ }
+diff --git a/src/main/java/org/bukkit/plugin/TimedRegisteredListener.java b/src/main/java/org/bukkit/plugin/TimedRegisteredListener.java
+index 164be93..23b82c6 100644
+--- a/src/main/java/org/bukkit/plugin/TimedRegisteredListener.java
++++ b/src/main/java/org/bukkit/plugin/TimedRegisteredListener.java
+@@ -2,22 +2,32 @@ package org.bukkit.plugin;
+ 
+ import org.bukkit.event.Event;
+ import org.bukkit.event.EventException;
++import org.bukkit.event.EventHandlerMeta;
++import org.bukkit.event.EventMethodExecutor;
+ import org.bukkit.event.EventPriority;
+ import org.bukkit.event.Listener;
+ 
+ /**
+  * Extends RegisteredListener to include timing information
++ *
++ * @deprecated legacy compatibility
+  */
++@Deprecated
+ public class TimedRegisteredListener extends RegisteredListener {
+     private int count;
+     private long totalTime;
+     private Class<? extends Event> eventClass;
+     private boolean multiple = false;
+ 
++    // This constructor is for upstream compatibility
+     public TimedRegisteredListener(final Listener pluginListener, final EventExecutor eventExecutor, final EventPriority eventPriority, final Plugin registeredPlugin, final boolean listenCancelled) {
+         super(pluginListener, eventExecutor, eventPriority, registeredPlugin, listenCancelled);
+     }
+ 
++    TimedRegisteredListener(EventHandlerMeta meta, EventExecutor executor, Listener listener, Plugin plugin, PluginEventRegistry registry) {
++        super(meta, executor, listener, plugin, registry);
++    }
++
+     @Override
+     public void callEvent(Event event) throws EventException {
+         if (event.isAsynchronous()) {
+diff --git a/src/main/java/org/bukkit/plugin/java/JavaPlugin.java b/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
+index 9da6dc8..d9a0ccb 100644
+--- a/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
++++ b/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
+@@ -9,7 +9,6 @@ import java.io.OutputStream;
+ import java.io.Reader;
+ import java.net.URL;
+ import java.net.URLConnection;
+-import java.nio.charset.Charset;
+ import java.util.ArrayList;
+ import java.util.List;
+ import java.util.logging.Level;
+@@ -17,16 +16,15 @@ import java.util.logging.Logger;
+ 
+ import org.apache.commons.lang.Validate;
+ import org.bukkit.Server;
+-import org.bukkit.Warning.WarningState;
+ import org.bukkit.command.Command;
+ import org.bukkit.command.CommandSender;
+ import org.bukkit.command.PluginCommand;
+-import org.bukkit.configuration.InvalidConfigurationException;
+ import org.bukkit.configuration.file.FileConfiguration;
+ import org.bukkit.configuration.file.YamlConfiguration;
++import org.bukkit.plugin.PluginEventRegistry;
++import org.bukkit.exception.ExceptionHandler;
++import org.bukkit.exception.PluginExceptionHandler;
+ import org.bukkit.generator.ChunkGenerator;
+-import org.bukkit.plugin.AuthorNagException;
+-import org.bukkit.plugin.PluginAwareness;
+ import org.bukkit.plugin.PluginBase;
+ import org.bukkit.plugin.PluginDescriptionFile;
+ import org.bukkit.plugin.PluginLoader;
+@@ -40,7 +38,6 @@ import com.avaje.ebeaninternal.api.SpiEbeanServer;
+ import com.avaje.ebeaninternal.server.ddl.DdlGenerator;
+ import com.google.common.base.Charsets;
+ import com.google.common.base.Preconditions;
+-import com.google.common.io.ByteStreams;
+ 
+ /**
+  * Represents a Java plugin
+@@ -58,6 +55,8 @@ public abstract class JavaPlugin extends PluginBase {
+     private FileConfiguration newConfig = null;
+     private File configFile = null;
+     private PluginLogger logger = null;
++    private ExceptionHandler exceptionHandler = null;
++    private PluginEventRegistry eventRegistry = null;
+ 
+     public JavaPlugin() {
+         final ClassLoader classLoader = this.getClass().getClassLoader();
+@@ -96,6 +95,16 @@ public abstract class JavaPlugin extends PluginBase {
+         return loader;
+     }
+ 
++    @Override
++    public PluginEventRegistry eventRegistry() {
++        return eventRegistry;
++    }
++
++    @Override
++    public ExceptionHandler exceptionHandler() {
++        return exceptionHandler;
++    }
++
+     /**
+      * Returns the Server instance currently running this plugin
+      *
+@@ -291,6 +300,8 @@ public abstract class JavaPlugin extends PluginBase {
+         this.classLoader = classLoader;
+         this.configFile = new File(dataFolder, "config.yml");
+         this.logger = PluginLogger.get(this);
++        this.exceptionHandler = new PluginExceptionHandler(this);
++        this.eventRegistry = new PluginEventRegistry(this);
+ 
+         if (description.isDatabaseEnabled()) {
+             ServerConfig db = new ServerConfig();
+diff --git a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
+index 6cb69ba..7f92280 100644
+--- a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
++++ b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
+@@ -4,9 +4,6 @@ import java.io.File;
+ import java.io.FileNotFoundException;
+ import java.io.IOException;
+ import java.io.InputStream;
+-import java.lang.reflect.InvocationTargetException;
+-import java.lang.reflect.Method;
+-import java.util.Arrays;
+ import java.util.HashMap;
+ import java.util.HashSet;
+ import java.util.LinkedHashMap;
+@@ -22,23 +19,16 @@ import java.util.regex.Pattern;
+ 
+ import org.apache.commons.lang.Validate;
+ import org.bukkit.Server;
+-import org.bukkit.Warning;
+-import org.bukkit.Warning.WarningState;
+ import org.bukkit.event.Event;
+-import org.bukkit.event.EventException;
+-import org.bukkit.event.EventHandler;
+ import org.bukkit.event.Listener;
+ import org.bukkit.event.server.PluginDisableEvent;
+ import org.bukkit.event.server.PluginEnableEvent;
+-import org.bukkit.plugin.AuthorNagException;
+-import org.bukkit.plugin.EventExecutor;
+ import org.bukkit.plugin.InvalidDescriptionException;
+ import org.bukkit.plugin.InvalidPluginException;
+ import org.bukkit.plugin.Plugin;
+ import org.bukkit.plugin.PluginDescriptionFile;
+ import org.bukkit.plugin.PluginLoader;
+ import org.bukkit.plugin.RegisteredListener;
+-import org.bukkit.plugin.TimedRegisteredListener;
+ import org.bukkit.plugin.UnknownDependencyException;
+ import org.yaml.snakeyaml.error.YAMLException;
+ 
+@@ -203,92 +193,12 @@ public final class JavaPluginLoader implements PluginLoader {
+     }
+ 
+     public Map<Class<? extends Event>, Set<RegisteredListener>> createRegisteredListeners(Listener listener, final Plugin plugin) {
+-        Validate.notNull(plugin, "Plugin can not be null");
+-        Validate.notNull(listener, "Listener can not be null");
+-
+-        boolean useTimings = server.getPluginManager().useTimings();
+-        Map<Class<? extends Event>, Set<RegisteredListener>> ret = new HashMap<Class<? extends Event>, Set<RegisteredListener>>();
+-        Set<Method> methods;
+-        try {
+-            Method[] publicMethods = listener.getClass().getMethods();
+-            Method[] privateMethods = listener.getClass().getDeclaredMethods();
+-            methods = new HashSet<Method>(publicMethods.length + privateMethods.length, 1.0f);
+-            for (Method method : publicMethods) {
+-                methods.add(method);
+-            }
+-            for (Method method : privateMethods) {
+-                methods.add(method);
+-            }
+-        } catch (NoClassDefFoundError e) {
+-            plugin.getLogger().severe("Plugin " + plugin.getDescription().getFullName() + " has failed to register events for " + listener.getClass() + " because " + e.getMessage() + " does not exist.");
+-            return ret;
+-        }
+-
+-        for (final Method method : methods) {
+-            final EventHandler eh = method.getAnnotation(EventHandler.class);
+-            if (eh == null) continue;
+-            // Do not register bridge or synthetic methods to avoid event duplication
+-            // Fixes SPIGOT-893
+-            if (method.isBridge() || method.isSynthetic()) {
+-                continue;
+-            }
+-            final Class<?> checkClass;
+-            if (method.getParameterTypes().length != 1 || !Event.class.isAssignableFrom(checkClass = method.getParameterTypes()[0])) {
+-                plugin.getLogger().severe(plugin.getDescription().getFullName() + " attempted to register an invalid EventHandler method signature \"" + method.toGenericString() + "\" in " + listener.getClass());
+-                continue;
+-            }
+-            final Class<? extends Event> eventClass = checkClass.asSubclass(Event.class);
+-            method.setAccessible(true);
+-            Set<RegisteredListener> eventSet = ret.get(eventClass);
+-            if (eventSet == null) {
+-                eventSet = new HashSet<RegisteredListener>();
+-                ret.put(eventClass, eventSet);
+-            }
+-
+-            for (Class<?> clazz = eventClass; Event.class.isAssignableFrom(clazz); clazz = clazz.getSuperclass()) {
+-                // This loop checks for extending deprecated events
+-                if (clazz.getAnnotation(Deprecated.class) != null) {
+-                    Warning warning = clazz.getAnnotation(Warning.class);
+-                    WarningState warningState = server.getWarningState();
+-                    if (!warningState.printFor(warning)) {
+-                        break;
+-                    }
+-                    plugin.getLogger().log(
+-                            Level.WARNING,
+-                            String.format(
+-                                    "\"%s\" has registered a listener for %s on method \"%s\", but the event is Deprecated." +
+-                                    " \"%s\"; please notify the authors %s.",
+-                                    plugin.getDescription().getFullName(),
+-                                    clazz.getName(),
+-                                    method.toGenericString(),
+-                                    (warning != null && warning.reason().length() != 0) ? warning.reason() : "Server performance will be affected",
+-                                    Arrays.toString(plugin.getDescription().getAuthors().toArray())),
+-                            warningState == WarningState.ON ? new AuthorNagException(null) : null);
+-                    break;
+-                }
+-            }
+-
+-            EventExecutor executor = new EventExecutor() {
+-                public void execute(Listener listener, Event event) throws EventException {
+-                    try {
+-                        if (!eventClass.isAssignableFrom(event.getClass())) {
+-                            return;
+-                        }
+-                        method.invoke(listener, event);
+-                    } catch (InvocationTargetException ex) {
+-                        throw new EventException(ex.getCause(), event);
+-                    } catch (Throwable t) {
+-                        throw new EventException(t, event);
+-                    }
+-                }
+-            };
+-            if (useTimings) {
+-                eventSet.add(new TimedRegisteredListener(listener, executor, eh.priority(), plugin, eh.ignoreCancelled()));
+-            } else {
+-                eventSet.add(new RegisteredListener(listener, executor, eh.priority(), plugin, eh.ignoreCancelled()));
+-            }
+-        }
+-        return ret;
++        final Map<Class<? extends Event>, Set<RegisteredListener>> result = new HashMap<>();
++        plugin.eventRegistry().bindHandlers(listener).forEach(
++            handler -> result.computeIfAbsent(handler.meta().event(), event -> new HashSet<>())
++                             .add((RegisteredListener) handler)
++        );
++        return result;
+     }
+ 
+     public void enablePlugin(final Plugin plugin) {
+diff --git a/src/test/java/org/bukkit/TestServer.java b/src/test/java/org/bukkit/TestServer.java
+index 2d84032..152010a 100644
+--- a/src/test/java/org/bukkit/TestServer.java
++++ b/src/test/java/org/bukkit/TestServer.java
+@@ -6,12 +6,13 @@ import java.lang.reflect.Proxy;
+ import java.util.Map;
+ import java.util.logging.Logger;
+ 
++import com.google.common.collect.ImmutableMap;
+ import org.bukkit.command.SimpleCommandMap;
++import org.bukkit.event.EventBus;
++import org.bukkit.event.SimpleEventBus;
+ import org.bukkit.plugin.PluginManager;
+ import org.bukkit.plugin.SimplePluginManager;
+ 
+-import com.google.common.collect.ImmutableMap;
+-
+ public class TestServer implements InvocationHandler {
+     private static interface MethodHandler {
+         Object handle(TestServer server, Object[] args);
+@@ -39,6 +40,14 @@ public class TestServer implements InvocationHandler {
+                     }
+                 );
+             methodMap.put(
++                    Server.class.getMethod("eventBus"),
++                    new MethodHandler() {
++                        public Object handle(TestServer server, Object[] args) {
++                            return server.eventBus;
++                        }
++                    }
++                );
++            methodMap.put(
+                     Server.class.getMethod("getLogger"),
+                     new MethodHandler() {
+                         final Logger logger = Logger.getLogger(TestServer.class.getCanonicalName());
+@@ -77,6 +86,7 @@ public class TestServer implements InvocationHandler {
+             Server instance = Proxy.getProxyClass(Server.class.getClassLoader(), Server.class).asSubclass(Server.class).getConstructor(InvocationHandler.class).newInstance(server);
+             Bukkit.setServer(instance);
+             server.pluginManager = new SimplePluginManager(instance, new SimpleCommandMap(instance));
++            server.eventBus = new SimpleEventBus(null, server.pluginManager);
+         } catch (Throwable t) {
+             throw new Error(t);
+         }
+@@ -84,6 +94,7 @@ public class TestServer implements InvocationHandler {
+ 
+     private Thread creatingThread = Thread.currentThread();
+     private PluginManager pluginManager;
++    private EventBus eventBus;
+     private TestServer() {};
+ 
+     public static Server getInstance() {
+diff --git a/src/test/java/org/bukkit/event/EventBusTest.java b/src/test/java/org/bukkit/event/EventBusTest.java
+new file mode 100644
+index 0000000..89e75b5
+--- /dev/null
++++ b/src/test/java/org/bukkit/event/EventBusTest.java
+@@ -0,0 +1,284 @@
++package org.bukkit.event;
++
++import java.util.ArrayList;
++import java.util.Arrays;
++import java.util.List;
++import java.util.stream.Stream;
++
++import org.bukkit.exception.ExceptionHandler;
++import org.bukkit.exception.TestExceptionHandler;
++import org.bukkit.test.TestThread;
++import org.junit.After;
++import org.junit.Before;
++import org.junit.Test;
++
++import static org.bukkit.test.Assert.assertThrows;
++import static org.junit.Assert.*;
++
++public class EventBusTest {
++
++    static class Oops extends Exception {}
++
++    ExceptionHandler exceptionHandler = new TestExceptionHandler();
++    SimpleEventBus bus;
++    List<String> flow;
++
++    @Before
++    public void setUp() throws Exception {
++        flow = new ArrayList<>();
++        bus = new SimpleEventBus();
++    }
++
++    @After
++    public void tearDown() throws Exception {
++        HandlerList.unregisterAll();
++    }
++
++    void flow(String action) {
++        flow.add(action);
++    }
++
++    void assertFlow(String... actions) {
++        assertEquals(Arrays.asList(actions), flow);
++    }
++
++    void register(EventCallable<TestEvent> handler) {
++        CallableEventHandler.register(TestEvent.class, handler, exceptionHandler);
++    }
++
++    void register(EventPriority priority, EventCallable<TestEvent> handler) {
++        CallableEventHandler.register(TestEvent.class, priority, handler, exceptionHandler);
++    }
++
++    @Test
++    public void handleSyncEvent() {
++        register(event ->
++            flow("handler")
++        );
++        bus.callEvent(new TestEvent());
++        assertFlow("handler");
++    }
++
++    @Test
++    public void handleAsyncEvent() throws Throwable {
++        register(event ->
++            flow("handler")
++        );
++        TestThread.join(() ->
++            bus.callEvent(new TestEvent(true))
++        );
++        assertFlow("handler");
++    }
++
++    @Test
++    public void asyncEventOnMainThreadThrows() throws Throwable {
++        assertThrows(IllegalStateException.class, () ->
++            bus.callEvent(new TestEvent(true))
++        );
++    }
++
++    @Test
++    public void asyncEventHoldingLockThrows() throws Throwable {
++        TestThread.join(() -> {
++            synchronized(bus.lock()) {
++                assertThrows(IllegalStateException.class, () ->
++                    bus.callEvent(new TestEvent(true))
++                );
++            }
++        });
++    }
++
++    @Test
++    public void eventWithBody() throws Exception {
++        bus.callEvent(new TestEvent(), event ->
++            flow("body")
++        );
++        assertFlow("body");
++    }
++
++    @Test
++    public void nestedDispatchThrows() throws Throwable {
++        final TestEvent event = new TestEvent();
++        bus.callEvent(event, e ->
++            assertThrows(IllegalStateException.class, () ->
++                bus.callEvent(event)
++            )
++        );
++    }
++
++    @Test
++    public void nonYieldingHandler() throws Exception {
++        register(event ->
++            flow("handler")
++        );
++        bus.callEvent(new TestEvent(), event ->
++            flow("body")
++        );
++        assertFlow("handler", "body");
++    }
++
++    @Test
++    public void yieldingHandler() throws Exception {
++        register(event -> {
++            flow("before");
++            event.yield();
++            flow("after");
++        });
++
++        bus.callEvent(new TestEvent(), event ->
++            flow("body")
++        );
++
++        assertFlow("before", "body", "after");
++    }
++
++    @Test
++    public void yieldMultipleTimesThrows() throws Throwable {
++        register(event -> {
++            event.yield();
++            assertThrows(IllegalStateException.class, event::yield);
++        });
++
++        bus.callEvent(new TestEvent());
++    }
++
++    @Test
++    public void mixedYieldingAndNonYieldingHandlers() throws Exception {
++        register(EventPriority.LOW, event -> {
++            flow("low");
++        });
++
++        register(EventPriority.NORMAL, event -> {
++            flow("normal before");
++            event.yield();
++            flow("normal after");
++        });
++
++        register(EventPriority.HIGH, event -> {
++            flow("high");
++        });
++
++        bus.callEvent(new TestEvent(), event ->
++            flow("body")
++        );
++
++        assertFlow(
++            "low",
++            "normal before",
++            "high",
++            "body",
++            "normal after"
++        );
++    }
++
++    @Test
++    public void yieldAtMultiplePriorityLevels() throws Exception {
++        Stream.of(EventPriority.LOW, EventPriority.NORMAL, EventPriority.HIGH).forEach(priority -> {
++            register(priority, event -> {
++                flow("before " + priority);
++                event.yield();
++                flow("after " + priority);
++            });
++        });
++
++        bus.callEvent(new TestEvent(), event ->
++            flow("body")
++        );
++
++        assertFlow(
++            "before LOW",
++            "before NORMAL",
++            "before HIGH",
++            "body",
++            "after HIGH",
++            "after NORMAL",
++            "after LOW"
++        );
++    }
++
++    @Test
++    public void eventBodyException() throws Throwable {
++        register(Event::yield); // A handler that just yields
++
++        assertThrows(Oops.class, () ->
++            bus.callEvent(new TestEvent(), event -> {
++                throw new Oops();
++            })
++        );
++    }
++
++    @Test
++    public void handlerExceptionBeforeYield() throws Exception {
++        ExceptionHandler exceptionHandler = (exception, message) -> flow("report");
++
++        CallableEventHandler.register(TestEvent.class, EventPriority.LOW, event -> {
++            flow("low handler before");
++            event.yield();
++            flow("low handler after");
++        }, exceptionHandler);
++
++        CallableEventHandler.register(TestEvent.class, EventPriority.NORMAL, event -> {
++            flow("bad handler");
++            throw new RuntimeException();
++        }, exceptionHandler);
++
++        CallableEventHandler.register(TestEvent.class, EventPriority.HIGH, event -> {
++            flow("high handler before");
++            event.yield();
++            flow("high handler after");
++        }, exceptionHandler);
++
++        bus.callEvent(new TestEvent(), event ->
++            flow("body")
++        );
++
++        assertFlow(
++            "low handler before",
++            "bad handler",
++            "report",
++            "high handler before",
++            "body",
++            "high handler after",
++            "low handler after"
++        );
++    }
++
++    @Test
++    public void handlerExceptionAfterYield() throws Exception {
++        ExceptionHandler exceptionHandler = (exception, message) -> flow("report");
++
++        CallableEventHandler.register(TestEvent.class, EventPriority.LOW, event -> {
++            flow("low handler before");
++            event.yield();
++            flow("low handler after");
++        }, exceptionHandler);
++
++        CallableEventHandler.register(TestEvent.class, EventPriority.NORMAL, event -> {
++            flow("bad handler before");
++            event.yield();
++            flow("bad handler after");
++            throw new RuntimeException();
++        }, exceptionHandler);
++
++        CallableEventHandler.register(TestEvent.class, EventPriority.HIGH, event -> {
++            flow("high handler before");
++            event.yield();
++            flow("high handler after");
++        }, exceptionHandler);
++
++        bus.callEvent(new TestEvent(), event ->
++            flow("body")
++        );
++
++        assertFlow(
++            "low handler before",
++            "bad handler before",
++            "high handler before",
++            "body",
++            "high handler after",
++            "bad handler after",
++            "report",
++            "low handler after"
++        );
++    }
++}
+diff --git a/src/test/java/org/bukkit/event/EventHandlerMetaTest.java b/src/test/java/org/bukkit/event/EventHandlerMetaTest.java
+new file mode 100644
+index 0000000..05aba89
+--- /dev/null
++++ b/src/test/java/org/bukkit/event/EventHandlerMetaTest.java
+@@ -0,0 +1,87 @@
++package org.bukkit.event;
++
++import org.junit.Test;
++
++import static org.bukkit.test.Assert.*;
++import static org.junit.Assert.*;
++
++public class EventHandlerMetaTest {
++
++    @Test
++    public void canHandle() throws Throwable {
++        EventHandlerMeta<TestEvent> meta = new EventHandlerMeta<>(TestEvent.class, EventPriority.NORMAL, false);
++
++        // Base case
++        assertTrue(meta.canHandle(new TestEvent(), null));
++
++        // Event type
++        assertFalse(meta.canHandle(new Event(){}, null));
++        assertTrue(meta.canHandle(new TestEvent(){}, null));
++
++        // Priority
++        assertTrue(meta.canHandle(new TestEvent(), EventPriority.NORMAL));
++        assertFalse(meta.canHandle(new TestEvent(), EventPriority.LOW));
++
++        // Cancelled
++        TestEvent cancelled = new TestEvent(){
++            public boolean isCancelled() { return true; }
++        };
++        assertTrue(meta.canHandle(cancelled, null));
++        assertFalse(new EventHandlerMeta<>(TestEvent.class, EventPriority.NORMAL, true).canHandle(cancelled, null));
++    }
++
++    @Test
++    public void createForMethod() throws Exception {
++        class C {
++            @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
++            void handler(TestEvent event) {}
++        }
++
++        EventHandlerMeta<?> meta = EventHandlerMeta.forMethod(C.class.getDeclaredMethod("handler", TestEvent.class));
++
++        assertEquals(TestEvent.class, meta.event());
++        assertEquals(EventPriority.HIGH, meta.priority());
++        assertEquals(true, meta.ignoreCancelled());
++    }
++
++    @Test
++    public void ignoreMethodWithoutAnnotation() throws Exception {
++        class C {
++            void handler(TestEvent event) {}
++        }
++        assertNull(EventHandlerMeta.forMethod(C.class.getDeclaredMethod("handler", TestEvent.class)));
++    }
++
++    @Test
++    public void missingEventParameter() throws Throwable {
++        class C {
++            @EventHandler
++            void handler() {}
++        }
++        assertThrows(IllegalArgumentException.class, () ->
++            EventHandlerMeta.forMethod(C.class.getDeclaredMethod("handler"))
++        );
++    }
++
++    @Test
++    public void extraParameter() throws Throwable {
++        class C {
++            @EventHandler
++            void handler(TestEvent event, int what) {}
++        }
++        assertThrows(IllegalArgumentException.class, () ->
++            EventHandlerMeta.forMethod(C.class.getDeclaredMethod("handler", TestEvent.class, int.class))
++        );
++    }
++
++    @Test
++    public void abstractEvent() throws Throwable {
++        class C {
++            @EventHandler
++            void handler(Event event) {}
++        }
++        assertThrows(IllegalArgumentException.class, () ->
++            EventHandlerMeta.forMethod(C.class.getDeclaredMethod("handler", Event.class))
++        );
++    }
++}
+diff --git a/src/test/java/org/bukkit/event/EventMethodExecutorTest.java b/src/test/java/org/bukkit/event/EventMethodExecutorTest.java
+new file mode 100644
+index 0000000..3ee3f43
+--- /dev/null
++++ b/src/test/java/org/bukkit/event/EventMethodExecutorTest.java
+@@ -0,0 +1,135 @@
++package org.bukkit.event;
++
++import java.util.List;
++import java.util.concurrent.atomic.AtomicBoolean;
++import java.util.stream.Collectors;
++
++import org.bukkit.exception.ExceptionHandler;
++import org.bukkit.exception.TestExceptionHandler;
++import org.bukkit.test.TestCodeBlock;
++import org.junit.Test;
++
++import static org.bukkit.test.Assert.*;
++import static org.junit.Assert.*;
++
++public class EventMethodExecutorTest {
++
++    ExceptionHandler exceptionHandler = new TestExceptionHandler();
++
++    List<EventMethodExecutor<?>> createHandlers(Class<? extends Listener> listener) {
++        return EventMethodExecutor.forMethods(listener, exceptionHandler)
++                                  .collect(Collectors.toList());
++    }
++
++    @Test
++    public void empty() throws Exception {
++        class C implements Listener {}
++        assertEmpty(createHandlers(C.class));
++    }
++
++    @Test
++    public void singleHandler() throws Exception {
++        class C implements Listener {
++            @EventHandler
++            public void handler(TestEvent event) {}
++        }
++        assertSize(1, createHandlers(C.class));
++    }
++
++    @Test
++    public void nonPublicHandlers() throws Exception {
++        class C implements Listener {
++            @EventHandler private void privateHandler(TestEvent event) {}
++            @EventHandler protected void protectedHandler(TestEvent event) {}
++            @EventHandler void packageHandler(TestEvent event) {}
++        }
++        assertSize(3, createHandlers(C.class));
++    }
++
++    @Test
++    public void superclassHandler() throws Exception {
++        class C implements Listener {
++            @EventHandler
++            public void handler(TestEvent event) {}
++        }
++        class D extends C {}
++        assertSize(1, createHandlers(D.class));
++    }
++
++    interface I extends Listener {
++        @EventHandler
++        default void handler(TestEvent event) {}
++    }
++
++    @Test
++    public void interfaceHandler() throws Exception {
++        assertSize(1, createHandlers(I.class));
++    }
++
++    @Test
++    public void inheritedInterfaceHandler() throws Exception {
++        class C implements I {}
++        assertSize(1, createHandlers(C.class));
++    }
++
++    static class PrivateHandler implements Listener {
++        boolean called = false;
++
++        @EventHandler
++        private void handler(TestEvent event) {
++            called = true;
++        }
++    }
++
++    @Test
++    public void callPrivateHandler() throws Throwable {
++        PrivateHandler listener = new PrivateHandler();
++        EventMethodExecutor.forMethod(
++            PrivateHandler.class.getDeclaredMethod("handler", TestEvent.class),
++            exceptionHandler
++        ).execute(listener, new TestEvent());
++
++        assertTrue(listener.called);
++    }
++
++    @Test
++    public void reportException() throws Throwable {
++        class C implements Listener {
++            @EventHandler
++            void handler(TestEvent event) throws Exception {
++                throw new Exception();
++            }
++        }
++
++        AtomicBoolean reported = new AtomicBoolean(false);
++
++        EventMethodExecutor.forMethod(
++            C.class.getDeclaredMethod("handler", TestEvent.class),
++            (exception, message) -> reported.set(true)
++        ).execute(new C(), new TestEvent());
++
++        assertTrue(reported.get());
++    }
++
++    @Test
++    public void propagateEventException() throws Throwable {
++        class C implements Listener {
++            @EventHandler
++            void handler(TestEvent event) throws Exception {
++                throw new EventException();
++            }
++        }
++
++        EventMethodExecutor executor = EventMethodExecutor.forMethod(
++            C.class.getDeclaredMethod("handler", TestEvent.class),
++            exceptionHandler
++        );
++
++        assertThrows(EventException.class, new TestCodeBlock() { // lambda here crashes the compiler
++            @Override
++            public void run() throws Throwable {
++                executor.execute(new C(), new TestEvent());
++            }
++        });
++    }
++}
+diff --git a/src/test/java/org/bukkit/event/EventRegistryTest.java b/src/test/java/org/bukkit/event/EventRegistryTest.java
+new file mode 100644
+index 0000000..ede5376
+--- /dev/null
++++ b/src/test/java/org/bukkit/event/EventRegistryTest.java
+@@ -0,0 +1,93 @@
++package org.bukkit.event;
++
++import java.util.List;
++import java.util.function.Predicate;
++import java.util.stream.Collectors;
++import java.util.stream.Stream;
++
++import org.junit.After;
++import org.junit.Before;
++import org.junit.Test;
++
++import static org.bukkit.test.Assert.*;
++import static org.junit.Assert.*;
++
++public class EventRegistryTest {
++
++    EventRegistry registry;
++
++    @Before
++    public void setUp() throws Exception {
++        registry = new SimpleEventRegistry();
++    }
++
++    @After
++    public void tearDown() throws Exception {
++        HandlerList.unregisterAll();
++    }
++
++    List<EventMethodExecutor<?>> createHandlers(Class<? extends Listener> listener) {
++        return registry.createHandlers(listener).collect(Collectors.toList());
++    }
++
++    void assertRegistered(Predicate<? super RegisteredHandler<?>> filter) {
++        assertRegistered(1, filter);
++    }
++
++    void assertNotRegistered(Predicate<? super RegisteredHandler<?>> filter) {
++        assertRegistered(0, filter);
++    }
++
++    void assertRegistered(int count, Predicate<? super RegisteredHandler<?>> filter) {
++        assertEquals(count, Stream.of(Event.getHandlerList(TestEvent.class)
++                                           .getRegisteredListeners())
++                                  .filter(filter)
++                                  .count());
++    }
++
++    @Test
++    public void registerListener() throws Exception {
++        class C implements Listener {
++            @EventHandler
++            void handler(TestEvent event) {}
++        }
++        C c = new C();
++        registry.registerListener(c);
++        assertRegistered(handler -> handler instanceof BoundEventHandler &&
++                                    ((BoundEventHandler) handler).listener() == c);
++    }
++
++    @Test
++    public void unregisterListener() throws Exception {
++        class C implements Listener {
++            @EventHandler
++            void handler(TestEvent event) {}
++        }
++        C c1 = new C();
++        C c2 = new C();
++        registry.registerListener(c1);
++        registry.registerListener(c2);
++        registry.unregisterListener(c1);
++
++        assertNotRegistered(handler -> handler instanceof BoundEventHandler && ((BoundEventHandler) handler).listener() == c1);
++        assertRegistered(handler -> handler instanceof BoundEventHandler && ((BoundEventHandler) handler).listener() == c2);
++    }
++
++    @Test
++    public void unregisterAll() throws Exception {
++        class C implements Listener {
++            @EventHandler
++            void handler(TestEvent event) {}
++        }
++        EventRegistry registry1 = new SimpleEventRegistry();
++        EventRegistry registry2 = new SimpleEventRegistry();
++        C c1 = new C();
++        C c2 = new C();
++        registry1.registerListener(c1);
++        registry2.registerListener(c2);
++        registry1.unregisterAll();
++
++        assertNotRegistered(handler -> handler instanceof BoundEventHandler && ((BoundEventHandler) handler).listener() == c1);
++        assertRegistered(handler -> handler instanceof BoundEventHandler && ((BoundEventHandler) handler).listener() == c2);
++    }
++}
+diff --git a/src/test/java/org/bukkit/event/HandlerListTest.java b/src/test/java/org/bukkit/event/HandlerListTest.java
+new file mode 100644
+index 0000000..d7e97a9
+--- /dev/null
++++ b/src/test/java/org/bukkit/event/HandlerListTest.java
+@@ -0,0 +1,18 @@
++package org.bukkit.event;
++
++import org.junit.Test;
++
++import static org.bukkit.test.Assert.*;
++
++public class HandlerListTest {
++
++    @Test
++    public void duplicateRegistration() throws Throwable {
++        HandlerList list = Event.getHandlerList(TestEvent.class);
++        CallableEventHandler<TestEvent> handler = CallableEventHandler.create(TestEvent.class, event -> {});
++        list.register(handler);
++        assertThrows(IllegalStateException.class, () ->
++            list.register(handler)
++        );
++    }
++}
+diff --git a/src/test/java/org/bukkit/event/SyntheticEventTest.java b/src/test/java/org/bukkit/event/SyntheticEventTest.java
+deleted file mode 100644
+index df6cf00..0000000
+--- a/src/test/java/org/bukkit/event/SyntheticEventTest.java
++++ /dev/null
+@@ -1,49 +0,0 @@
+-package org.bukkit.event;
+-
+-import org.bukkit.TestServer;
+-import org.bukkit.plugin.PluginLoader;
+-import org.bukkit.plugin.SimplePluginManager;
+-import org.bukkit.plugin.TestPlugin;
+-import org.bukkit.plugin.java.JavaPluginLoader;
+-import org.junit.Assert;
+-import org.junit.Test;
+-
+-public class SyntheticEventTest {
+-    @SuppressWarnings("deprecation")
+-    @Test
+-    public void test() {
+-        final JavaPluginLoader loader = new JavaPluginLoader(TestServer.getInstance());
+-        TestPlugin plugin = new TestPlugin(getClass().getName()) {
+-            @Override
+-            public PluginLoader getPluginLoader() {
+-                return loader;
+-            }
+-        };
+-        SimplePluginManager pluginManager = new SimplePluginManager(TestServer.getInstance(), null);
+-
+-        TestEvent event = new TestEvent(false);
+-        Impl impl = new Impl();
+-
+-        pluginManager.registerEvents(impl, plugin);
+-        pluginManager.callEvent(event);
+-
+-        Assert.assertEquals(1, impl.callCount);
+-    }
+-
+-    public static abstract class Base<E extends Event> implements Listener {
+-        int callCount = 0;
+-
+-        public void accept(E evt) {
+-            System.out.println("Invk " + evt);
+-            callCount++;
+-        }
+-    }
+-
+-    public static class Impl extends Base<TestEvent> {
+-        @Override
+-        @EventHandler
+-        public void accept(TestEvent evt) {
+-            super.accept(evt);
+-        }
+-    }
+-}
+diff --git a/src/test/java/org/bukkit/event/TestEvent.java b/src/test/java/org/bukkit/event/TestEvent.java
+index 25904f5..badbcee 100644
+--- a/src/test/java/org/bukkit/event/TestEvent.java
++++ b/src/test/java/org/bukkit/event/TestEvent.java
+@@ -4,6 +4,10 @@ package org.bukkit.event;
+ public class TestEvent extends Event {
+     private static final HandlerList handlers = new HandlerList();
+ 
++    public TestEvent() {
++        this(false);
++    }
++
+     public TestEvent(boolean async) {
+         super(async);
+     }
+diff --git a/src/test/java/org/bukkit/exception/TestExceptionHandler.java b/src/test/java/org/bukkit/exception/TestExceptionHandler.java
+new file mode 100644
+index 0000000..49c1abe
+--- /dev/null
++++ b/src/test/java/org/bukkit/exception/TestExceptionHandler.java
+@@ -0,0 +1,8 @@
++package org.bukkit.exception;
++
++public class TestExceptionHandler implements ExceptionHandler {
++    @Override
++    public void handleException(Throwable exception, String message) {
++        throw new AssertionError(message, exception);
++    }
++}
+diff --git a/src/test/java/org/bukkit/plugin/PluginManagerTest.java b/src/test/java/org/bukkit/plugin/PluginManagerTest.java
+index 6b86128..fd00bd9 100644
+--- a/src/test/java/org/bukkit/plugin/PluginManagerTest.java
++++ b/src/test/java/org/bukkit/plugin/PluginManagerTest.java
+@@ -26,7 +26,7 @@ public class PluginManagerTest {
+         try {
+             pm.callEvent(event);
+         } catch (IllegalStateException ex) {
+-            assertThat(event.getEventName() + " cannot be triggered asynchronously from primary server thread.", is(ex.getMessage()));
++            assertThat(event.getEventName() + " cannot be called asynchronously from primary thread.", is(ex.getMessage()));
+             return;
+         }
+         throw new IllegalStateException("No exception thrown");
+@@ -57,7 +57,7 @@ public class PluginManagerTest {
+         secondThread.start();
+         secondThread.join();
+         assertThat(store.value, is(instanceOf(IllegalStateException.class)));
+-        assertThat(event.getEventName() + " cannot be triggered asynchronously from inside synchronized code.", is(((Throwable) store.value).getMessage()));
++        assertThat(event.getEventName() + " cannot be called asynchronously from inside synchronized code.", is(((Throwable) store.value).getMessage()));
+     }
+ 
+     @Test
+diff --git a/src/test/java/org/bukkit/plugin/TestPlugin.java b/src/test/java/org/bukkit/plugin/TestPlugin.java
+index 7e09892..46e5cf8 100644
+--- a/src/test/java/org/bukkit/plugin/TestPlugin.java
++++ b/src/test/java/org/bukkit/plugin/TestPlugin.java
+@@ -3,22 +3,38 @@ package org.bukkit.plugin;
+ import java.io.File;
+ import java.io.InputStream;
+ import java.util.List;
++import java.util.logging.Logger;
++import javax.annotation.Nullable;
+ 
++import com.avaje.ebean.EbeanServer;
+ import org.bukkit.Server;
+ import org.bukkit.command.Command;
+ import org.bukkit.command.CommandSender;
+ import org.bukkit.configuration.file.FileConfiguration;
++import org.bukkit.exception.ExceptionHandler;
++import org.bukkit.exception.PluginExceptionHandler;
+ import org.bukkit.generator.ChunkGenerator;
+ 
+-import com.avaje.ebean.EbeanServer;
+-
+ public class TestPlugin extends PluginBase {
+     private boolean enabled = true;
++    private boolean naggable = true;
+ 
+     final private String pluginName;
++    final private @Nullable Server server;
++    final private Logger logger;
++    final private ExceptionHandler exceptionHandler;
++    final private PluginEventRegistry eventRegistry;
+ 
+     public TestPlugin(String pluginName) {
++        this(pluginName, null);
++    }
++
++    public TestPlugin(String pluginName, @Nullable Server server) {
+         this.pluginName = pluginName;
++        this.server = server;
++        this.logger = server != null ? new PluginLogger(this) : Logger.getGlobal();
++        this.exceptionHandler = new PluginExceptionHandler(this);
++        this.eventRegistry = new PluginEventRegistry(this);
+     }
+ 
+     public void setEnabled(boolean enabled) {
+@@ -57,15 +73,26 @@ public class TestPlugin extends PluginBase {
+         throw new UnsupportedOperationException("Not supported.");
+     }
+ 
+-    public PluginLogger getLogger() {
+-        throw new UnsupportedOperationException("Not supported.");
++    public Logger getLogger() {
++        return logger;
++    }
++
++    @Override
++    public ExceptionHandler exceptionHandler() {
++        return exceptionHandler;
+     }
+ 
+     public PluginLoader getPluginLoader() {
+         throw new UnsupportedOperationException("Not supported.");
+     }
+ 
++    @Override
++    public PluginEventRegistry eventRegistry() {
++        return eventRegistry;
++    }
++
+     public Server getServer() {
++        if(server != null) return server;
+         throw new UnsupportedOperationException("Not supported.");
+     }
+ 
+@@ -86,11 +113,11 @@ public class TestPlugin extends PluginBase {
+     }
+ 
+     public boolean isNaggable() {
+-        throw new UnsupportedOperationException("Not supported.");
++        return naggable;
+     }
+ 
+-    public void setNaggable(boolean canNag) {
+-        throw new UnsupportedOperationException("Not supported.");
++    public void setNaggable(boolean naggable) {
++        this.naggable = naggable;
+     }
+ 
+     public EbeanServer getDatabase() {
+diff --git a/src/test/java/org/bukkit/test/Assert.java b/src/test/java/org/bukkit/test/Assert.java
+new file mode 100644
+index 0000000..5a44776
+--- /dev/null
++++ b/src/test/java/org/bukkit/test/Assert.java
+@@ -0,0 +1,43 @@
++package org.bukkit.test;
++
++import java.util.Arrays;
++import java.util.Collection;
++import java.util.List;
++
++import static org.junit.Assert.*;
++
++public final class Assert {
++
++    public static void assertEmpty(Object[] array) {
++        assertEmpty(Arrays.asList(array));
++    }
++
++    public static void assertEmpty(Collection collection) {
++        if(collection.isEmpty()) return;
++        fail("Expected collection to be empty, but it contains " + collection.size() + " elements");
++    }
++
++    public static void assertSize(int size, Object[] array) {
++        assertSize(size, Arrays.asList(array));
++    }
++
++    public static void assertSize(int size, Collection collection) {
++        if(collection.size() == size) return;
++        fail("Expected collection to contain " + size +
++             " elements, but it actually contains " + collection.size());
++    }
++
++    public static void assertList(List actual, Object...expected) {
++        assertEquals(Arrays.asList(expected), actual);
++    }
++
++    public static void assertThrows(Class<? extends Throwable> expected, TestCodeBlock block) throws Throwable {
++        try {
++            block.run();
++        } catch(Throwable throwable) {
++            if(expected.isInstance(throwable)) return;
++            throw throwable;
++        }
++        fail("Expected " + expected.getSimpleName() + " to be thrown, but nothing was thrown");
++    }
++}
+diff --git a/src/test/java/org/bukkit/test/TestCodeBlock.java b/src/test/java/org/bukkit/test/TestCodeBlock.java
+new file mode 100644
+index 0000000..f1101fa
+--- /dev/null
++++ b/src/test/java/org/bukkit/test/TestCodeBlock.java
+@@ -0,0 +1,6 @@
++package org.bukkit.test;
++
++@FunctionalInterface
++public interface TestCodeBlock {
++    void run() throws Throwable;
++}
+diff --git a/src/test/java/org/bukkit/test/TestLogger.java b/src/test/java/org/bukkit/test/TestLogger.java
+new file mode 100644
+index 0000000..9a85863
+--- /dev/null
++++ b/src/test/java/org/bukkit/test/TestLogger.java
+@@ -0,0 +1,49 @@
++package org.bukkit.test;
++
++import java.util.ArrayList;
++import java.util.Collections;
++import java.util.List;
++import java.util.logging.Handler;
++import java.util.logging.Level;
++import java.util.logging.LogRecord;
++import java.util.logging.Logger;
++
++import static org.junit.Assert.*;
++
++/**
++ * A {@link Logger} that asserts if an error is logged,
++ * and retains all {@link LogRecord}s for tests to examine.
++ */
++public class TestLogger extends Logger {
++
++    final Level failureLevel;
++    final List<LogRecord> records = new ArrayList<>();
++    final List<LogRecord> recordsView = Collections.unmodifiableList(records);
++
++    public TestLogger() {
++        this(Level.SEVERE);
++    }
++
++    public TestLogger(Level failureLevel) {
++        super(null, null);
++        this.failureLevel = failureLevel;
++        setUseParentHandlers(false);
++
++        addHandler(new Handler() {
++            @Override
++            public void publish(LogRecord record) {
++                if(failureLevel.intValue() <= record.getLevel().intValue()) {
++                    fail(record.getMessage());
++                }
++                records.add(record);
++            }
++
++            @Override public void flush() {}
++            @Override public void close() throws SecurityException { }
++        });
++    }
++
++    public List<LogRecord> records() {
++        return recordsView;
++    }
++}
+diff --git a/src/test/java/org/bukkit/test/TestThread.java b/src/test/java/org/bukkit/test/TestThread.java
+new file mode 100644
+index 0000000..6b372c1
+--- /dev/null
++++ b/src/test/java/org/bukkit/test/TestThread.java
+@@ -0,0 +1,46 @@
++package org.bukkit.test;
++
++import javax.annotation.Nullable;
++
++public class TestThread extends Thread {
++
++    public static TestThread start(TestCodeBlock body) {
++        final TestThread thread = new TestThread(body);
++        thread.start();
++        return thread;
++    }
++
++    public static TestThread join(TestCodeBlock body) throws Throwable {
++        final TestThread thread = new TestThread(body);
++        thread.start();
++        thread.assertJoin();
++        return thread;
++    }
++
++    private final TestCodeBlock body;
++    private volatile @Nullable Throwable exception;
++
++    public TestThread(TestCodeBlock body) {
++        this.body = body;
++    }
++
++    @Override
++    public void run() {
++        try {
++            body.run();
++        } catch(Throwable ex) {
++            this.exception = ex;
++        }
++    }
++
++    public void assertJoin() throws Throwable {
++        join();
++
++        if(exception != null) {
++            if(exception instanceof AssertionError) {
++                throw exception;
++            }
++            throw new AssertionError("Thread " + getName() + " terminated with an exception", exception);
++        }
++    }
++}
+-- 
+1.9.0
+

--- a/Bukkit/0085-Pause-entity-API.patch
+++ b/Bukkit/0085-Pause-entity-API.patch
@@ -1,0 +1,35 @@
+From 0697f3c5b1e60becaf1990cd62d747eb2afc0218 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Sat, 3 Dec 2016 23:45:45 -0500
+Subject: [PATCH] Pause entity API
+
+
+diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
+index 6a1b1f3..4496d40 100644
+--- a/src/main/java/org/bukkit/entity/Entity.java
++++ b/src/main/java/org/bukkit/entity/Entity.java
+@@ -506,4 +506,21 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Physical {
+     boolean removeScoreboardTag(String tag);
+ 
+     Cuboid getBoundingBox();
++
++    /**
++     * Pause/unpause this entity.
++     *
++     * Pausing an entity prevents various dynamic properties from advancing.
++     * The set of affected properties may expand in the future.
++     *
++     * Currently, only potion effect durations are affected.
++     */
++    void setPaused(boolean paused);
++
++    /**
++     * Is this entity paused?
++     *
++     * @see #setPaused
++     */
++    boolean isPaused();
+ }
+-- 
+1.9.0
+

--- a/Bukkit/0086-More-ways-to-spawn-FallingBlocks.patch
+++ b/Bukkit/0086-More-ways-to-spawn-FallingBlocks.patch
@@ -1,0 +1,104 @@
+From e813c7a9ca6af67159f73392d4999051c423015e Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Wed, 7 Dec 2016 04:08:39 -0500
+Subject: [PATCH] More ways to spawn FallingBlocks
+
+
+diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
+index f7fc037..3fd2a53 100644
+--- a/src/main/java/org/bukkit/World.java
++++ b/src/main/java/org/bukkit/World.java
+@@ -773,7 +773,25 @@ public interface World extends PluginMessageRecipient, Metadatable, Physical {
+      * @throws IllegalArgumentException if {@link Location} or {@link
+      *     MaterialData} are null or {@link Material} of the {@link MaterialData} is not a block
+      */
+-    public FallingBlock spawnFallingBlock(Location location, MaterialData data) throws IllegalArgumentException;
++    default FallingBlock spawnFallingBlock(Location location, MaterialData data) throws IllegalArgumentException {
++        return spawnFallingBlock(location.position(), data);
++    }
++
++    /**
++     * Spawn a {@link FallingBlock} entity at the given position in this world.
++     *
++     * @see #spawnFallingBlock(Location, MaterialData)
++     */
++    FallingBlock spawnFallingBlock(Vec3 position, MaterialData data) throws IllegalArgumentException;
++
++    /**
++     * Spawn a {@link FallingBlock} entity at the given coarse position in this world.
++     * The spawned entity will initially be aligned with the block grid,
++     * as a naturally falling block would be.
++     *
++     * @see #spawnFallingBlock(Location, MaterialData)
++     */
++    FallingBlock spawnFallingBlockAligned(Vec3 position, MaterialData data) throws IllegalArgumentException;
+ 
+     /**
+      * Spawn a {@link FallingBlock} entity at the given {@link Location} of
+@@ -792,7 +810,12 @@ public interface World extends PluginMessageRecipient, Metadatable, Physical {
+      * @deprecated Magic value
+      */
+     @Deprecated
+-    public FallingBlock spawnFallingBlock(Location location, Material material, byte data) throws IllegalArgumentException;
++    default FallingBlock spawnFallingBlock(Location location, Material material, byte data) throws IllegalArgumentException {
++        return spawnFallingBlock(location.position(), material, data);
++    }
++
++    @Deprecated
++    FallingBlock spawnFallingBlock(Vec3 position, Material material, byte data) throws IllegalArgumentException;
+ 
+     /**
+      * Spawn a {@link FallingBlock} entity at the given {@link Location} of
+@@ -808,7 +831,12 @@ public interface World extends PluginMessageRecipient, Metadatable, Physical {
+      * @deprecated Magic value
+      */
+     @Deprecated
+-    public FallingBlock spawnFallingBlock(Location location, int blockId, byte blockData) throws IllegalArgumentException;
++    default FallingBlock spawnFallingBlock(Location location, int blockId, byte blockData) throws IllegalArgumentException {
++        return spawnFallingBlock(location.position(), blockId, blockData);
++    }
++
++    @Deprecated
++    FallingBlock spawnFallingBlock(Vec3 position, int blockId, byte blockData) throws IllegalArgumentException;
+ 
+     /**
+      * Plays an effect to all players within a default radius around a given
+diff --git a/src/main/java/org/bukkit/block/BlockState.java b/src/main/java/org/bukkit/block/BlockState.java
+index 967eac0..b1fcb8e 100644
+--- a/src/main/java/org/bukkit/block/BlockState.java
++++ b/src/main/java/org/bukkit/block/BlockState.java
+@@ -5,6 +5,7 @@ import org.bukkit.Location;
+ import org.bukkit.Material;
+ import org.bukkit.World;
+ import org.bukkit.Physical;
++import org.bukkit.entity.FallingBlock;
+ import org.bukkit.geometry.BlockRotoflection;
+ import org.bukkit.geometry.BlockReflection;
+ import org.bukkit.geometry.BlockRotation;
+@@ -262,4 +263,23 @@ public interface BlockState extends Metadatable, Physical {
+     boolean isPlaced();
+ 
+     boolean hasPosition();
++
++    /**
++     * Spawn a {@link FallingBlock} entity with a position and material matching this block state.
++     *
++     * The entity is spawned in the {@link World} returned from {@link #getWorld()}.
++     *
++     * @throws IllegalStateException if this block state does not belong to a world
++     */
++    default FallingBlock spawnFallingBlock() {
++        return spawnFallingBlock(getWorld());
++    }
++
++    /**
++     * Spawn a {@link FallingBlock} entity in the given {@link World},
++     * with a position and material matching this block state.
++     */
++    default FallingBlock spawnFallingBlock(World world) {
++        return world.spawnFallingBlockAligned(getPosition(), getMaterialData());
++    }
+ }
+-- 
+1.9.0
+

--- a/Bukkit/0087-FallingBlock-form-block-flag.patch
+++ b/Bukkit/0087-FallingBlock-form-block-flag.patch
@@ -1,0 +1,33 @@
+From 59a6e6b92c7588837ccbce5268e513697a7a6596 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Wed, 7 Dec 2016 04:29:15 -0500
+Subject: [PATCH] FallingBlock form block flag
+
+
+diff --git a/src/main/java/org/bukkit/entity/FallingBlock.java b/src/main/java/org/bukkit/entity/FallingBlock.java
+index bc56fa2..4ff5c06 100644
+--- a/src/main/java/org/bukkit/entity/FallingBlock.java
++++ b/src/main/java/org/bukkit/entity/FallingBlock.java
+@@ -59,4 +59,19 @@ public interface FallingBlock extends Entity {
+      * @param hurtEntities whether entities will be damaged by this block.
+      */
+     void setHurtEntities(boolean hurtEntities);
++
++    /**
++     * Can this entity form a block when it lands?
++     */
++    boolean canFormBlock();
++
++    /**
++     * Allow or prevent this entity from forming a block when it lands.
++     *
++     * If this is false, the entity will just disappear when it lands.
++     * If true, it may form a block if other circumstances permit it.
++     *
++     * This is initially true by default.
++     */
++    void setFormBlock(boolean formBlock);
+ }
+-- 
+1.9.0
+

--- a/Bukkit/0088-Server-suspend-API.patch
+++ b/Bukkit/0088-Server-suspend-API.patch
@@ -1,0 +1,216 @@
+From 45cb7b0cd39fb2883820e9975ae160c486405f3f Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Sat, 10 Dec 2016 20:14:13 -0500
+Subject: [PATCH] Server suspend API
+
+
+diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
+index c1a982f..b50176c 100644
+--- a/src/main/java/org/bukkit/Server.java
++++ b/src/main/java/org/bukkit/Server.java
+@@ -3,6 +3,8 @@ package org.bukkit;
+ import java.awt.image.BufferedImage;
+ import java.io.File;
+ import java.io.Serializable;
++import java.time.Duration;
++import java.time.Instant;
+ import java.util.Collection;
+ import java.util.Collections;
+ import java.util.Iterator;
+@@ -11,6 +13,7 @@ import java.util.Map;
+ import java.util.Set;
+ import java.util.UUID;
+ import java.util.logging.Logger;
++import javax.annotation.Nullable;
+ 
+ import org.bukkit.Warning.WarningState;
+ import org.bukkit.boss.BarColor;
+@@ -136,6 +139,12 @@ public interface Server extends PluginMessageRecipient, BukkitRuntime, tc.oc.min
+     public Collection<? extends Player> getOnlinePlayers();
+ 
+     /**
++     * If the server is currently empty of players, return the {@link Instant}
++     * that the last player disconnected. If the server is not empty, return null.
++     */
++    @Nullable Instant emptySince();
++
++    /**
+      * Get the maximum amount of players which can login to this server.
+      *
+      * @return the amount of players this server allows
+@@ -358,6 +367,13 @@ public interface Server extends PluginMessageRecipient, BukkitRuntime, tc.oc.min
+     public int getTicksPerMonsterSpawns();
+ 
+     /**
++     * Time to wait before automatically suspending an empty server.
++     *
++     * @see #setSuspended(boolean)
++     */
++    @Nullable Duration getEmptyServerSuspendDelay();
++
++    /**
+      * Gets a player object by the given username.
+      * <p>
+      * This method may not return objects for offline players.
+@@ -1082,4 +1098,65 @@ public interface Server extends PluginMessageRecipient, BukkitRuntime, tc.oc.min
+      *         false if it was added to the main thread queue
+      */
+     boolean runOnMainThread(Plugin plugin, boolean priority, Runnable task);
++
++    /**
++     * Suspend or resume the server.
++     *
++     * A suspended server does not tick or run scheduled tasks. However, it does
++     * execute console commands, and tasks submitted to {@link #postToMainThread},
++     * while remaining suspended.
++     *
++     * The server can only be suspended when no players are connected. The server
++     * will resume when a player successfully logs in. Failed logins due to bans
++     * or whitelisting do not cause the server to resume.
++     *
++     * @param suspend true to suspend the server, false to resume
++     *
++     * @return true if the suspended state of the server changed,
++     *         false if the state did not change, because the server was already
++     *         in the given state, or because the change is not currently possible.
++     *
++     * @see org.bukkit.event.server.ServerSuspendEvent
++     */
++    boolean setSuspended(boolean suspend);
++
++    /**
++     * Can the server be suspended right now?
++     *
++     * The server can be suspended only when it has no players connected,
++     * and is not in the process of shutting down. This method returns
++     * true if the server is already suspended.
++     *
++     * @see #setSuspended(boolean)
++     */
++    boolean canSuspend();
++
++    /**
++     * Is the server currently suspended?
++     *
++     * @see #setSuspended(boolean)
++     */
++    boolean isSuspended();
++
++    /**
++     * The {@link Instant} that the server entered the suspended state,
++     * or null if the server is not currently suspended.
++     *
++     * @see #setSuspended(boolean)
++     */
++    @Nullable Instant suspendedAt();
++
++    /**
++     * The number of times the server has been interrupted from suspension.
++     *
++     * If the server is not currently suspended, returns 0.
++     *
++     * Interruptions are caused by tasks posted to the main thread through
++     * {@link #postToMainThread}, console commands, and various internal events.
++     * Internal interruptions should be rare. If the server is being interrupted
++     * frequently, it is likely caused by a plugin.
++     *
++     * @see #setSuspended(boolean)
++     */
++    int interruptions();
+ }
+diff --git a/src/main/java/org/bukkit/command/SimpleCommandMap.java b/src/main/java/org/bukkit/command/SimpleCommandMap.java
+index 4d475c6..8b2fa79 100644
+--- a/src/main/java/org/bukkit/command/SimpleCommandMap.java
++++ b/src/main/java/org/bukkit/command/SimpleCommandMap.java
+@@ -32,6 +32,7 @@ public class SimpleCommandMap implements CommandMap {
+         register("bukkit", new ReloadCommand("reload"));
+         register("bukkit", new PluginsCommand("plugins"));
+         register("bukkit", new TimingsCommand("timings"));
++        register("bukkit", new SuspendCommand());
+     }
+ 
+     public void setFallbackCommands() {
+diff --git a/src/main/java/org/bukkit/command/defaults/SuspendCommand.java b/src/main/java/org/bukkit/command/defaults/SuspendCommand.java
+new file mode 100644
+index 0000000..2a844e6
+--- /dev/null
++++ b/src/main/java/org/bukkit/command/defaults/SuspendCommand.java
+@@ -0,0 +1,53 @@
++package org.bukkit.command.defaults;
++
++import java.time.Duration;
++import java.time.Instant;
++import java.util.Collections;
++
++import net.md_5.bungee.api.ChatColor;
++import net.md_5.bungee.api.chat.ComponentBuilder;
++import org.bukkit.Server;
++import org.bukkit.command.CommandSender;
++
++public class SuspendCommand extends BukkitCommand {
++
++    public SuspendCommand() {
++        super(
++            "suspend",
++            "Suspends the server, if no players are connected",
++            "/suspend [true|false]",
++            Collections.emptyList()
++        );
++    }
++
++    @Override
++    public boolean execute(CommandSender sender, String commandLabel, String[] args) {
++        if(!testPermission(sender)) return true;
++        final Server server = sender.getServer();
++        if(args.length == 0) {
++            final Instant at = server.suspendedAt();
++            if(at == null) {
++                sender.sendMessage(new ComponentBuilder("Server is not suspended").color(ChatColor.WHITE).create());
++            } else {
++                final Duration dur = Duration.between(at, Instant.now());
++                sender.sendMessage(new ComponentBuilder(
++                    "Server suspended for " + dur +
++                    " and interrupted " + server.interruptions() + " times"
++                ).color(ChatColor.WHITE).create());
++            }
++        } else if("true".equals(args[0])) {
++            if(server.isSuspended()) {
++                sender.sendMessage(new ComponentBuilder("Server is already suspended").color(ChatColor.RED).create());
++                return true;
++            }
++            if(!server.setSuspended(true)) {
++                sender.sendMessage(new ComponentBuilder("Server cannot be suspended while players are connected").color(ChatColor.RED).create());
++            }
++        } else if("false".equals(args[0])) {
++            if(!server.setSuspended(false)) {
++                sender.sendMessage(new ComponentBuilder("Server is not currently suspended").color(ChatColor.RED).create());
++            }
++        }
++        return true;
++    }
++}
+diff --git a/src/main/java/org/bukkit/event/server/ServerSuspendEvent.java b/src/main/java/org/bukkit/event/server/ServerSuspendEvent.java
+new file mode 100644
+index 0000000..aac9118
+--- /dev/null
++++ b/src/main/java/org/bukkit/event/server/ServerSuspendEvent.java
+@@ -0,0 +1,16 @@
++package org.bukkit.event.server;
++
++import org.bukkit.Server;
++import org.bukkit.event.HandlerList;
++
++/**
++ * Fired when the server transitions to a suspended state, which can happen from an
++ * explicit call to {@link org.bukkit.Server#setSuspended(boolean)}, or automatically
++ * due to {@link Server#getEmptyServerSuspendDelay()}.
++ *
++ * The suspension happens entirely within the event. A call to {@link #yield()}
++ * will not return until the server has resumed.
++ */
++public class ServerSuspendEvent extends ServerEvent {
++    private static final HandlerList<ServerSuspendEvent> handlers = new HandlerList<>();
++}
+-- 
+1.9.0
+

--- a/CraftBukkit/0001-Import-necessary-NMS-classes.patch
+++ b/CraftBukkit/0001-Import-necessary-NMS-classes.patch
@@ -1,4 +1,4 @@
-From 98141dc0fd489fb51228ce75ac460efd666e2b52 Mon Sep 17 00:00:00 2001
+From 53e6d69407a478d4ab12e50f9a7bf664dd6b593b Mon Sep 17 00:00:00 2001
 From: Jedediah Smith <jedediah@silencegreys.com>
 Date: Tue, 1 Mar 2016 04:32:08 -0500
 Subject: [PATCH] Import necessary NMS classes
@@ -6849,6 +6849,105 @@ index 0000000..2cafa4c
 +            ix = a("entity.zombie_villager.hurt");
 +            iy = a("entity.zombie_villager.step");
 +        }
++    }
++}
+diff --git a/src/main/java/net/minecraft/server/ThreadWatchdog.java b/src/main/java/net/minecraft/server/ThreadWatchdog.java
+new file mode 100644
+index 0000000..da6702c
+--- /dev/null
++++ b/src/main/java/net/minecraft/server/ThreadWatchdog.java
+@@ -0,0 +1,93 @@
++package net.minecraft.server;
++
++import java.io.File;
++import java.lang.management.ManagementFactory;
++import java.lang.management.ThreadInfo;
++import java.lang.management.ThreadMXBean;
++import java.text.SimpleDateFormat;
++import java.util.Date;
++import java.util.Timer;
++import java.util.TimerTask;
++import org.apache.logging.log4j.LogManager;
++import org.apache.logging.log4j.Logger;
++
++public class ThreadWatchdog implements Runnable {
++
++    private static final Logger a = LogManager.getLogger();
++    private final DedicatedServer b;
++    private final long c;
++
++    public ThreadWatchdog(DedicatedServer dedicatedserver) {
++        this.b = dedicatedserver;
++        this.c = dedicatedserver.aQ();
++    }
++
++    public void run() {
++        while (this.b.isRunning()) {
++            long i = this.b.aH();
++            long j = MinecraftServer.aw();
++            long k = j - i;
++
++            if (k > this.c) {
++                ThreadWatchdog.a.fatal("A single server tick took {} seconds (should be max {})", new Object[] { String.format("%.2f", new Object[] { Float.valueOf((float) k / 1000.0F)}), String.format("%.2f", new Object[] { Float.valueOf(0.05F)})});
++                ThreadWatchdog.a.fatal("Considering it to be crashed, server will forcibly shutdown.");
++                ThreadMXBean threadmxbean = ManagementFactory.getThreadMXBean();
++                ThreadInfo[] athreadinfo = threadmxbean.dumpAllThreads(true, true);
++                StringBuilder stringbuilder = new StringBuilder();
++                Error error = new Error();
++                ThreadInfo[] athreadinfo1 = athreadinfo;
++                int l = athreadinfo.length;
++
++                for (int i1 = 0; i1 < l; ++i1) {
++                    ThreadInfo threadinfo = athreadinfo1[i1];
++
++                    if (threadinfo.getThreadId() == this.b.aI().getId()) {
++                        error.setStackTrace(threadinfo.getStackTrace());
++                    }
++
++                    stringbuilder.append(threadinfo);
++                    stringbuilder.append("\n");
++                }
++
++                CrashReport crashreport = new CrashReport("Watching Server", error);
++
++                this.b.b(crashreport);
++                CrashReportSystemDetails crashreportsystemdetails = crashreport.a("Thread Dump");
++
++                crashreportsystemdetails.a("Threads", (Object) stringbuilder);
++                File file = new File(new File(this.b.A(), "crash-reports"), "crash-" + (new SimpleDateFormat("yyyy-MM-dd_HH.mm.ss")).format(new Date()) + "-server.txt");
++
++                if (crashreport.a(file)) {
++                    ThreadWatchdog.a.error("This crash report has been saved to: {}", new Object[] { file.getAbsolutePath()});
++                } else {
++                    ThreadWatchdog.a.error("We were unable to save this crash report to disk.");
++                }
++
++                this.a();
++            }
++
++            try {
++                Thread.sleep(i + this.c - j);
++            } catch (InterruptedException interruptedexception) {
++                ;
++            }
++        }
++
++    }
++
++    private void a() {
++        try {
++            Timer timer = new Timer();
++
++            timer.schedule(new TimerTask() {
++                public void run() {
++                    Runtime.getRuntime().halt(1);
++                }
++            }, 10000L);
++            System.exit(1);
++        } catch (Throwable throwable) {
++            Runtime.getRuntime().halt(1);
++        }
++
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/TileEntitySkull.java b/src/main/java/net/minecraft/server/TileEntitySkull.java

--- a/CraftBukkit/0030-Add-getHostname-to-Player.patch
+++ b/CraftBukkit/0030-Add-getHostname-to-Player.patch
@@ -1,4 +1,4 @@
-From 302e9edb085ecb25da1e6a514658b18f254bef27 Mon Sep 17 00:00:00 2001
+From 39e6514d0f1b8119f3cb1a4c31fda4fa62396cf1 Mon Sep 17 00:00:00 2001
 From: Marcos Vives Del Sol <socram8888@gmail.com>
 Date: Sun, 28 Jul 2013 21:57:34 +0200
 Subject: [PATCH] Add getHostname to Player

--- a/CraftBukkit/0150-Mojang-task-queue-access.patch
+++ b/CraftBukkit/0150-Mojang-task-queue-access.patch
@@ -1,52 +1,170 @@
-From 8b0b184490efff6dc4eb8ce263954953dd244bfc Mon Sep 17 00:00:00 2001
+From 8923b7d1ae0495365b44d4746485ae9c249622df Mon Sep 17 00:00:00 2001
 From: Jedediah Smith <jedediah@silencegreys.com>
 Date: Fri, 5 Aug 2016 10:46:15 -0400
 Subject: [PATCH] Mojang task queue access
 
 
+diff --git a/src/main/java/net/minecraft/server/DedicatedServer.java b/src/main/java/net/minecraft/server/DedicatedServer.java
+index 830ec90..ece5a7c 100644
+--- a/src/main/java/net/minecraft/server/DedicatedServer.java
++++ b/src/main/java/net/minecraft/server/DedicatedServer.java
+@@ -363,7 +363,7 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
+ 
+     public void D() { // CraftBukkit - fix decompile error
+         super.D();
+-        this.aM();
++        // this.aM(); // SportBukkit - moved to processTasks()
+     }
+ 
+     public boolean getAllowNether() {
+@@ -388,6 +388,15 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
+         this.serverCommandQueue.add(new ServerCommand(s, icommandlistener));
+     }
+ 
++    // SportBukkit start
++    @Override
++    protected void processTasks() {
++        super.processTasks();
++        processCommands();
++    }
++    // SportBukkit end
++
++    public void processCommands() { aM(); } // SportBukkit - alias
+     public void aM() {
+         while (!this.serverCommandQueue.isEmpty()) {
+             ServerCommand servercommand = (ServerCommand) this.serverCommandQueue.remove(0);
+@@ -657,7 +666,7 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
+                 return remoteControlCommandListener.getMessages();
+             }
+         };
+-        processQueue.add(waitable);
++        addMainThreadTask(waitable);
+         try {
+             return waitable.get();
+         } catch (java.util.concurrent.ExecutionException e) {
+diff --git a/src/main/java/net/minecraft/server/LoginListener.java b/src/main/java/net/minecraft/server/LoginListener.java
+index 957756c..7e2a590 100644
+--- a/src/main/java/net/minecraft/server/LoginListener.java
++++ b/src/main/java/net/minecraft/server/LoginListener.java
+@@ -243,7 +243,7 @@ public class LoginListener implements PacketLoginInListener, ITickable {
+                     return event.getResult();
+                 }};
+ 
+-            LoginListener.this.server.processQueue.add(waitable);
++            LoginListener.this.server.addMainThreadTask(waitable);
+             try {
+                 if (waitable.get() != PlayerPreLoginEvent.Result.ALLOWED) {
+                     disconnect(event.getKickMessage());
+@@ -261,6 +261,7 @@ public class LoginListener implements PacketLoginInListener, ITickable {
+             }
+         }
+ 
++        server.setSuspended(false);
+         this.g = LoginListener.EnumProtocolState.READY_TO_ACCEPT;
+     }
+ 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 9eaebf5..1937be2 100644
+index 9eaebf5..5656f57 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -710,11 +710,25 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
+@@ -48,6 +48,11 @@ import org.bukkit.craftbukkit.CraftServer;
+ import org.bukkit.craftbukkit.Main;
+ // CraftBukkit end
+ 
++// SportBukkit start
++import java.time.Instant;
++import java.util.Deque;
++// SportBukkit end
++
+ public abstract class MinecraftServer implements Runnable, ICommandListener, IAsyncTaskHandler, IMojangStatistics {
+ 
+     public static final Logger LOGGER = LogManager.getLogger();
+@@ -101,6 +106,7 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
+     private final UserCache Y;
+     private long Z;
+     protected final Queue<FutureTask<?>> j = Queues.newArrayDeque();
++    protected final Deque<FutureTask<?>> taskQueue = (Deque<FutureTask<?>>) j; // SportBukkit - alias and downcast
+     private Thread serverThread;
+     void setLastTickStart(long millis) { ab = millis; } // SportBukkit - alias
+     private long ab = aw();
+@@ -114,7 +120,7 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
+     public ConsoleReader reader;
+     public static int currentTick = (int) (System.currentTimeMillis() / 50);
+     public final Thread primaryThread;
+-    public java.util.Queue<Runnable> processQueue = new java.util.concurrent.ConcurrentLinkedQueue<Runnable>();
++    //public java.util.Queue<Runnable> processQueue = new java.util.concurrent.ConcurrentLinkedQueue<Runnable>(); SportBukkit - use Mojang's task queue
+     public int autosavePeriod;
+     // CraftBukkit end
+     // SportBukkit start
+@@ -710,19 +716,25 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
          this.methodProfiler.a("jobs");
          Queue queue = this.j;
  
 +        // SportBukkit start - don't lock the task queue while running tasks
-+        for(;;) {
-+            final FutureTask<?> task;
-+            synchronized(this.j) {
-+                task = this.j.poll();
-+            }
-+            if(task == null) {
-+                break;
-+            } else {
-+                SystemUtils.a(task, MinecraftServer.LOGGER);
-+            }
-+        }
-+        /* SportBukkit end
++        processTasks();
++        /*
          synchronized (this.j) {
              while (!this.j.isEmpty()) {
                  SystemUtils.a((FutureTask) this.j.poll(), MinecraftServer.LOGGER);
              }
          }
-+        SportBukkit */
++        */
++        // SportBukkit end
  
          this.methodProfiler.c("levels");
  
-@@ -1475,6 +1489,20 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
+         // CraftBukkit start
+         // Run tasks that are waiting on processing
+-        while (!processQueue.isEmpty()) {
+-            processQueue.remove().run();
+-        }
++        // SportBukkit - use Mojang's task queue
++        //while (!processQueue.isEmpty()) {
++        //    processQueue.remove().run();
++        //}
+ 
+         org.bukkit.craftbukkit.chunkio.ChunkIOExecutor.tick();
+ 
+@@ -1475,6 +1487,47 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
          return Thread.currentThread() == this.serverThread;
      }
  
 +    // SportBukkit start
-+    public void addMainThreadTask(boolean priority, Runnable task) {
-+        synchronized(this.j) {
-+            final FutureTask<?> futureTask = ListenableFutureTask.create(task, null);
-+            final java.util.Deque<FutureTask<?>> deque = (java.util.Deque<FutureTask<?>>) this.j;
++    public void addMainThreadTask(FutureTask<?> task) {
++        addMainThreadTask(false, task);
++    }
++
++    public void addMainThreadTask(boolean priority, FutureTask<?> task) {
++        synchronized(taskQueue) {
 +            if(priority) {
-+                deque.addFirst(futureTask);
++                taskQueue.addFirst(task);
 +            } else {
-+                deque.addLast(futureTask);
++                taskQueue.addLast(task);
++            }
++        }
++    }
++
++    public void addMainThreadTask(Runnable task) {
++        addMainThreadTask(false, task);
++    }
++
++    public <T> ListenableFuture<T> addMainThreadTask(boolean priority, Runnable task) {
++        final ListenableFutureTask<T> future = ListenableFutureTask.create(task, null);
++        addMainThreadTask(priority, future);
++        return future;
++    }
++
++    protected void processTasks() {
++        if(!isMainThread()) throw new IllegalStateException("Tasks must be processed on the main thread");
++        for(;;) {
++            final FutureTask<?> task;
++            synchronized(taskQueue) {
++                task = taskQueue.poll();
++            }
++            if(task == null) {
++                break;
++            } else {
++                SystemUtils.a(task, MinecraftServer.LOGGER);
 +            }
 +        }
 +    }
@@ -55,6 +173,58 @@ index 9eaebf5..1937be2 100644
      public int aG() {
          return 256;
      }
+diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
+index 3b70010..0325ef2 100644
+--- a/src/main/java/net/minecraft/server/PlayerConnection.java
++++ b/src/main/java/net/minecraft/server/PlayerConnection.java
+@@ -1323,7 +1323,7 @@ public class PlayerConnection implements PacketListenerPlayIn, ITickable {
+                             }
+                         };
+ 
+-                        this.minecraftServer.processQueue.add(waitable);
++                        this.minecraftServer.addMainThreadTask(waitable); // SportBukkit
+ 
+                         try {
+                             waitable.get();
+@@ -1378,7 +1378,7 @@ public class PlayerConnection implements PacketListenerPlayIn, ITickable {
+                         }
+                     };
+ 
+-                    this.minecraftServer.processQueue.add(waitable);
++                    this.minecraftServer.addMainThreadTask(waitable); // SportBukkit
+ 
+                     try {
+                         waitable.get();
+@@ -1438,7 +1438,7 @@ public class PlayerConnection implements PacketListenerPlayIn, ITickable {
+                         return null;
+                     }};
+                 if (async) {
+-                    minecraftServer.processQueue.add(waitable);
++                    minecraftServer.addMainThreadTask(waitable); // SportBukkit
+                 } else {
+                     waitable.run();
+                 }
+diff --git a/src/main/java/net/minecraft/server/ServerConnection.java b/src/main/java/net/minecraft/server/ServerConnection.java
+index 7847d05..7105833 100644
+--- a/src/main/java/net/minecraft/server/ServerConnection.java
++++ b/src/main/java/net/minecraft/server/ServerConnection.java
+@@ -126,14 +126,8 @@ public class ServerConnection {
+         }
+ 
+         for(;;) {
+-            for(Iterator<ChannelFuture> iter = futures.iterator(); iter.hasNext();) {
+-                if(iter.next().isDone()) iter.remove();
+-            }
+-
+-            while(!f.processQueue.isEmpty()) {
+-                f.processQueue.remove().run();
+-            }
+-
++            futures.removeIf(java.util.concurrent.Future::isDone);
++            f.processTasks();
+             if(futures.isEmpty()) break;
+ 
+             try {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 index f43ec56..d73a58c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
@@ -112,6 +282,19 @@ index f43ec56..d73a58c 100644
 +        return task instanceof Wrapped ? task : new Wrapped();
 +    }
  }
+diff --git a/src/main/java/org/bukkit/craftbukkit/command/ConsoleCommandCompleter.java b/src/main/java/org/bukkit/craftbukkit/command/ConsoleCommandCompleter.java
+index 9dc1218..3a67414 100644
+--- a/src/main/java/org/bukkit/craftbukkit/command/ConsoleCommandCompleter.java
++++ b/src/main/java/org/bukkit/craftbukkit/command/ConsoleCommandCompleter.java
+@@ -30,7 +30,7 @@ public class ConsoleCommandCompleter implements Completer {
+                 return tabEvent.isCancelled() ? Collections.EMPTY_LIST : tabEvent.getCompletions();
+             }
+         };
+-        this.server.getServer().processQueue.add(waitable);
++        this.server.getServer().addMainThreadTask(waitable);
+         try {
+             List<String> offers = waitable.get();
+             if (offers == null) {
 -- 
 1.9.0
 

--- a/CraftBukkit/0162-Server-suspend-API.patch
+++ b/CraftBukkit/0162-Server-suspend-API.patch
@@ -1,0 +1,335 @@
+From 8ef38c8d3b07956c87ac5619f3028fbcb52bccd9 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Sat, 10 Dec 2016 20:28:26 -0500
+Subject: [PATCH] Server suspend API
+
+
+diff --git a/src/main/java/net/minecraft/server/DedicatedServer.java b/src/main/java/net/minecraft/server/DedicatedServer.java
+index ece5a7c..87f710d 100644
+--- a/src/main/java/net/minecraft/server/DedicatedServer.java
++++ b/src/main/java/net/minecraft/server/DedicatedServer.java
+@@ -280,6 +280,7 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
+                     thread1.setName("Server Watchdog");
+                     thread1.setDaemon(true);
+                     thread1.start();
++                    watchdogThread = thread1; // SportBukkit
+                 }
+ 
+                 return true;
+@@ -386,6 +387,7 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
+ 
+     public void issueCommand(String s, ICommandListener icommandlistener) {
+         this.serverCommandQueue.add(new ServerCommand(s, icommandlistener));
++        interrupt(); // SportBukkit
+     }
+ 
+     // SportBukkit start
+diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
+index 5656f57..835dae4 100644
+--- a/src/main/java/net/minecraft/server/MinecraftServer.java
++++ b/src/main/java/net/minecraft/server/MinecraftServer.java
+@@ -51,6 +51,9 @@ import org.bukkit.craftbukkit.Main;
+ // SportBukkit start
+ import java.time.Instant;
+ import java.util.Deque;
++import java.util.concurrent.atomic.AtomicBoolean;
++import org.bukkit.event.EventBody;
++import org.bukkit.event.server.ServerSuspendEvent;
+ // SportBukkit end
+ 
+ public abstract class MinecraftServer implements Runnable, ICommandListener, IAsyncTaskHandler, IMojangStatistics {
+@@ -132,6 +135,13 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
+     protected boolean abnormalTermination;
+     // Sportbukkit end
+ 
++    // SportBukkit start
++    private final AtomicBoolean suspended = new AtomicBoolean(false);
++    private @Nullable Instant suspendedAt;
++    private int interruptions;
++    protected Thread watchdogThread;
++    // SportBukkit end
++
+     public MinecraftServer(OptionSet options, Proxy proxy, DataConverterManager dataconvertermanager, YggdrasilAuthenticationService yggdrasilauthenticationservice, MinecraftSessionService minecraftsessionservice, GameProfileRepository gameprofilerepository, UserCache usercache) {
+         this.e = proxy;
+         this.V = yggdrasilauthenticationservice;
+@@ -534,9 +544,75 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
+ 
+     public void safeShutdown() {
+         this.isRunning = false;
++        setSuspended(false); // SportBukkit
++    }
++
++    // SportBukkit start
++    public boolean isSuspended() {
++        return isRunning() && suspended.get();
++    }
++
++    public boolean canSuspend() {
++        return isRunning() && !p.hasClientConnections();
++    }
++
++    public boolean setSuspended(boolean suspend) {
++        if(suspend && !canSuspend()) return false;
++
++        if(suspended.compareAndSet(!suspend, suspend)) {
++            if(!isMainThread() && !suspend) {
++                serverThread.interrupt();
++            }
++            return true;
++        }
++
++        return false;
++    }
++
++    public @Nullable Instant suspendedAt() {
++        return suspendedAt;
++    }
++
++    public int interruptions() {
++        return interruptions;
++    }
++
++    private boolean doSuspension() {
++        if(isSuspended()) {
++            server.eventBus().callEvent(new ServerSuspendEvent(), (EventBody<ServerSuspendEvent, RuntimeException>) ev -> { // Cast needed due to javac bug
++                server.getLogger().info("Suspending server");
++                suspendedAt = Instant.now();
++                interruptions = 0;
++
++                if(watchdogThread != null) watchdogThread.interrupt();
++
++                while(isSuspended()) {
++                    processTasks(); // Empty the task queue
++                    if(isSuspended()) { // Check suspended state again, in case a task resumed
++                        try { Thread.sleep(Long.MAX_VALUE); }
++                        catch(InterruptedException ignored) {}
++                        interruptions++;
++                    }
++                }
++
++                if(watchdogThread != null) watchdogThread.interrupt();
++
++                interruptions = 0;
++                suspendedAt = null;
++                setLastTickStart(realTimeMillis());
++                server.getLogger().info("Resuming server");
++            });
++            return true;
++        }
++        return false;
++    }
++
++    public void interrupt() {
++        if(!isMainThread() && suspended.get()) {
++            serverThread.interrupt();
++        }
+     }
+ 
+-    // SportBukkit Start
+     private static double calcTps(double avg, double exp, double tps)
+     {
+         return ( avg * exp ) + ( tps * ( 1 - exp ) );
+@@ -552,18 +628,22 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
+ 
+                 // SportBukkit start
+                 Arrays.fill( recentTps, 20 );
+-                long lastTick = System.nanoTime(), catchupTime = 0, curTime, wait, tickSection = lastTick;
++                long lastTick = System.nanoTime(), catchupTime = 0, curTime, tickSection = lastTick;
+                 while (this.isRunning) {
+                     setLastTickStart(realTimeMillis());
+ 
+                     curTime = System.nanoTime();
+-                    wait = TICK_TIME - (curTime - lastTick) - catchupTime;
+-                    if (wait > 0) {
+-                        Thread.sleep(wait / 1000000);
++                    final long wait = TICK_TIME - (curTime - lastTick) - catchupTime;
++                    if(wait < 0) {
++                        catchupTime = Math.min(1000000000, Math.abs(wait));
++                    } else {
+                         catchupTime = 0;
++                        if(doSuspension()) {
++                            tickSection = lastTick = curTime - TICK_TIME;
++                        } else {
++                            Thread.sleep(wait / 1000000);
++                        }
+                         continue;
+-                    } else {
+-                        catchupTime = Math.min(1000000000, Math.abs(wait));
+                     }
+ 
+                     if ( MinecraftServer.currentTick++ % SAMPLE_INTERVAL == 0 )
+@@ -718,6 +798,8 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
+ 
+         // SportBukkit start - don't lock the task queue while running tasks
+         processTasks();
++        this.server.checkEmpty();
++        if(suspended.get()) return;
+         /*
+         synchronized (this.j) {
+             while (!this.j.isEmpty()) {
+@@ -1467,6 +1549,7 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
+ 
+             synchronized (this.j) {
+                 this.j.add(listenablefuturetask);
++                interrupt(); // SportBukkit
+                 return listenablefuturetask;
+             }
+         } else {
+@@ -1500,6 +1583,7 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
+                 taskQueue.addLast(task);
+             }
+         }
++        interrupt();
+     }
+ 
+     public void addMainThreadTask(Runnable task) {
+diff --git a/src/main/java/net/minecraft/server/ServerConnection.java b/src/main/java/net/minecraft/server/ServerConnection.java
+index 7105833..0b45b38 100644
+--- a/src/main/java/net/minecraft/server/ServerConnection.java
++++ b/src/main/java/net/minecraft/server/ServerConnection.java
+@@ -192,4 +192,10 @@ public class ServerConnection {
+     public MinecraftServer d() {
+         return this.f;
+     }
++
++    // SportBukkit start
++    public boolean hasClientConnections() {
++        return !h.isEmpty();
++    }
++    // SportBukkit end
+ }
+diff --git a/src/main/java/net/minecraft/server/ThreadWatchdog.java b/src/main/java/net/minecraft/server/ThreadWatchdog.java
+index da6702c..99f49c0 100644
+--- a/src/main/java/net/minecraft/server/ThreadWatchdog.java
++++ b/src/main/java/net/minecraft/server/ThreadWatchdog.java
+@@ -22,8 +22,17 @@ public class ThreadWatchdog implements Runnable {
+         this.c = dedicatedserver.aQ();
+     }
+ 
++    // SportBukkit start
++    synchronized private void doSuspension() {
++        while(this.b.isSuspended()) {
++            try { wait(); } catch(InterruptedException ignored) {}
++        }
++    }
++    // SportBukkit end
++
+     public void run() {
+         while (this.b.isRunning()) {
++            doSuspension(); // SportBukkit
+             long i = this.b.aH();
+             long j = MinecraftServer.aw();
+             long k = j - i;
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+index 7b65f00..8912202 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+@@ -6,6 +6,8 @@ import java.io.FileInputStream;
+ import java.io.FileNotFoundException;
+ import java.io.IOException;
+ import java.io.InputStreamReader;
++import java.time.Duration;
++import java.time.Instant;
+ import java.util.ArrayList;
+ import java.util.Arrays;
+ import java.util.Collections;
+@@ -20,7 +22,7 @@ import java.util.UUID;
+ import java.util.logging.Level;
+ import java.util.logging.Logger;
+ import java.util.regex.Pattern;
+-
++import javax.annotation.Nullable;
+ import javax.imageio.ImageIO;
+ 
+ import net.minecraft.server.*;
+@@ -136,6 +138,7 @@ import io.netty.handler.codec.base64.Base64;
+ import jline.console.ConsoleReader;
+ import org.bukkit.event.server.TabCompleteEvent;
+ import net.md_5.bungee.api.chat.BaseComponent;
++import tc.oc.minecraft.api.configuration.InvalidConfigurationException;
+ import tc.oc.minecraft.api.plugin.PluginFinder;
+ 
+ public final class CraftServer extends CraftBukkitRuntime implements Server {
+@@ -183,6 +186,8 @@ public final class CraftServer extends CraftBukkitRuntime implements Server {
+     public boolean bungee = false;
+     public static final com.google.gson.Gson gson = new com.google.gson.Gson();
+ 
++    private @Nullable Instant emptySince;
++
+     private final class BooleanWrapper {
+         private boolean value = true;
+     }
+@@ -662,6 +667,16 @@ public final class CraftServer extends CraftBukkitRuntime implements Server {
+     }
+ 
+     @Override
++    public @Nullable Duration getEmptyServerSuspendDelay() {
++        try {
++            return this.configuration.getDuration("settings.empty-server-suspend");
++        } catch(InvalidConfigurationException e) {
++            getLogger().log(Level.SEVERE, "Invalid configuration value", e);
++            return null;
++        }
++    }
++
++    @Override
+     public PluginManager getPluginManager() {
+         return pluginManager;
+     }
+@@ -1879,4 +1894,53 @@ public final class CraftServer extends CraftBukkitRuntime implements Server {
+ 
+         return task instanceof Wrapped ? task : new Wrapped();
+     }
++
++    @Override
++    public boolean isSuspended() {
++        return getServer().isSuspended();
++    }
++
++    @Override
++    public boolean canSuspend() {
++        return getServer().canSuspend();
++    }
++
++    @Override
++    public boolean setSuspended(boolean suspend) {
++        return getServer().setSuspended(suspend);
++    }
++
++    @Override
++    public @Nullable Instant suspendedAt() {
++        return getServer().suspendedAt();
++    }
++
++    @Override
++    public int interruptions() {
++        return getServer().interruptions();
++    }
++
++    @Override
++    public @Nullable Instant emptySince() {
++        if(getOnlinePlayers().isEmpty()) {
++            if(emptySince == null) {
++                emptySince = Instant.now();
++            }
++        } else {
++            emptySince = null;
++        }
++        return emptySince;
++    }
++
++    public void checkEmpty() {
++        final Instant since = emptySince();
++        if(since == null) {
++            setSuspended(false);
++        } else {
++            final Duration delay = getEmptyServerSuspendDelay();
++            if(delay != null && canSuspend() && !since.plus(delay).isAfter(Instant.now())) {
++                setSuspended(true);
++            }
++        }
++    }
+ }
+-- 
+1.9.0
+


### PR DESCRIPTION
Provide a way to put the server in a "suspended" state, where it does not tick or run any scheduled tasks. The server can only be suspended when empty, and resumes automatically when a player connects. The server can be suspended through the API, or by an automatic timeout configured in `bukkit.yml`.