### PR TITLE
Guice plugin support

### DIFF
--- a/Bukkit/0084-Pause-entity-API.patch
+++ b/Bukkit/0084-Pause-entity-API.patch
@@ -1,4 +1,4 @@
-From 74b25a55e2e0fb8828de6916ede79236d38921a5 Mon Sep 17 00:00:00 2001
+From df39b993b223c4cc3012c8180711f3b4e6fac97a Mon Sep 17 00:00:00 2001
 From: Jedediah Smith <jedediah@silencegreys.com>
 Date: Sat, 3 Dec 2016 23:45:45 -0500
 Subject: [PATCH] Pause entity API

--- a/Bukkit/0085-More-ways-to-spawn-FallingBlocks.patch
+++ b/Bukkit/0085-More-ways-to-spawn-FallingBlocks.patch
@@ -1,4 +1,4 @@
-From c03c4ba6249232ef4971a3da0b65fb51e6c59041 Mon Sep 17 00:00:00 2001
+From 1337e103795d4cbe196a65850b7597a884c35697 Mon Sep 17 00:00:00 2001
 From: Jedediah Smith <jedediah@silencegreys.com>
 Date: Wed, 7 Dec 2016 04:08:39 -0500
 Subject: [PATCH] More ways to spawn FallingBlocks

--- a/Bukkit/0086-FallingBlock-form-block-flag.patch
+++ b/Bukkit/0086-FallingBlock-form-block-flag.patch
@@ -1,4 +1,4 @@
-From 59a6e6b92c7588837ccbce5268e513697a7a6596 Mon Sep 17 00:00:00 2001
+From 2dc5ee1f8a1cd84e3accbfc7aaebca7927652f32 Mon Sep 17 00:00:00 2001
 From: Jedediah Smith <jedediah@silencegreys.com>
 Date: Wed, 7 Dec 2016 04:29:15 -0500
 Subject: [PATCH] FallingBlock form block flag

--- a/Bukkit/0087-Chest-lid-API.patch
+++ b/Bukkit/0087-Chest-lid-API.patch
@@ -1,4 +1,4 @@
-From 950ca21895b53cfaaab4874b3d6d5a072548d9b2 Mon Sep 17 00:00:00 2001
+From 23473dfb45d952b46caf131b3a5bca4b56c96c56 Mon Sep 17 00:00:00 2001
 From: Jedediah Smith <jedediah@silencegreys.com>
 Date: Sat, 24 Dec 2016 19:58:54 -0500
 Subject: [PATCH] Chest lid API

--- a/Bukkit/0088-New-event-API.patch
+++ b/Bukkit/0088-New-event-API.patch
@@ -1,4 +1,4 @@
-From 890cd84648c3311513c84d255d20de6916518671 Mon Sep 17 00:00:00 2001
+From 53589c6514f819f44c53390c1f2041910313552d Mon Sep 17 00:00:00 2001
 From: Jedediah Smith <jedediah@silencegreys.com>
 Date: Sat, 9 Jul 2016 05:27:03 -0400
 Subject: [PATCH] New event API
@@ -38,8 +38,85 @@ index b3837d9..867f2d0 100644
      /**
       * Gets the instance of the item factory (for {@link ItemMeta}).
       *
+diff --git a/src/main/java/org/bukkit/BukkitModule.java b/src/main/java/org/bukkit/BukkitModule.java
+new file mode 100644
+index 0000000..2cb3a71
+--- /dev/null
++++ b/src/main/java/org/bukkit/BukkitModule.java
+@@ -0,0 +1,44 @@
++package org.bukkit;
++
++import com.google.inject.Provides;
++import org.bukkit.block.BlockFactory;
++import org.bukkit.geometry.VectorFactory;
++import org.bukkit.inventory.ItemFactory;
++import org.bukkit.potion.PotionBrewRegistry;
++import org.bukkit.potion.PotionEffectRegistry;
++import tc.oc.inject.SingletonModule;
++
++/**
++ * Bindings for global things that would be shared between servers,
++ * if there were multiple servers.
++ */
++public class BukkitModule extends SingletonModule {
++
++    @Override
++    protected void configure() {}
++
++    @Provides
++    VectorFactory vectorFactory(BukkitRuntime bukkit) {
++        return bukkit.vectors();
++    }
++
++    @Provides
++    BlockFactory blockFactory(BukkitRuntime bukkit) {
++        return bukkit.blocks();
++    }
++
++    @Provides
++    ItemFactory itemFactory(BukkitRuntime bukkit) {
++        return bukkit.getItemFactory();
++    }
++
++    @Provides
++    PotionEffectRegistry potionEffectRegistry(BukkitRuntime bukkit) {
++        return bukkit.potionEffectRegistry();
++    }
++
++    @Provides
++    PotionBrewRegistry potionBrewRegistry(BukkitRuntime bukkit) {
++        return bukkit.potionRegistry();
++    }
++}
+diff --git a/src/main/java/org/bukkit/BukkitRuntime.java b/src/main/java/org/bukkit/BukkitRuntime.java
+index 8a7b3a2..ed038b8 100644
+--- a/src/main/java/org/bukkit/BukkitRuntime.java
++++ b/src/main/java/org/bukkit/BukkitRuntime.java
+@@ -1,5 +1,6 @@
+ package org.bukkit;
+ 
++import com.google.inject.Injector;
+ import org.bukkit.block.BlockFactory;
+ import org.bukkit.inventory.ItemFactory;
+ import org.bukkit.inventory.meta.ItemMeta;
+@@ -10,6 +11,15 @@ import org.bukkit.geometry.VectorFactory;
+ 
+ public interface BukkitRuntime {
+ 
++    /**
++     * Return the global {@link Injector}.
++     *
++     * Note that direct injector use is considered bad form,
++     * and is only provided to assist in migrating legacy code.
++     * Nice code should @Inject its dependencies.
++     */
++    Injector injector();
++
+     Key key(String prefix, String id);
+ 
+     Key key(String key);
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index deecc6e..c1a982f 100644
+index deecc6e..079f496 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -24,6 +24,7 @@ import org.bukkit.command.ConsoleCommandSender;
@@ -50,7 +127,16 @@ index deecc6e..c1a982f 100644
  import org.bukkit.event.inventory.InventoryType;
  import org.bukkit.event.server.ServerListPingEvent;
  import org.bukkit.help.HelpMap;
-@@ -440,6 +441,11 @@ public interface Server extends PluginMessageRecipient, BukkitRuntime, tc.oc.min
+@@ -134,6 +135,8 @@ public interface Server extends PluginMessageRecipient, BukkitRuntime, tc.oc.min
+      */
+     public Collection<? extends Player> getOnlinePlayers();
+ 
++    Map<UUID, Player> playersById();
++
+     /**
+      * Get the maximum amount of players which can login to this server.
+      *
+@@ -440,12 +443,21 @@ public interface Server extends PluginMessageRecipient, BukkitRuntime, tc.oc.min
      public ServicesManager getServicesManager();
  
      /**
@@ -62,7 +148,17 @@ index deecc6e..c1a982f 100644
       * Gets a list of all worlds on this server.
       *
       * @return a list of worlds
-@@ -928,6 +934,8 @@ public interface Server extends PluginMessageRecipient, BukkitRuntime, tc.oc.min
+      */
+     public List<World> getWorlds();
+ 
++    Map<String, World> worldsByName();
++
++    Map<UUID, World> worldsById();
++
+     /**
+      * Check for a level.dat file belonging to a world with the given name.
+      * If found, return a {@link WorldCreator} configured to match the settings
+@@ -928,6 +940,8 @@ public interface Server extends PluginMessageRecipient, BukkitRuntime, tc.oc.min
       */
      public WarningState getWarningState();
  
@@ -71,6 +167,164 @@ index deecc6e..c1a982f 100644
      /**
       * Gets the instance of the item factory (for {@link ItemMeta}).
       *
+diff --git a/src/main/java/org/bukkit/ServerInstanceModule.java b/src/main/java/org/bukkit/ServerInstanceModule.java
+new file mode 100644
+index 0000000..4c82a5f
+--- /dev/null
++++ b/src/main/java/org/bukkit/ServerInstanceModule.java
+@@ -0,0 +1,35 @@
++package org.bukkit;
++
++import java.util.Collection;
++
++import com.google.inject.AbstractModule;
++import org.bukkit.plugin.Plugin;
++import org.bukkit.plugin.PluginInstanceModule;
++import tc.oc.inject.KeyedModule;
++import tc.oc.inject.ProtectedBinder;
++
++/**
++ * Configures a {@link Server} instance and a collection of {@link Plugin}s.
++ */
++public class ServerInstanceModule extends KeyedModule {
++
++    private final Server server;
++    private final Collection<Plugin> plugins;
++
++    public ServerInstanceModule(Server server, Collection<Plugin> plugins) {
++        super(server);
++        this.server = server;
++        this.plugins = plugins;
++    }
++
++    @Override
++    protected void configure() {
++        install(new ServerModule());
++        bind(Server.class).toInstance(server);
++
++        for(Plugin plugin : plugins) {
++            ProtectedBinder.newProtectedBinder(binder())
++                           .install(new PluginInstanceModule(plugin));
++        }
++    }
++}
+diff --git a/src/main/java/org/bukkit/ServerModule.java b/src/main/java/org/bukkit/ServerModule.java
+new file mode 100644
+index 0000000..373967b
+--- /dev/null
++++ b/src/main/java/org/bukkit/ServerModule.java
+@@ -0,0 +1,111 @@
++package org.bukkit;
++
++import java.util.Collection;
++import java.util.Map;
++import java.util.UUID;
++
++import com.google.inject.Provides;
++import org.bukkit.command.CommandMap;
++import org.bukkit.command.ConsoleCommandSender;
++import org.bukkit.entity.Player;
++import org.bukkit.event.EventBus;
++import org.bukkit.help.HelpMap;
++import org.bukkit.plugin.PluginManager;
++import org.bukkit.plugin.ServicesManager;
++import org.bukkit.plugin.messaging.Messenger;
++import org.bukkit.scheduler.BukkitScheduler;
++import org.bukkit.scoreboard.ScoreboardManager;
++import tc.oc.inject.SingletonModule;
++import tc.oc.minecraft.api.plugin.PluginFinder;
++import tc.oc.minecraft.api.server.LocalServer;
++
++/**
++ * Bindings for things that belong to a {@link Server}.
++ *
++ * Does not bind {@link Server} itself.
++ *
++ * @see ServerInstanceModule
++ */
++public class ServerModule extends SingletonModule {
++
++    @Override
++    protected void configure() {
++        install(new BukkitModule());
++
++        bind(tc.oc.minecraft.api.server.Server.class).to(LocalServer.class);
++        bind(LocalServer.class).to(Server.class);
++        bind(BukkitRuntime.class).to(Server.class);
++        bind(tc.oc.minecraft.api.command.ConsoleCommandSender.class).to(ConsoleCommandSender.class);
++        bind(PluginFinder.class).to(PluginManager.class);
++    }
++
++    @Provides
++    PluginManager pluginManager(Server server) {
++        return server.getPluginManager();
++    }
++
++    @Provides
++    EventBus eventBus(Server server) {
++        return server.eventBus();
++    }
++
++    @Provides
++    BukkitScheduler bukkitScheduler(Server server) {
++        return server.getScheduler();
++    }
++
++    @Provides
++    CommandMap commandMap(Server server) {
++        return server.getCommandMap();
++    }
++
++    @Provides
++    HelpMap helpMap(Server server) {
++        return server.getHelpMap();
++    }
++
++    @Provides
++    ConsoleCommandSender consoleCommandSender(Server server) {
++        return server.getConsoleSender();
++    }
++
++    @Provides
++    Messenger messenger(Server server) {
++        return server.getMessenger();
++    }
++
++    @Provides
++    ScoreboardManager scoreboardManager(Server server) {
++        return server.getScoreboardManager();
++    }
++
++    @Provides
++    ServicesManager servicesManager(Server server) {
++        return server.getServicesManager();
++    }
++
++    @Provides
++    Collection<World> worlds(Server server) {
++        return server.worldsById().values();
++    }
++
++    @Provides
++    Map<UUID, World> worldsById(Server server) {
++        return server.worldsById();
++    }
++
++    @Provides
++    Map<String, World> worldsByName(Server server) {
++        return server.worldsByName();
++    }
++
++    @Provides
++    Collection<Player> onlinePlayers(Server server) {
++        return (Collection<Player>) server.getOnlinePlayers();
++    }
++
++    @Provides
++    Map<UUID, Player> playersById(Server server) {
++        return server.playersById();
++    }
++}
 diff --git a/src/main/java/org/bukkit/command/defaults/TimingsCommand.java b/src/main/java/org/bukkit/command/defaults/TimingsCommand.java
 index a39ea5d..09554e4 100644
 --- a/src/main/java/org/bukkit/command/defaults/TimingsCommand.java
@@ -103,7 +357,7 @@ index a39ea5d..09554e4 100644
                      }
 diff --git a/src/main/java/org/bukkit/event/BoundEventHandler.java b/src/main/java/org/bukkit/event/BoundEventHandler.java
 new file mode 100644
-index 0000000..2c70a55
+index 0000000..0fd01db
 --- /dev/null
 +++ b/src/main/java/org/bukkit/event/BoundEventHandler.java
 @@ -0,0 +1,74 @@
@@ -111,13 +365,13 @@ index 0000000..2c70a55
 +
 +import java.util.Objects;
 +
-+import org.bukkit.plugin.EventExecutor;
++import tc.oc.minecraft.api.event.Listener;
 +
 +import static com.google.common.base.Preconditions.checkNotNull;
 +
 +/**
 + * A {@link RegisteredHandler} associated with a {@link Listener}, that passes events
-+ * to an {@link EventExecutor}, along with that listener.
++ * to an {@link EventMethodExecutor}, along with that listener.
 + */
 +public class BoundEventHandler<T extends Event> implements RegisteredHandler<T> {
 +
@@ -183,14 +437,14 @@ index 0000000..2c70a55
 +}
 diff --git a/src/main/java/org/bukkit/event/CallableEventHandler.java b/src/main/java/org/bukkit/event/CallableEventHandler.java
 new file mode 100644
-index 0000000..52d6df8
+index 0000000..fa77ef1
 --- /dev/null
 +++ b/src/main/java/org/bukkit/event/CallableEventHandler.java
 @@ -0,0 +1,101 @@
 +package org.bukkit.event;
 +
-+import org.bukkit.exception.ExceptionHandler;
-+import org.bukkit.exception.LoggingExceptionHandler;
++import tc.oc.exception.ExceptionHandler;
++import tc.oc.exception.LoggingExceptionHandler;
 +
 +import static com.google.common.base.Preconditions.checkNotNull;
 +
@@ -464,7 +718,7 @@ index 0000000..7abbbbb
 +}
 diff --git a/src/main/java/org/bukkit/event/EventBus.java b/src/main/java/org/bukkit/event/EventBus.java
 new file mode 100644
-index 0000000..91383e1
+index 0000000..7fac014
 --- /dev/null
 +++ b/src/main/java/org/bukkit/event/EventBus.java
 @@ -0,0 +1,55 @@
@@ -472,7 +726,7 @@ index 0000000..91383e1
 +
 +import javax.annotation.Nullable;
 +
-+import org.bukkit.exception.ExceptionHandler;
++import tc.oc.exception.ExceptionHandler;
 +
 +public interface EventBus {
 +
@@ -553,6 +807,19 @@ index aef8d49..d34096e 100644
  public class EventException extends Exception {
      private static final long serialVersionUID = 3532808232324183999L;
      private final Event event;
+diff --git a/src/main/java/org/bukkit/event/EventExecutor.java b/src/main/java/org/bukkit/event/EventExecutor.java
+new file mode 100644
+index 0000000..7bfa1c9
+--- /dev/null
++++ b/src/main/java/org/bukkit/event/EventExecutor.java
+@@ -0,0 +1,7 @@
++package org.bukkit.event;
++
++import tc.oc.minecraft.api.event.Listener;
++
++public interface EventExecutor<T extends Event> {
++    void execute(Listener listener, T event) throws EventException;
++}
 diff --git a/src/main/java/org/bukkit/event/EventHandlerMeta.java b/src/main/java/org/bukkit/event/EventHandlerMeta.java
 new file mode 100644
 index 0000000..54f89ac
@@ -681,10 +948,10 @@ index 0000000..54f89ac
 +}
 diff --git a/src/main/java/org/bukkit/event/EventMethodExecutor.java b/src/main/java/org/bukkit/event/EventMethodExecutor.java
 new file mode 100644
-index 0000000..05ba959
+index 0000000..ac3afad
 --- /dev/null
 +++ b/src/main/java/org/bukkit/event/EventMethodExecutor.java
-@@ -0,0 +1,120 @@
+@@ -0,0 +1,119 @@
 +package org.bukkit.event;
 +
 +import java.lang.reflect.InvocationTargetException;
@@ -693,8 +960,8 @@ index 0000000..05ba959
 +import java.util.stream.Stream;
 +import javax.annotation.Nullable;
 +
-+import org.bukkit.exception.ExceptionHandler;
-+import org.bukkit.plugin.EventExecutor;
++import tc.oc.exception.ExceptionHandler;
++import tc.oc.minecraft.api.event.Listener;
 +
 +import static com.google.common.base.Preconditions.checkNotNull;
 +
@@ -734,7 +1001,6 @@ index 0000000..05ba959
 +        return new BoundEventHandler<>(meta, this, listener);
 +    }
 +
-+    @Override
 +    public void execute(Listener listener, T event) throws EventException {
 +        if(meta.canHandle(event, null)) {
 +            try {
@@ -807,18 +1073,18 @@ index 0000000..05ba959
 +}
 diff --git a/src/main/java/org/bukkit/event/EventRegistry.java b/src/main/java/org/bukkit/event/EventRegistry.java
 new file mode 100644
-index 0000000..d10b10d
+index 0000000..dcf4a37
 --- /dev/null
 +++ b/src/main/java/org/bukkit/event/EventRegistry.java
-@@ -0,0 +1,98 @@
+@@ -0,0 +1,80 @@
 +package org.bukkit.event;
 +
 +import java.lang.reflect.Method;
 +import java.util.stream.Stream;
 +import javax.annotation.Nullable;
 +
-+import org.bukkit.exception.ExceptionHandler;
-+import org.bukkit.plugin.EventExecutor;
++import tc.oc.exception.ExceptionHandler;
++import tc.oc.minecraft.api.event.Listener;
 +
 +/**
 + * Service used to reflectively create and register {@link RegisteredHandler}s for {@link Listener}s.
@@ -829,7 +1095,7 @@ index 0000000..d10b10d
 + * An {@link EventRegistry} has an implicit {@link ExceptionHandler} that it uses to
 + * construct handlers, though this is not exposed in the base API.
 + */
-+public interface EventRegistry {
++public interface EventRegistry extends tc.oc.minecraft.api.event.EventRegistry {
 +
 +    /**
 +     * Create a {@link EventMethodExecutor} wrapping the given method.
@@ -861,7 +1127,7 @@ index 0000000..d10b10d
 +     * TODO: The executor could be created from a different registry.
 +     * It's hard to prevent this while still supporting the old API.
 +     */
-+    <T extends Event> BoundEventHandler<T> bindHandler(EventHandlerMeta<T> meta, EventExecutor<T> executor, Listener listener);
++    <T extends Event> BoundEventHandler<T> bindHandler(EventHandlerMeta<T> meta, Listener listener, EventExecutor<T> executor);
 +
 +    /**
 +     * Create a {@link BoundEventHandler} binding the given {@link EventMethodExecutor} to the given {@link Listener}.
@@ -873,7 +1139,7 @@ index 0000000..d10b10d
 +     * TODO: The executor could be created from a different registry.
 +     * It's hard to prevent this while still supporting the old API.
 +     */
-+    <T extends Event> BoundEventHandler<T> bindHandler(EventMethodExecutor<T> executor, Listener listener);
++    <T extends Event> BoundEventHandler<T> bindHandler(Listener listener, EventMethodExecutor<T> executor);
 +
 +    /**
 +     * Create {@link EventMethodExecutor}s for all event handler methods found in the given {@link Listener} class.
@@ -890,24 +1156,6 @@ index 0000000..d10b10d
 +     * @see #createHandlers
 +     */
 +    Stream<BoundEventHandler<?>> bindHandlers(Listener listener);
-+
-+    /**
-+     * Register all event handler methods found in the given {@link Listener} to receive events.
-+     *
-+     * @see #createHandlers
-+     */
-+    void registerListener(Listener listener);
-+
-+    /**
-+     * Unregister all event handlers created from this {@link EventRegistry}
-+     * that belong to the given {@link Listener}.
-+     */
-+    void unregisterListener(Listener listener);
-+
-+    /**
-+     * Unregister all event handlers created from this {@link EventRegistry}.
-+     */
-+    void unregisterAll();
 +}
 diff --git a/src/main/java/org/bukkit/event/HandlerList.java b/src/main/java/org/bukkit/event/HandlerList.java
 index 7d5efff..821220a 100644
@@ -1348,19 +1596,20 @@ index 0000000..6d57ff4
 +}
 diff --git a/src/main/java/org/bukkit/event/SimpleEventRegistry.java b/src/main/java/org/bukkit/event/SimpleEventRegistry.java
 new file mode 100644
-index 0000000..94a7b90
+index 0000000..2b37b7a
 --- /dev/null
 +++ b/src/main/java/org/bukkit/event/SimpleEventRegistry.java
-@@ -0,0 +1,87 @@
+@@ -0,0 +1,88 @@
 +package org.bukkit.event;
 +
 +import java.lang.reflect.Method;
 +import java.util.stream.Stream;
 +import javax.annotation.Nullable;
++import javax.inject.Inject;
 +
-+import org.bukkit.exception.ExceptionHandler;
-+import org.bukkit.exception.LoggingExceptionHandler;
-+import org.bukkit.plugin.EventExecutor;
++import tc.oc.exception.ExceptionHandler;
++import tc.oc.exception.LoggingExceptionHandler;
++import tc.oc.minecraft.api.event.Listener;
 +
 +public class SimpleEventRegistry implements EventRegistry {
 +
@@ -1370,18 +1619,18 @@ index 0000000..94a7b90
 +        this(null);
 +    }
 +
-+    public SimpleEventRegistry(@Nullable ExceptionHandler exceptionHandler) {
++    @Inject public SimpleEventRegistry(@Nullable ExceptionHandler exceptionHandler) {
 +        this.exceptionHandler = exceptionHandler != null ? exceptionHandler
 +                                                         : LoggingExceptionHandler.forGlobalLogger();
 +    }
 +
 +    @Override
-+    public <T extends Event> BoundEventHandler<T> bindHandler(EventHandlerMeta<T> meta, EventExecutor<T> executor, Listener listener) {
++    public <T extends Event> BoundEventHandler<T> bindHandler(EventHandlerMeta<T> meta, Listener listener, EventExecutor<T> executor) {
 +        return new OwnedEventHandler<>(meta, executor, listener);
 +    }
 +
 +    @Override
-+    public <T extends Event> BoundEventHandler<T> bindHandler(EventMethodExecutor<T> executor, Listener listener) {
++    public <T extends Event> BoundEventHandler<T> bindHandler(Listener listener, EventMethodExecutor<T> executor) {
 +        return new OwnedEventHandler<>(executor, listener);
 +    }
 +
@@ -1403,7 +1652,7 @@ index 0000000..94a7b90
 +    @Override
 +    public Stream<BoundEventHandler<?>> bindHandlers(Listener listener) {
 +        return createHandlers(listener.getClass())
-+            .map(unbound -> bindHandler(unbound, listener));
++            .map(unbound -> bindHandler(listener, unbound));
 +    }
 +
 +    @Override
@@ -1439,80 +1688,245 @@ index 0000000..94a7b90
 +        }
 +    }
 +}
-diff --git a/src/main/java/org/bukkit/exception/ExceptionHandler.java b/src/main/java/org/bukkit/exception/ExceptionHandler.java
+diff --git a/src/main/java/org/bukkit/permissions/PermissionBinder.java b/src/main/java/org/bukkit/permissions/PermissionBinder.java
 new file mode 100644
-index 0000000..fc1acc1
+index 0000000..bb0172e
 --- /dev/null
-+++ b/src/main/java/org/bukkit/exception/ExceptionHandler.java
-@@ -0,0 +1,15 @@
-+package org.bukkit.exception;
++++ b/src/main/java/org/bukkit/permissions/PermissionBinder.java
+@@ -0,0 +1,18 @@
++package org.bukkit.permissions;
 +
-+/**
-+ * An object that encapsulates the handling of exceptions.
-+ *
-+ * Think of it as a catch block wrapper.
-+ */
-+public interface ExceptionHandler {
++import com.google.inject.Binder;
++import com.google.inject.binder.LinkedBindingBuilder;
++import com.google.inject.multibindings.Multibinder;
 +
-+    void handleException(Throwable exception, String message);
++public class PermissionBinder {
 +
-+    default void handleException(Throwable exception) {
-+        handleException(exception, "Uncaught exception");
++    private final Multibinder<Permission> permissions;
++
++    public PermissionBinder(Binder binder) {
++        this.permissions = Multibinder.newSetBinder(binder, Permission.class);
++    }
++
++    public LinkedBindingBuilder<Permission> bindPermission() {
++        return permissions.addBinding();
 +    }
 +}
-diff --git a/src/main/java/org/bukkit/exception/LoggingExceptionHandler.java b/src/main/java/org/bukkit/exception/LoggingExceptionHandler.java
+diff --git a/src/main/java/org/bukkit/plugin/EventExecutor.java b/src/main/java/org/bukkit/plugin/EventExecutor.java
+index 3b2c99e..2a994fa 100644
+--- a/src/main/java/org/bukkit/plugin/EventExecutor.java
++++ b/src/main/java/org/bukkit/plugin/EventExecutor.java
+@@ -5,8 +5,9 @@ import org.bukkit.event.EventException;
+ import org.bukkit.event.Listener;
+ 
+ /**
+- * Interface which defines the class for event call backs to plugins
++ * An event handler that belongs to a {@link Listener}, and must be passed an
++ * instance of the listener when handling an event.
+  */
+ public interface EventExecutor {
+-    public void execute(Listener listener, Event event) throws EventException;
++    void execute(Listener listener, Event event) throws EventException;
+ }
+diff --git a/src/main/java/org/bukkit/plugin/EventExecutorAdapter.java b/src/main/java/org/bukkit/plugin/EventExecutorAdapter.java
 new file mode 100644
-index 0000000..a446e2f
+index 0000000..5b03f17
 --- /dev/null
-+++ b/src/main/java/org/bukkit/exception/LoggingExceptionHandler.java
-@@ -0,0 +1,29 @@
-+package org.bukkit.exception;
++++ b/src/main/java/org/bukkit/plugin/EventExecutorAdapter.java
+@@ -0,0 +1,18 @@
++package org.bukkit.plugin;
 +
-+import java.util.logging.Level;
-+import java.util.logging.Logger;
++import org.bukkit.event.*;
++import tc.oc.minecraft.api.event.Listener;
 +
-+import static com.google.common.base.Preconditions.checkNotNull;
++class EventExecutorAdapter<T extends Event> implements org.bukkit.event.EventExecutor<T> {
 +
-+public class LoggingExceptionHandler implements ExceptionHandler {
++    private final EventExecutor legacy;
 +
-+    private final Logger logger;
-+
-+    public LoggingExceptionHandler(Logger logger) {
-+        this.logger = checkNotNull(logger);
++    EventExecutorAdapter(EventExecutor legacy) {
++        this.legacy = legacy;
 +    }
 +
 +    @Override
-+    public void handleException(Throwable exception, String message) {
-+        logger.log(Level.SEVERE, message, exception);
++    public void execute(Listener listener, T event) throws EventException {
++        legacy.execute((org.bukkit.event.Listener) listener, event);
 +    }
-+
-+    public static LoggingExceptionHandler forGlobalLogger() {
-+        if(GLOBAL == null) {
-+            GLOBAL = new LoggingExceptionHandler(Logger.getGlobal());
-+        }
-+        return GLOBAL;
-+    }
-+
-+    private static LoggingExceptionHandler GLOBAL;
 +}
-diff --git a/src/main/java/org/bukkit/exception/PluginExceptionHandler.java b/src/main/java/org/bukkit/exception/PluginExceptionHandler.java
+diff --git a/src/main/java/org/bukkit/plugin/Plugin.java b/src/main/java/org/bukkit/plugin/Plugin.java
+index 0d21654..9a1c231 100644
+--- a/src/main/java/org/bukkit/plugin/Plugin.java
++++ b/src/main/java/org/bukkit/plugin/Plugin.java
+@@ -7,6 +7,7 @@ import java.util.logging.Logger;
+ import org.bukkit.Server;
+ import org.bukkit.command.TabExecutor;
+ import org.bukkit.configuration.file.FileConfiguration;
++import org.bukkit.event.EventRegistry;
+ import org.bukkit.generator.ChunkGenerator;
+ 
+ import com.avaje.ebean.EbeanServer;
+@@ -93,6 +94,11 @@ public interface Plugin extends TabExecutor, tc.oc.minecraft.api.plugin.Plugin,
+     public PluginLoader getPluginLoader();
+ 
+     /**
++     * @return The {@link EventRegistry} belonging to this plugin.
++     */
++    EventRegistry eventRegistry();
++
++    /**
+      * Returns the Server instance currently running this plugin
+      *
+      * @return Server running this plugin
+diff --git a/src/main/java/org/bukkit/plugin/PluginBase.java b/src/main/java/org/bukkit/plugin/PluginBase.java
+index 6031af1..44f438b 100644
+--- a/src/main/java/org/bukkit/plugin/PluginBase.java
++++ b/src/main/java/org/bukkit/plugin/PluginBase.java
+@@ -1,5 +1,15 @@
+ package org.bukkit.plugin;
+ 
++import java.util.Set;
++import javax.inject.Inject;
++import javax.inject.Provider;
++
++import com.google.inject.Injector;
++import org.bukkit.event.EventRegistry;
++import org.bukkit.permissions.Permission;
++import tc.oc.minecraft.api.event.ListenerContext;
++import tc.oc.exception.ExceptionHandler;
++
+ /**
+  * Represents a base {@link Plugin}
+  * <p>
+@@ -7,6 +17,49 @@ package org.bukkit.plugin;
+  * org.bukkit.plugin.java.JavaPlugin}
+  */
+ public abstract class PluginBase implements Plugin {
++
++    @Inject private Injector injector;
++    @Inject private PluginManager pluginManager;
++    @Inject private ExceptionHandler exceptionHandler;
++    @Inject private EventRegistry eventRegistry;
++
++    @Inject private Set<Permission> permissions;
++    @Inject private Provider<ListenerContext> listenerContext;
++
++    protected void assertInjected() {
++        if(injector == null) {
++            throw new IllegalStateException("Not available until plugin has been injected");
++        }
++    }
++
++    @Override
++    public Injector injector() {
++        assertInjected();
++        return injector;
++    }
++
++    @Override
++    public EventRegistry eventRegistry() {
++        assertInjected();
++        return eventRegistry;
++    }
++
++    @Override
++    public ExceptionHandler exceptionHandler() {
++        assertInjected();
++        return exceptionHandler;
++    }
++
++    protected final void preEnable() {
++        permissions.forEach(pluginManager::addPermission);
++        listenerContext.get().enable();
++    }
++
++    protected final void postDisable() {
++        listenerContext.get().disable();
++        permissions.forEach(pluginManager::removePermission);
++    }
++
+     @Override
+     public final int hashCode() {
+         return getName().hashCode();
+diff --git a/src/main/java/org/bukkit/plugin/PluginEventRegistry.java b/src/main/java/org/bukkit/plugin/PluginEventRegistry.java
 new file mode 100644
-index 0000000..b51c190
+index 0000000..bc06595
 --- /dev/null
-+++ b/src/main/java/org/bukkit/exception/PluginExceptionHandler.java
++++ b/src/main/java/org/bukkit/plugin/PluginEventRegistry.java
+@@ -0,0 +1,57 @@
++package org.bukkit.plugin;
++
++import javax.inject.Inject;
++
++import tc.oc.minecraft.api.event.Listener;
++import org.bukkit.event.Event;
++import org.bukkit.event.EventExecutor;
++import org.bukkit.event.EventHandlerMeta;
++import org.bukkit.event.EventMethodExecutor;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.SimpleEventRegistry;
++
++public class PluginEventRegistry extends SimpleEventRegistry {
++
++    private final Plugin plugin;
++
++    @Inject public PluginEventRegistry(Plugin plugin) {
++        super(plugin.exceptionHandler());
++        this.plugin = plugin;
++    }
++
++    @Override
++    public void registerListener(Listener listener) {
++        if(!plugin.isEnabled()) {
++            throw new IllegalPluginAccessException(
++                "Plugin " + plugin.getDescription().getFullName() +
++                " attempted to register event listener while not enabled"
++            );
++        }
++        super.registerListener(listener);
++    }
++
++    @Override
++    public <T extends Event> RegisteredListener bindHandler(EventHandlerMeta<T> meta, Listener listener, EventExecutor<T> executor) {
++        return plugin.getServer().pluginProfiling()
++               ? new TimedRegisteredListener(meta, executor, listener, plugin, this)
++               : new RegisteredListener(meta, executor, listener, plugin, this);
++    }
++
++    @Override
++    public <T extends Event> RegisteredListener bindHandler(Listener listener, EventMethodExecutor<T> executor) {
++        return bindHandler(executor.meta(), listener, executor);
++    }
++
++    @Override
++    public void unregisterListener(Listener listener) {
++        HandlerList.unregisterAll(handler -> handler instanceof RegisteredListener &&
++                                             this == ((RegisteredListener) handler).registry &&
++                                             listener == ((RegisteredListener) handler).listener());
++    }
++
++    @Override
++    public void unregisterAll() {
++        HandlerList.unregisterAll(handler -> handler instanceof RegisteredListener &&
++                                             this == ((RegisteredListener) handler).registry);
++    }
++}
+diff --git a/src/main/java/org/bukkit/plugin/PluginExceptionHandler.java b/src/main/java/org/bukkit/plugin/PluginExceptionHandler.java
+new file mode 100644
+index 0000000..d5a96b1
+--- /dev/null
++++ b/src/main/java/org/bukkit/plugin/PluginExceptionHandler.java
 @@ -0,0 +1,33 @@
-+package org.bukkit.exception;
++package org.bukkit.plugin;
 +
 +import java.util.logging.Level;
++import javax.inject.Inject;
 +
-+import org.bukkit.plugin.AuthorNagException;
-+import org.bukkit.plugin.Plugin;
++import tc.oc.exception.LoggingExceptionHandler;
 +
 +public class PluginExceptionHandler extends LoggingExceptionHandler {
 +
 +    private final Plugin plugin;
 +
-+    public PluginExceptionHandler(Plugin plugin) {
++    @Inject public PluginExceptionHandler(Plugin plugin) {
 +        super(plugin.getLogger());
 +        this.plugin = plugin;
 +    }
@@ -1534,123 +1948,39 @@ index 0000000..b51c190
 +        super.handleException(exception, message);
 +    }
 +}
-diff --git a/src/main/java/org/bukkit/plugin/EventExecutor.java b/src/main/java/org/bukkit/plugin/EventExecutor.java
-index 3b2c99e..b21e408 100644
---- a/src/main/java/org/bukkit/plugin/EventExecutor.java
-+++ b/src/main/java/org/bukkit/plugin/EventExecutor.java
-@@ -5,8 +5,9 @@ import org.bukkit.event.EventException;
- import org.bukkit.event.Listener;
- 
- /**
-- * Interface which defines the class for event call backs to plugins
-+ * An event handler that belongs to a {@link Listener}, and must be passed an
-+ * instance of the listener when handling an event.
-  */
--public interface EventExecutor {
--    public void execute(Listener listener, Event event) throws EventException;
-+public interface EventExecutor<T extends Event> {
-+    void execute(Listener listener, T event) throws EventException;
- }
-diff --git a/src/main/java/org/bukkit/plugin/Plugin.java b/src/main/java/org/bukkit/plugin/Plugin.java
-index 0d21654..08e434c 100644
---- a/src/main/java/org/bukkit/plugin/Plugin.java
-+++ b/src/main/java/org/bukkit/plugin/Plugin.java
-@@ -7,6 +7,8 @@ import java.util.logging.Logger;
- import org.bukkit.Server;
- import org.bukkit.command.TabExecutor;
- import org.bukkit.configuration.file.FileConfiguration;
-+import org.bukkit.event.EventRegistry;
-+import org.bukkit.exception.ExceptionHandler;
- import org.bukkit.generator.ChunkGenerator;
- 
- import com.avaje.ebean.EbeanServer;
-@@ -93,6 +95,17 @@ public interface Plugin extends TabExecutor, tc.oc.minecraft.api.plugin.Plugin,
-     public PluginLoader getPluginLoader();
- 
-     /**
-+     * @return The {@link EventRegistry} belonging to this plugin.
-+     */
-+    EventRegistry eventRegistry();
-+
-+    /**
-+     * @return An {@link ExceptionHandler} that canbe used to report
-+     *         exceptions related to this plugin.
-+     */
-+    ExceptionHandler exceptionHandler();
-+
-+    /**
-      * Returns the Server instance currently running this plugin
-      *
-      * @return Server running this plugin
-diff --git a/src/main/java/org/bukkit/plugin/PluginEventRegistry.java b/src/main/java/org/bukkit/plugin/PluginEventRegistry.java
+diff --git a/src/main/java/org/bukkit/plugin/PluginInstanceModule.java b/src/main/java/org/bukkit/plugin/PluginInstanceModule.java
 new file mode 100644
-index 0000000..dcec1fb
+index 0000000..8c64d81
 --- /dev/null
-+++ b/src/main/java/org/bukkit/plugin/PluginEventRegistry.java
-@@ -0,0 +1,54 @@
++++ b/src/main/java/org/bukkit/plugin/PluginInstanceModule.java
+@@ -0,0 +1,22 @@
 +package org.bukkit.plugin;
 +
-+import org.bukkit.event.Event;
-+import org.bukkit.event.EventHandlerMeta;
-+import org.bukkit.event.EventMethodExecutor;
-+import org.bukkit.event.HandlerList;
-+import org.bukkit.event.Listener;
-+import org.bukkit.event.SimpleEventRegistry;
++import tc.oc.inject.ProtectedModule;
 +
-+public class PluginEventRegistry extends SimpleEventRegistry {
++/**
++ * Configures a {@link Plugin} instance
++ */
++public class PluginInstanceModule extends ProtectedModule {
 +
 +    private final Plugin plugin;
 +
-+    public PluginEventRegistry(Plugin plugin) {
-+        super(plugin.exceptionHandler());
++    public PluginInstanceModule(Plugin plugin) {
 +        this.plugin = plugin;
 +    }
 +
 +    @Override
-+    public void registerListener(Listener listener) {
-+        if(!plugin.isEnabled()) {
-+            throw new IllegalPluginAccessException(
-+                "Plugin " + plugin.getDescription().getFullName() +
-+                " attempted to register event listener while not enabled"
-+            );
-+        }
-+        super.registerListener(listener);
-+    }
-+
-+    @Override
-+    public <T extends Event> RegisteredListener bindHandler(EventHandlerMeta<T> meta, EventExecutor<T> executor, Listener listener) {
-+        return plugin.getServer().pluginProfiling()
-+               ? new TimedRegisteredListener(meta, executor, listener, plugin, this)
-+               : new RegisteredListener(meta, executor, listener, plugin, this);
-+    }
-+
-+    @Override
-+    public <T extends Event> RegisteredListener bindHandler(EventMethodExecutor<T> executor, Listener listener) {
-+        return bindHandler(executor.meta(), executor, listener);
-+    }
-+
-+    @Override
-+    public void unregisterListener(Listener listener) {
-+        HandlerList.unregisterAll(handler -> handler instanceof RegisteredListener &&
-+                                             this == ((RegisteredListener) handler).registry &&
-+                                             listener == ((RegisteredListener) handler).listener());
-+    }
-+
-+    @Override
-+    public void unregisterAll() {
-+        HandlerList.unregisterAll(handler -> handler instanceof RegisteredListener &&
-+                                             this == ((RegisteredListener) handler).registry);
++    protected void configure() {
++        install(new PluginModule());
++        bind(Plugin.class).toInstance(plugin);
++        plugin.configure(binder());
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/plugin/PluginManager.java b/src/main/java/org/bukkit/plugin/PluginManager.java
-index 15f6218..d52a971 100644
+index 15f6218..0864ecb 100644
 --- a/src/main/java/org/bukkit/plugin/PluginManager.java
 +++ b/src/main/java/org/bukkit/plugin/PluginManager.java
-@@ -5,16 +5,16 @@ import java.util.Set;
- 
- import org.bukkit.event.Event;
- import org.bukkit.event.EventPriority;
-+import org.bukkit.event.HandlerList;
+@@ -8,13 +8,12 @@ import org.bukkit.event.EventPriority;
  import org.bukkit.event.Listener;
  import org.bukkit.permissions.Permissible;
  import org.bukkit.permissions.Permission;
@@ -1661,42 +1991,120 @@ index 15f6218..d52a971 100644
   * Handles all plugin management from the Server
   */
 -public interface PluginManager extends PluginFinder, EventBus {
-+public interface PluginManager extends PluginFinder, tc.oc.minecraft.api.event.EventBus {
++public interface PluginManager extends PluginFinder {
  
      /**
       * Registers the specified plugin loader
-@@ -137,6 +137,21 @@ public interface PluginManager extends PluginFinder, EventBus {
-      */
-     public void registerEvent(Class<? extends Event> event, Listener listener, EventPriority priority, EventExecutor executor, Plugin plugin, boolean ignoreCancelled);
- 
+diff --git a/src/main/java/org/bukkit/plugin/PluginModule.java b/src/main/java/org/bukkit/plugin/PluginModule.java
+new file mode 100644
+index 0000000..1e2dda4
+--- /dev/null
++++ b/src/main/java/org/bukkit/plugin/PluginModule.java
+@@ -0,0 +1,54 @@
++package org.bukkit.plugin;
++
++import javax.inject.Singleton;
++
++import com.google.inject.Provides;
++import org.bukkit.configuration.Configuration;
++import org.bukkit.event.EventRegistry;
++import org.bukkit.permissions.PermissionBinder;
++import tc.oc.inject.ProtectedModule;
++import tc.oc.minecraft.api.event.ListenerBinder;
++import tc.oc.exception.ExceptionHandler;
++import tc.oc.minecraft.api.plugin.PluginDescription;
++import tc.oc.minecraft.api.scheduler.Scheduler;
++
++/**
++ * Bindings for things belonging to a particular {@link Plugin}.
++ *
++ * Does not bind {@link Plugin} itself
++ *
++ * @see PluginInstanceModule
++ */
++public class PluginModule extends ProtectedModule {
++
 +    @Override
-+    default void registerListener(tc.oc.minecraft.api.plugin.Plugin plugin, tc.oc.minecraft.api.event.Listener listener) {
-+        registerEvents((Listener) listener, (Plugin) plugin);
++    protected void configure() {
++        // Ensure these collections have bindings
++        new PermissionBinder(binder());
++        new ListenerBinder(binder());
++
++        bind(tc.oc.minecraft.api.plugin.Plugin.class).to(Plugin.class);
++        bind(PluginDescription.class).to(PluginDescriptionFile.class);
++        bind(tc.oc.minecraft.api.configuration.Configuration.class).to(Configuration.class);
++        bind(tc.oc.minecraft.api.event.EventRegistry.class).to(EventRegistry.class);
++
++        bind(ExceptionHandler.class).to(PluginExceptionHandler.class).in(Singleton.class);
++        bind(EventRegistry.class).to(PluginEventRegistry.class).in(Singleton.class);
++        bind(Scheduler.class).to(PluginScheduler.class).in(Singleton.class);
++    }
++
++    @Provides
++    PluginDescriptionFile description(Plugin plugin) {
++        return plugin.getDescription();
++    }
++
++    @Provides
++    PluginLogger logger(Plugin plugin) {
++        return (PluginLogger) plugin.getLogger();
++    }
++
++    @Provides
++    Configuration configuration(Plugin plugin) {
++        return plugin.getConfig();
++    }
++}
+diff --git a/src/main/java/org/bukkit/plugin/PluginScheduler.java b/src/main/java/org/bukkit/plugin/PluginScheduler.java
+new file mode 100644
+index 0000000..80c562e
+--- /dev/null
++++ b/src/main/java/org/bukkit/plugin/PluginScheduler.java
+@@ -0,0 +1,33 @@
++package org.bukkit.plugin;
++
++import java.time.Duration;
++import javax.annotation.Nullable;
++import javax.inject.Inject;
++
++import org.bukkit.scheduler.BukkitScheduler;
++import org.bukkit.scheduler.BukkitTask;
++import tc.oc.minecraft.api.scheduler.Scheduler;
++
++class PluginScheduler implements Scheduler {
++
++    private final Plugin plugin;
++    private final BukkitScheduler scheduler;
++
++    @Inject PluginScheduler(Plugin plugin, BukkitScheduler scheduler) {
++        this.plugin = plugin;
++        this.scheduler = scheduler;
++    }
++
++    private long ticks(Duration duration) {
++        return Math.max(1, scheduler.toTicks(duration, 1));
 +    }
 +
 +    @Override
-+    default void unregisterListener(tc.oc.minecraft.api.event.Listener listener) {
-+        HandlerList.unregisterAll((Listener) listener);
-+    }
++    public BukkitTask schedule(boolean sync, @Nullable Duration delay, @Nullable Duration period, Runnable task) {
++        final long delayTicks = delay == null ? 0 : ticks(delay);
++        final long periodTicks = period == null ? -1 : ticks(period);
 +
-+    @Override
-+    default void unregisterListeners(tc.oc.minecraft.api.plugin.Plugin plugin) {
-+        HandlerList.unregisterAll((Plugin) plugin);
++        return sync ? scheduler.runTaskTimer(plugin, task, delayTicks, periodTicks)
++                    : scheduler.runTaskTimerAsynchronously(plugin, task, delayTicks, periodTicks);
 +    }
-+
-     /**
-      * Enables the specified plugin
-      * <p>
++}
 diff --git a/src/main/java/org/bukkit/plugin/RegisteredListener.java b/src/main/java/org/bukkit/plugin/RegisteredListener.java
-index 9dd0b7a..66092a7 100644
+index 9dd0b7a..89a50a1 100644
 --- a/src/main/java/org/bukkit/plugin/RegisteredListener.java
 +++ b/src/main/java/org/bukkit/plugin/RegisteredListener.java
-@@ -1,32 +1,31 @@
+@@ -1,32 +1,32 @@
  package org.bukkit.plugin;
  
 +import javax.annotation.Nullable;
 +
  import org.bukkit.event.*;
++import org.bukkit.event.Listener;
  
  /**
 - * Stores relevant information for plugin listeners
@@ -1719,7 +2127,7 @@ index 9dd0b7a..66092a7 100644
      public RegisteredListener(final Listener listener, final EventExecutor executor, final EventPriority priority, final Plugin plugin, final boolean ignoreCancelled) {
 -        this.listener = listener;
 -        this.priority = priority;
-+        super(new EventHandlerMeta<>(Event.class, priority, ignoreCancelled), executor, listener);
++        super(new EventHandlerMeta<>(Event.class, priority, ignoreCancelled), new EventExecutorAdapter<>(executor), listener);
          this.plugin = plugin;
 -        this.executor = executor;
 -        this.ignoreCancelled = ignoreCancelled;
@@ -1733,14 +2141,14 @@ index 9dd0b7a..66092a7 100644
 -     */
 -    public Listener getListener() {
 -        return listener;
-+    RegisteredListener(EventHandlerMeta meta, EventExecutor executor, Listener listener, Plugin plugin, PluginEventRegistry registry) {
++    RegisteredListener(EventHandlerMeta meta, org.bukkit.event.EventExecutor executor, tc.oc.minecraft.api.event.Listener listener, Plugin plugin, PluginEventRegistry registry) {
 +        super(meta, executor, listener);
 +        this.plugin = plugin;
 +        this.registry = registry;
      }
  
      /**
-@@ -38,36 +37,13 @@ public class RegisteredListener {
+@@ -38,36 +38,13 @@ public class RegisteredListener {
          return plugin;
      }
  
@@ -1780,12 +2188,12 @@ index 9dd0b7a..66092a7 100644
 -        return ignoreCancelled;
 -    }
 +    // These aliases provided for legacy binary compatibility
-+    public Listener getListener() { return listener(); }
++    public Listener getListener() { return (Listener) listener(); }
 +    public EventPriority getPriority() { return meta().priority(); }
 +    public boolean isIgnoringCancelled() { return meta().ignoreCancelled(); }
  }
 diff --git a/src/main/java/org/bukkit/plugin/SimplePluginManager.java b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
-index c4adbd8..877e6d6 100644
+index c4adbd8..a8ac144 100644
 --- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
 +++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
 @@ -2,7 +2,6 @@ package org.bukkit.plugin;
@@ -1942,7 +2350,7 @@ index c4adbd8..877e6d6 100644
 -                throw new IllegalPluginAccessException("Unable to find handler list for event " + clazz.getName() + ". Static getHandlerList method required!");
 -            }
 -        }
-+        plugin.eventRegistry().bindHandler(new EventHandlerMeta<>(event, priority, ignoreCancelled), executor, listener);
++        plugin.eventRegistry().bindHandler(new EventHandlerMeta<>(event, priority, ignoreCancelled), listener, new EventExecutorAdapter<>(executor));
      }
  
      public Permission getPermission(String name) {
@@ -1964,15 +2372,14 @@ index c4adbd8..877e6d6 100644
      }
  }
 diff --git a/src/main/java/org/bukkit/plugin/TimedRegisteredListener.java b/src/main/java/org/bukkit/plugin/TimedRegisteredListener.java
-index 164be93..23b82c6 100644
+index 164be93..a5eb0a8 100644
 --- a/src/main/java/org/bukkit/plugin/TimedRegisteredListener.java
 +++ b/src/main/java/org/bukkit/plugin/TimedRegisteredListener.java
-@@ -2,22 +2,32 @@ package org.bukkit.plugin;
+@@ -2,22 +2,31 @@ package org.bukkit.plugin;
  
  import org.bukkit.event.Event;
  import org.bukkit.event.EventException;
 +import org.bukkit.event.EventHandlerMeta;
-+import org.bukkit.event.EventMethodExecutor;
  import org.bukkit.event.EventPriority;
  import org.bukkit.event.Listener;
  
@@ -1993,7 +2400,7 @@ index 164be93..23b82c6 100644
          super(pluginListener, eventExecutor, eventPriority, registeredPlugin, listenCancelled);
      }
  
-+    TimedRegisteredListener(EventHandlerMeta meta, EventExecutor executor, Listener listener, Plugin plugin, PluginEventRegistry registry) {
++    TimedRegisteredListener(EventHandlerMeta meta, org.bukkit.event.EventExecutor executor, tc.oc.minecraft.api.event.Listener listener, Plugin plugin, PluginEventRegistry registry) {
 +        super(meta, executor, listener, plugin, registry);
 +    }
 +
@@ -2001,10 +2408,10 @@ index 164be93..23b82c6 100644
      public void callEvent(Event event) throws EventException {
          if (event.isAsynchronous()) {
 diff --git a/src/main/java/org/bukkit/plugin/java/JavaPlugin.java b/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
-index 9da6dc8..d9a0ccb 100644
+index 9da6dc8..c74bae2 100644
 --- a/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
 +++ b/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
-@@ -9,7 +9,6 @@ import java.io.OutputStream;
+@@ -9,24 +9,20 @@ import java.io.OutputStream;
  import java.io.Reader;
  import java.net.URL;
  import java.net.URLConnection;
@@ -2012,7 +2419,8 @@ index 9da6dc8..d9a0ccb 100644
  import java.util.ArrayList;
  import java.util.List;
  import java.util.logging.Level;
-@@ -17,16 +16,15 @@ import java.util.logging.Logger;
+ import java.util.logging.Logger;
++import javax.annotation.Nullable;
  
  import org.apache.commons.lang.Validate;
  import org.bukkit.Server;
@@ -2023,16 +2431,13 @@ index 9da6dc8..d9a0ccb 100644
 -import org.bukkit.configuration.InvalidConfigurationException;
  import org.bukkit.configuration.file.FileConfiguration;
  import org.bukkit.configuration.file.YamlConfiguration;
-+import org.bukkit.plugin.PluginEventRegistry;
-+import org.bukkit.exception.ExceptionHandler;
-+import org.bukkit.exception.PluginExceptionHandler;
  import org.bukkit.generator.ChunkGenerator;
 -import org.bukkit.plugin.AuthorNagException;
 -import org.bukkit.plugin.PluginAwareness;
  import org.bukkit.plugin.PluginBase;
  import org.bukkit.plugin.PluginDescriptionFile;
  import org.bukkit.plugin.PluginLoader;
-@@ -40,7 +38,6 @@ import com.avaje.ebeaninternal.api.SpiEbeanServer;
+@@ -40,7 +36,6 @@ import com.avaje.ebeaninternal.api.SpiEbeanServer;
  import com.avaje.ebeaninternal.server.ddl.DdlGenerator;
  import com.google.common.base.Charsets;
  import com.google.common.base.Preconditions;
@@ -2040,41 +2445,49 @@ index 9da6dc8..d9a0ccb 100644
  
  /**
   * Represents a Java plugin
-@@ -58,6 +55,8 @@ public abstract class JavaPlugin extends PluginBase {
-     private FileConfiguration newConfig = null;
-     private File configFile = null;
+@@ -60,7 +55,13 @@ public abstract class JavaPlugin extends PluginBase {
      private PluginLogger logger = null;
-+    private ExceptionHandler exceptionHandler = null;
-+    private PluginEventRegistry eventRegistry = null;
  
      public JavaPlugin() {
-         final ClassLoader classLoader = this.getClass().getClassLoader();
-@@ -96,6 +95,16 @@ public abstract class JavaPlugin extends PluginBase {
-         return loader;
-     }
- 
-+    @Override
-+    public PluginEventRegistry eventRegistry() {
-+        return eventRegistry;
+-        final ClassLoader classLoader = this.getClass().getClassLoader();
++        this(null);
 +    }
 +
-+    @Override
-+    public ExceptionHandler exceptionHandler() {
-+        return exceptionHandler;
-+    }
-+
-     /**
-      * Returns the Server instance currently running this plugin
-      *
-@@ -291,6 +300,8 @@ public abstract class JavaPlugin extends PluginBase {
-         this.classLoader = classLoader;
-         this.configFile = new File(dataFolder, "config.yml");
-         this.logger = PluginLogger.get(this);
-+        this.exceptionHandler = new PluginExceptionHandler(this);
-+        this.eventRegistry = new PluginEventRegistry(this);
- 
-         if (description.isDatabaseEnabled()) {
-             ServerConfig db = new ServerConfig();
++    JavaPlugin(@Nullable ClassLoader classLoader) {
++        if(classLoader == null) {
++            classLoader = getClass().getClassLoader();
++        }
+         if (!(classLoader instanceof PluginClassLoader)) {
+             throw new IllegalStateException("JavaPlugin requires " + PluginClassLoader.class.getName());
+         }
+@@ -266,15 +267,21 @@ public abstract class JavaPlugin extends PluginBase {
+     protected final void setEnabled(final boolean enabled) {
+         if(!isEnabled && enabled) {
+             isEnabled = true;
+-            try {
+-                onEnable();
+-            } catch(RuntimeException e) {
+-                isEnabled = false;
+-                throw e;
++            if(isActive()) {
++                try {
++                    preEnable();
++                    onEnable();
++                } catch(RuntimeException e) {
++                    isEnabled = false;
++                    throw e;
++                }
+             }
+         } else if(isEnabled && !enabled) {
+             try {
+-                onDisable();
++                if(isActive()) {
++                    onDisable();
++                    postDisable();
++                }
+             } finally {
+                 isEnabled = false;
+             }
 diff --git a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
 index 6cb69ba..7f92280 100644
 --- a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
@@ -2212,6 +2625,126 @@ index 6cb69ba..7f92280 100644
      }
  
      public void enablePlugin(final Plugin plugin) {
+diff --git a/src/main/java/org/bukkit/plugin/java/ModularPlugin.java b/src/main/java/org/bukkit/plugin/java/ModularPlugin.java
+new file mode 100644
+index 0000000..98941df
+--- /dev/null
++++ b/src/main/java/org/bukkit/plugin/java/ModularPlugin.java
+@@ -0,0 +1,18 @@
++package org.bukkit.plugin.java;
++
++import com.google.inject.Module;
++import tc.oc.inject.ProtectedBinder;
++
++class ModularPlugin extends JavaPlugin {
++
++    private final Module module;
++
++    ModularPlugin(Module module) {
++        super(module.getClass().getClassLoader());
++        this.module = module;
++    }
++
++    public void configure(ProtectedBinder binder) {
++        binder.install(module);
++    }
++}
+diff --git a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
+index 4e94cc8..977d6bb 100644
+--- a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
++++ b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
+@@ -9,6 +9,7 @@ import java.util.Set;
+ import java.util.concurrent.locks.ReadWriteLock;
+ import java.util.concurrent.locks.ReentrantReadWriteLock;
+ 
++import com.google.inject.Module;
+ import org.apache.commons.lang.Validate;
+ import org.bukkit.Bukkit;
+ import org.bukkit.plugin.InvalidPluginException;
+@@ -58,14 +59,16 @@ final class PluginClassLoader extends URLClassLoader {
+                 throw new InvalidPluginException("Cannot find main class `" + description.getMain() + "'", ex);
+             }
+ 
+-            Class<? extends JavaPlugin> pluginClass;
+-            try {
+-                pluginClass = jarClass.asSubclass(JavaPlugin.class);
+-            } catch (ClassCastException ex) {
+-                throw new InvalidPluginException("main class `" + description.getMain() + "' does not extend JavaPlugin", ex);
++            if(JavaPlugin.class.isAssignableFrom(jarClass)) {
++                plugin = jarClass.asSubclass(JavaPlugin.class).newInstance();
++            } else if(Module.class.isAssignableFrom(jarClass)) {
++                plugin = new ModularPlugin(jarClass.asSubclass(Module.class).newInstance());
++            } else {
++                throw new InvalidPluginException("main class `" + jarClass.getName() +
++                                                 "' must extend either " + JavaPlugin.class.getName() +
++                                                 " or " + Module.class.getName());
+             }
+ 
+-            plugin = pluginClass.newInstance();
+             return plugin;
+         } catch (IllegalAccessException ex) {
+             throw new InvalidPluginException("No public constructor", ex);
+@@ -180,7 +183,6 @@ final class PluginClassLoader extends URLClassLoader {
+ 
+     synchronized void initialize(JavaPlugin javaPlugin) {
+         Validate.notNull(javaPlugin, "Initializing plugin cannot be null");
+-        Validate.isTrue(javaPlugin.getClass().getClassLoader() == this, "Cannot initialize plugin outside of this class loader");
+ 
+         if (this.plugin != null) {
+             throw new IllegalArgumentException("Plugin already initialized!");
+diff --git a/src/main/java/org/bukkit/scheduler/BukkitScheduler.java b/src/main/java/org/bukkit/scheduler/BukkitScheduler.java
+index 6e28205..28ac02e 100644
+--- a/src/main/java/org/bukkit/scheduler/BukkitScheduler.java
++++ b/src/main/java/org/bukkit/scheduler/BukkitScheduler.java
+@@ -1,6 +1,8 @@
+ package org.bukkit.scheduler;
+ 
+ import org.bukkit.plugin.Plugin;
++
++import java.time.Duration;
+ import java.util.concurrent.Callable;
+ import java.util.concurrent.Future;
+ import java.util.List;
+@@ -366,4 +368,21 @@ public interface BukkitScheduler {
+      */
+     @Deprecated
+     public BukkitTask runTaskTimerAsynchronously(Plugin plugin, BukkitRunnable task, long delay, long period) throws IllegalArgumentException;
++
++    Duration tickDuration();
++
++    default Duration tickDuration(long ticks) {
++        return tickDuration().multipliedBy(ticks);
++    }
++
++    default long toTicks(Duration duration, int rounding) {
++        final long tick = tickDuration().toNanos();
++        if(rounding < 0) {
++            return duration.toNanos() / tick;
++        }
++        if(rounding > 0) {
++            return (duration.toNanos() + tick - 1) / tick;
++        }
++        return (duration.toNanos() + (tick / 2)) / tick;
++    }
+ }
+diff --git a/src/main/java/org/bukkit/scheduler/BukkitTask.java b/src/main/java/org/bukkit/scheduler/BukkitTask.java
+index e447e64..ce24c8b 100644
+--- a/src/main/java/org/bukkit/scheduler/BukkitTask.java
++++ b/src/main/java/org/bukkit/scheduler/BukkitTask.java
+@@ -1,11 +1,12 @@
+ package org.bukkit.scheduler;
+ 
+ import org.bukkit.plugin.Plugin;
++import tc.oc.minecraft.api.scheduler.Task;
+ 
+ /**
+  * Represents a task being executed by the scheduler
+  */
+-public interface BukkitTask {
++public interface BukkitTask extends Task {
+ 
+     /**
+      * Returns the taskId for the task.
 diff --git a/src/test/java/org/bukkit/TestServer.java b/src/test/java/org/bukkit/TestServer.java
 index 2d84032..152010a 100644
 --- a/src/test/java/org/bukkit/TestServer.java
@@ -2265,7 +2798,7 @@ index 2d84032..152010a 100644
      public static Server getInstance() {
 diff --git a/src/test/java/org/bukkit/event/EventBusTest.java b/src/test/java/org/bukkit/event/EventBusTest.java
 new file mode 100644
-index 0000000..b545894
+index 0000000..e99c934
 --- /dev/null
 +++ b/src/test/java/org/bukkit/event/EventBusTest.java
 @@ -0,0 +1,285 @@
@@ -2276,7 +2809,7 @@ index 0000000..b545894
 +import java.util.List;
 +import java.util.stream.Stream;
 +
-+import org.bukkit.exception.ExceptionHandler;
++import tc.oc.exception.ExceptionHandler;
 +import org.bukkit.exception.TestExceptionHandler;
 +import org.bukkit.test.TestThread;
 +import org.junit.After;
@@ -2649,7 +3182,7 @@ index 0000000..05aba89
 +}
 diff --git a/src/test/java/org/bukkit/event/EventMethodExecutorTest.java b/src/test/java/org/bukkit/event/EventMethodExecutorTest.java
 new file mode 100644
-index 0000000..3ee3f43
+index 0000000..6227c7b
 --- /dev/null
 +++ b/src/test/java/org/bukkit/event/EventMethodExecutorTest.java
 @@ -0,0 +1,135 @@
@@ -2659,7 +3192,7 @@ index 0000000..3ee3f43
 +import java.util.concurrent.atomic.AtomicBoolean;
 +import java.util.stream.Collectors;
 +
-+import org.bukkit.exception.ExceptionHandler;
++import tc.oc.exception.ExceptionHandler;
 +import org.bukkit.exception.TestExceptionHandler;
 +import org.bukkit.test.TestCodeBlock;
 +import org.junit.Test;
@@ -2983,11 +3516,13 @@ index 25904f5..badbcee 100644
      }
 diff --git a/src/test/java/org/bukkit/exception/TestExceptionHandler.java b/src/test/java/org/bukkit/exception/TestExceptionHandler.java
 new file mode 100644
-index 0000000..49c1abe
+index 0000000..440d183
 --- /dev/null
 +++ b/src/test/java/org/bukkit/exception/TestExceptionHandler.java
-@@ -0,0 +1,8 @@
+@@ -0,0 +1,10 @@
 +package org.bukkit.exception;
++
++import tc.oc.exception.ExceptionHandler;
 +
 +public class TestExceptionHandler implements ExceptionHandler {
 +    @Override
@@ -3018,10 +3553,10 @@ index 6b86128..fd00bd9 100644
  
      @Test
 diff --git a/src/test/java/org/bukkit/plugin/TestPlugin.java b/src/test/java/org/bukkit/plugin/TestPlugin.java
-index 7e09892..46e5cf8 100644
+index 7e09892..82aff85 100644
 --- a/src/test/java/org/bukkit/plugin/TestPlugin.java
 +++ b/src/test/java/org/bukkit/plugin/TestPlugin.java
-@@ -3,22 +3,38 @@ package org.bukkit.plugin;
+@@ -3,22 +3,37 @@ package org.bukkit.plugin;
  import java.io.File;
  import java.io.InputStream;
  import java.util.List;
@@ -3033,8 +3568,7 @@ index 7e09892..46e5cf8 100644
  import org.bukkit.command.Command;
  import org.bukkit.command.CommandSender;
  import org.bukkit.configuration.file.FileConfiguration;
-+import org.bukkit.exception.ExceptionHandler;
-+import org.bukkit.exception.PluginExceptionHandler;
++import tc.oc.exception.ExceptionHandler;
  import org.bukkit.generator.ChunkGenerator;
  
 -import com.avaje.ebean.EbeanServer;
@@ -3062,7 +3596,7 @@ index 7e09892..46e5cf8 100644
      }
  
      public void setEnabled(boolean enabled) {
-@@ -57,15 +73,26 @@ public class TestPlugin extends PluginBase {
+@@ -57,15 +72,26 @@ public class TestPlugin extends PluginBase {
          throw new UnsupportedOperationException("Not supported.");
      }
  
@@ -3091,7 +3625,7 @@ index 7e09892..46e5cf8 100644
          throw new UnsupportedOperationException("Not supported.");
      }
  
-@@ -86,11 +113,11 @@ public class TestPlugin extends PluginBase {
+@@ -86,11 +112,11 @@ public class TestPlugin extends PluginBase {
      }
  
      public boolean isNaggable() {

--- a/Bukkit/0089-Server-suspend-API.patch
+++ b/Bukkit/0089-Server-suspend-API.patch
@@ -1,11 +1,11 @@
-From 45cb7b0cd39fb2883820e9975ae160c486405f3f Mon Sep 17 00:00:00 2001
+From 4bbd37a9375d895c2867f91fcbceeecb955c4682 Mon Sep 17 00:00:00 2001
 From: Jedediah Smith <jedediah@silencegreys.com>
 Date: Sat, 10 Dec 2016 20:14:13 -0500
 Subject: [PATCH] Server suspend API
 
 
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index c1a982f..b50176c 100644
+index 079f496..12170b6 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -3,6 +3,8 @@ package org.bukkit;
@@ -25,8 +25,8 @@ index c1a982f..b50176c 100644
  
  import org.bukkit.Warning.WarningState;
  import org.bukkit.boss.BarColor;
-@@ -136,6 +139,12 @@ public interface Server extends PluginMessageRecipient, BukkitRuntime, tc.oc.min
-     public Collection<? extends Player> getOnlinePlayers();
+@@ -138,6 +141,12 @@ public interface Server extends PluginMessageRecipient, BukkitRuntime, tc.oc.min
+     Map<UUID, Player> playersById();
  
      /**
 +     * If the server is currently empty of players, return the {@link Instant}
@@ -38,7 +38,7 @@ index c1a982f..b50176c 100644
       * Get the maximum amount of players which can login to this server.
       *
       * @return the amount of players this server allows
-@@ -358,6 +367,13 @@ public interface Server extends PluginMessageRecipient, BukkitRuntime, tc.oc.min
+@@ -360,6 +369,13 @@ public interface Server extends PluginMessageRecipient, BukkitRuntime, tc.oc.min
      public int getTicksPerMonsterSpawns();
  
      /**
@@ -52,7 +52,7 @@ index c1a982f..b50176c 100644
       * Gets a player object by the given username.
       * <p>
       * This method may not return objects for offline players.
-@@ -1082,4 +1098,65 @@ public interface Server extends PluginMessageRecipient, BukkitRuntime, tc.oc.min
+@@ -1088,4 +1104,65 @@ public interface Server extends PluginMessageRecipient, BukkitRuntime, tc.oc.min
       *         false if it was added to the main thread queue
       */
      boolean runOnMainThread(Plugin plugin, boolean priority, Runnable task);

--- a/Bukkit/0090-Do-things-inside-events.patch
+++ b/Bukkit/0090-Do-things-inside-events.patch
@@ -1,4 +1,4 @@
-From 5446c8ec96f6588b08e0c707764188bf152f90f1 Mon Sep 17 00:00:00 2001
+From bcbed61efe2b16886878f146c4db09348e68a8d7 Mon Sep 17 00:00:00 2001
 From: Jedediah Smith <jedediah@silencegreys.com>
 Date: Fri, 23 Dec 2016 14:05:06 -0500
 Subject: [PATCH] Do things inside events

--- a/CraftBukkit/0155-New-event-API.patch
+++ b/CraftBukkit/0155-New-event-API.patch
@@ -1,14 +1,103 @@
-From dc255ca801fda062fe11a31636b372bb5a4dc439 Mon Sep 17 00:00:00 2001
+From 422cdcdb9a4add9d6be6709c1e6b25857ec81b6a Mon Sep 17 00:00:00 2001
 From: Jedediah Smith <jedediah@silencegreys.com>
 Date: Fri, 2 Dec 2016 01:48:56 -0500
 Subject: [PATCH] New event API
 
 
+diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
+index 1578a05..e042d3d 100644
+--- a/src/main/java/net/minecraft/server/PlayerList.java
++++ b/src/main/java/net/minecraft/server/PlayerList.java
+@@ -55,7 +55,7 @@ public abstract class PlayerList {
+     private static final SimpleDateFormat g = new SimpleDateFormat("yyyy-MM-dd \'at\' HH:mm:ss z");
+     private final MinecraftServer server;
+     public final List<EntityPlayer> players = new java.util.concurrent.CopyOnWriteArrayList(); // CraftBukkit - ArrayList -> CopyOnWriteArrayList: Iterator safety
+-    private final Map<UUID, EntityPlayer> j = Maps.newHashMap();
++    private final Map<UUID, EntityPlayer> j = Maps.newHashMap(); public Map<UUID, EntityPlayer> playersById() { return j; } // SportBukkit - accessor
+     private final GameProfileBanList k;
+     private final IpBanList l;
+     private final OpList operators;
+@@ -74,7 +74,7 @@ public abstract class PlayerList {
+ 
+     public PlayerList(MinecraftServer minecraftserver) {
+         this.cserver = minecraftserver.server = new CraftServer(minecraftserver, this);
+-        minecraftserver.console = org.bukkit.craftbukkit.command.ColouredConsoleSender.getInstance();
++        this.cserver.getConsoleSender();
+         minecraftserver.reader.addCompleter(new org.bukkit.craftbukkit.command.ConsoleCommandCompleter(minecraftserver.server));
+         // CraftBukkit end
+ 
+diff --git a/src/main/java/org/bukkit/CraftBukkitRuntime.java b/src/main/java/org/bukkit/CraftBukkitRuntime.java
+index ed4a904..af45b1a 100644
+--- a/src/main/java/org/bukkit/CraftBukkitRuntime.java
++++ b/src/main/java/org/bukkit/CraftBukkitRuntime.java
+@@ -1,5 +1,8 @@
+ package org.bukkit;
+ 
++import javax.annotation.Nullable;
++
++import com.google.inject.Injector;
+ import net.minecraft.server.DispenserRegistry;
+ import org.bukkit.block.BlockFactory;
+ import org.bukkit.craftbukkit.block.CraftBlockFactory;
+@@ -28,6 +31,8 @@ public class CraftBukkitRuntime implements BukkitRuntime {
+         }
+     }
+ 
++    protected @Nullable Injector injector;
++
+     private final CraftBlockFactory blockFactory = new CraftBlockFactory();
+     private final CraftVectorFactory vectorFactory = new CraftVectorFactory();
+ 
+@@ -39,6 +44,14 @@ public class CraftBukkitRuntime implements BukkitRuntime {
+     }
+ 
+     @Override
++    public Injector injector() {
++        if(injector == null) {
++            throw new IllegalStateException("Injector has not been created yet");
++        }
++        return injector;
++    }
++
++    @Override
+     public Key key(String prefix, String id) {
+         return CraftKey.get(prefix, id);
+     }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index e56de6c..db5e399 100644
+index e56de6c..1aadad1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -78,6 +78,8 @@ import org.bukkit.craftbukkit.util.DatFileFilter;
+@@ -23,6 +23,9 @@ import java.util.regex.Pattern;
+ 
+ import javax.imageio.ImageIO;
+ 
++import com.google.common.collect.Maps;
++import com.google.inject.Guice;
++import com.google.inject.Stage;
+ import net.minecraft.server.*;
+ 
+ import org.bukkit.BanList;
+@@ -33,6 +36,7 @@ import org.bukkit.GameMode;
+ import org.bukkit.Location;
+ import org.bukkit.OfflinePlayer;
+ import org.bukkit.Server;
++import org.bukkit.ServerInstanceModule;
+ import org.bukkit.UnsafeValues;
+ import org.bukkit.Warning.WarningState;
+ import org.bukkit.World;
+@@ -53,6 +57,7 @@ import org.bukkit.configuration.file.YamlConfiguration;
+ import org.bukkit.configuration.serialization.ConfigurationSerialization;
+ import org.bukkit.conversations.Conversable;
+ import org.bukkit.craftbukkit.boss.CraftBossBar;
++import org.bukkit.craftbukkit.command.ColouredConsoleSender;
+ import org.bukkit.craftbukkit.command.VanillaCommandWrapper;
+ import org.bukkit.craftbukkit.entity.CraftPlayer;
+ import org.bukkit.craftbukkit.generator.CraftChunkData;
+@@ -75,9 +80,12 @@ import org.bukkit.craftbukkit.scoreboard.CraftScoreboardManager;
+ import org.bukkit.craftbukkit.util.CraftIconCache;
+ import org.bukkit.craftbukkit.util.CraftMagicNumbers;
+ import org.bukkit.craftbukkit.util.DatFileFilter;
++import org.bukkit.craftbukkit.util.CaseInsensitiveNameMap;
  import org.bukkit.craftbukkit.util.Versioning;
  import org.bukkit.craftbukkit.util.permissions.CraftDefaultPermissions;
  import org.bukkit.entity.Player;
@@ -17,15 +106,17 @@ index e56de6c..db5e399 100644
  import org.bukkit.event.inventory.InventoryType;
  import org.bukkit.event.player.PlayerChatTabCompleteEvent;
  import org.bukkit.event.world.WorldInitEvent;
-@@ -122,7 +124,6 @@ import com.avaje.ebeaninternal.server.lib.sql.TransactionIsolation;
+@@ -120,9 +128,7 @@ import com.avaje.ebean.config.ServerConfig;
+ import com.avaje.ebean.config.dbplatform.SQLitePlatform;
+ import com.avaje.ebeaninternal.server.lib.sql.TransactionIsolation;
  import com.google.common.base.Charsets;
- import com.google.common.base.Function;
+-import com.google.common.base.Function;
  import com.google.common.collect.ImmutableList;
 -import com.google.common.collect.ImmutableSet;
  import com.google.common.collect.Lists;
  import com.google.common.collect.MapMaker;
  import com.mojang.authlib.GameProfile;
-@@ -148,6 +149,7 @@ public final class CraftServer extends CraftBukkitRuntime implements Server {
+@@ -148,9 +154,13 @@ public final class CraftServer extends CraftBukkitRuntime implements Server {
      private final SimpleHelpMap helpMap = new SimpleHelpMap(this);
      private final StandardMessenger messenger = new StandardMessenger();
      private final PluginManager pluginManager = new SimplePluginManager(this, commandMap);
@@ -33,7 +124,13 @@ index e56de6c..db5e399 100644
      protected final MinecraftServer console;
      protected final DedicatedPlayerList playerList;
      private final Map<String, World> worlds = new LinkedHashMap<String, World>();
-@@ -166,6 +168,7 @@ public final class CraftServer extends CraftBukkitRuntime implements Server {
++    private final Map<String, World> worldsView = new CaseInsensitiveNameMap<>(worlds.values(), World::getName);
++    private final Map<UUID, World> worldsById = new LinkedHashMap<>();
++    private final Map<UUID, World> worldsByIdView = Collections.unmodifiableMap(worldsById);
+     private YamlConfiguration configuration;
+     private YamlConfiguration commandsConfiguration;
+     private final Yaml yaml = new Yaml(new SafeConstructor());
+@@ -166,6 +176,7 @@ public final class CraftServer extends CraftBukkitRuntime implements Server {
      public int chunkGCLoadThresh = 0;
      private File container;
      private WarningState warningState = WarningState.DEFAULT;
@@ -41,15 +138,32 @@ index e56de6c..db5e399 100644
      private final BooleanWrapper online = new BooleanWrapper();
      public CraftScoreboardManager scoreboardManager;
      public boolean playerCommandState;
-@@ -190,6 +193,7 @@ public final class CraftServer extends CraftBukkitRuntime implements Server {
+@@ -175,6 +186,7 @@ public final class CraftServer extends CraftBukkitRuntime implements Server {
+     private final Pattern validUserPattern = Pattern.compile("^[a-zA-Z0-9_]{2,16}$");
+     private final UUID invalidUserUUID = UUID.nameUUIDFromBytes("InvalidUsername".getBytes(Charsets.UTF_8));
+     private final List<CraftPlayer> playerView;
++    private final Map<UUID, Player> playersById;
+     public int reloadCount;
+     public boolean bungee = false;
+     public static final com.google.gson.Gson gson = new com.google.gson.Gson();
+@@ -190,13 +202,10 @@ public final class CraftServer extends CraftBukkitRuntime implements Server {
  
      public CraftServer(MinecraftServer console, PlayerList playerList) {
          this.console = console;
 +        this.eventBus = new SimpleEventBus(this.console.primaryThread, pluginManager);
          this.playerList = (DedicatedPlayerList) playerList;
-         this.playerView = Collections.unmodifiableList(Lists.transform(playerList.players, new Function<EntityPlayer, CraftPlayer>() {
-             @Override
-@@ -253,7 +257,7 @@ public final class CraftServer extends CraftBukkitRuntime implements Server {
+-        this.playerView = Collections.unmodifiableList(Lists.transform(playerList.players, new Function<EntityPlayer, CraftPlayer>() {
+-            @Override
+-            public CraftPlayer apply(EntityPlayer player) {
+-                return player.getBukkitEntity();
+-            }
+-        }));
++        this.playerView = Collections.unmodifiableList(Lists.transform(playerList.players, EntityPlayer::getBukkitEntity));
++        this.playersById = Collections.unmodifiableMap(Maps.transformValues(playerList.playersById(), EntityPlayer::getBukkitEntity));
+         this.serverVersion = CraftServer.class.getPackage().getImplementationVersion();
+         online.value = console.getPropertyManager().getBoolean("online-mode", true);
+ 
+@@ -253,7 +262,7 @@ public final class CraftServer extends CraftBukkitRuntime implements Server {
          saveCommandsConfig();
          bungee = configuration.getBoolean("settings.bungeecord");
          overrideAllCommandBlockCommands = commandsConfiguration.getStringList("command-block-overrides").contains("*");
@@ -58,7 +172,47 @@ index e56de6c..db5e399 100644
          monsterSpawn = configuration.getInt("spawn-limits.monsters");
          animalSpawn = configuration.getInt("spawn-limits.animals");
          waterAnimalSpawn = configuration.getInt("spawn-limits.water-animals");
-@@ -677,6 +681,11 @@ public final class CraftServer extends CraftBukkitRuntime implements Server {
+@@ -309,6 +318,17 @@ public final class CraftServer extends CraftBukkitRuntime implements Server {
+ 
+         if (pluginFolder.exists()) {
+             Plugin[] plugins = pluginManager.loadPlugins(pluginFolder);
++
++            final Stage stage = console.options.valueOf(Main.GUICE_STAGE_OPTION);
++            logger.info("Creating injector in stage " + stage);
++
++            try {
++                injector = Guice.createInjector(stage, new ServerInstanceModule(this, Arrays.asList(plugins)));
++            } catch(RuntimeException ex) {
++                logger.log(Level.SEVERE, "Injector creation failed, server will shut down", ex);
++                throw ex;
++            }
++
+             for (Plugin plugin : plugins) {
+                 try {
+                     String message = String.format("Loading %s", plugin.getDescription().getFullName());
+@@ -375,9 +395,6 @@ public final class CraftServer extends CraftBukkitRuntime implements Server {
+             pluginManager.enablePlugin(plugin);
+         } catch (RuntimeException ex) {
+             Logger.getLogger(CraftServer.class.getName()).log(Level.SEVERE, ex.getMessage() + " loading " + plugin.getDescription().getFullName() + " (Is it up to date?)", ex);
+-        }
+-
+-        if(!plugin.isEnabled()) {
+             pluginFailedToLoad(plugin);
+         }
+     }
+@@ -410,6 +427,11 @@ public final class CraftServer extends CraftBukkitRuntime implements Server {
+     }
+ 
+     @Override
++    public Map<UUID, Player> playersById() {
++        return playersById;
++    }
++
++    @Override
+     @Deprecated
+     public Player getPlayer(final String name, final CommandSender viewer) {
+         Validate.notNull(name, "Name cannot be null");
+@@ -677,10 +699,25 @@ public final class CraftServer extends CraftBukkitRuntime implements Server {
      }
  
      @Override
@@ -70,7 +224,47 @@ index e56de6c..db5e399 100644
      public List<World> getWorlds() {
          return new ArrayList<World>(worlds.values());
      }
-@@ -1669,6 +1678,11 @@ public final class CraftServer extends CraftBukkitRuntime implements Server {
+ 
++    @Override
++    public Map<String, World> worldsByName() {
++        return worldsView;
++    }
++
++    @Override
++    public Map<UUID, World> worldsById() {
++        return worldsByIdView;
++    }
++
+     public DedicatedPlayerList getHandle() {
+         return playerList;
+     }
+@@ -1074,6 +1111,7 @@ public final class CraftServer extends CraftBukkitRuntime implements Server {
+             }
+         }
+ 
++        worldsById.remove(world.getUID());
+         worlds.remove(world.getName().toLowerCase(java.util.Locale.ENGLISH));
+         console.worlds.remove(console.worlds.indexOf(handle));
+ 
+@@ -1131,6 +1169,7 @@ public final class CraftServer extends CraftBukkitRuntime implements Server {
+             System.out.println("World " + world.getName() + " is a duplicate of another world and has been prevented from loading. Please delete the uid.dat file from " + world.getName() + "'s world directory if you want to be able to load the duplicate world.");
+             return;
+         }
++        worldsById.put(world.getUID(), world);
+         worlds.put(world.getName().toLowerCase(java.util.Locale.ENGLISH), world);
+     }
+ 
+@@ -1524,6 +1563,9 @@ public final class CraftServer extends CraftBukkitRuntime implements Server {
+ 
+     @Override
+     public ConsoleCommandSender getConsoleSender() {
++        if(console.console == null) {
++            console.console = new ColouredConsoleSender();
++        }
+         return console.console;
+     }
+ 
+@@ -1669,6 +1711,11 @@ public final class CraftServer extends CraftBukkitRuntime implements Server {
          return warningState;
      }
  
@@ -82,6 +276,188 @@ index e56de6c..db5e399 100644
      public List<String> tabComplete(net.minecraft.server.ICommandListener sender, String message, BlockPosition pos) {
          if (!(sender instanceof EntityPlayer)) {
              return ImmutableList.of();
+diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
+index 54470be..b704069 100644
+--- a/src/main/java/org/bukkit/craftbukkit/Main.java
++++ b/src/main/java/org/bukkit/craftbukkit/Main.java
+@@ -7,16 +7,20 @@ import java.util.Arrays;
+ import java.util.Calendar;
+ import java.util.Date;
+ import java.util.List;
+-import java.util.TimeZone;
+-import java.util.concurrent.TimeUnit;
+ import java.util.logging.Level;
+ import java.util.logging.Logger;
++
++import com.google.inject.Stage;
+ import joptsimple.OptionParser;
+ import joptsimple.OptionSet;
++import joptsimple.OptionSpec;
+ import net.minecraft.server.MinecraftServer;
+ import org.fusesource.jansi.AnsiConsole;
+ 
+ public class Main {
++
++    public static OptionSpec<Stage> GUICE_STAGE_OPTION;
++
+     public static boolean useJline = true;
+     public static boolean useConsole = true;
+ 
+@@ -118,6 +122,11 @@ public class Main {
+                 acceptsAll(asList("v", "version"), "Show the CraftBukkit Version");
+ 
+                 acceptsAll(asList("demo"), "Demo mode");
++
++                GUICE_STAGE_OPTION = acceptsAll(asList("stage"), "Guice run stage (development/production)")
++                        .withRequiredArg()
++                        .ofType(com.google.inject.Stage.class)
++                        .defaultsTo(com.google.inject.Stage.PRODUCTION);
+             }
+         };
+ 
+diff --git a/src/main/java/org/bukkit/craftbukkit/command/ColouredConsoleSender.java b/src/main/java/org/bukkit/craftbukkit/command/ColouredConsoleSender.java
+index 26a2fb8..b8deea4 100644
+--- a/src/main/java/org/bukkit/craftbukkit/command/ColouredConsoleSender.java
++++ b/src/main/java/org/bukkit/craftbukkit/command/ColouredConsoleSender.java
+@@ -7,9 +7,7 @@ import org.fusesource.jansi.Ansi;
+ import org.fusesource.jansi.Ansi.Attribute;
+ import jline.Terminal;
+ 
+-import org.bukkit.Bukkit;
+ import org.bukkit.ChatColor;
+-import org.bukkit.command.ConsoleCommandSender;
+ import org.bukkit.craftbukkit.CraftServer;
+ 
+ public class ColouredConsoleSender extends CraftConsoleCommandSender {
+@@ -17,7 +15,7 @@ public class ColouredConsoleSender extends CraftConsoleCommandSender {
+     private final Map<ChatColor, String> replacements = new EnumMap<ChatColor, String>(ChatColor.class);
+     private final ChatColor[] colors = ChatColor.values();
+ 
+-    protected ColouredConsoleSender() {
++    public ColouredConsoleSender() {
+         super();
+         this.terminal = ((CraftServer) getServer()).getReader().getTerminal();
+ 
+@@ -63,12 +61,4 @@ public class ColouredConsoleSender extends CraftConsoleCommandSender {
+             super.sendMessage(message);
+         }
+     }
+-
+-    public static ConsoleCommandSender getInstance() {
+-        if (Bukkit.getConsoleSender() != null) {
+-            return Bukkit.getConsoleSender();
+-        } else {
+-            return new ColouredConsoleSender();
+-        }
+-    }
+ }
+diff --git a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java b/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
+index 3d5abfa..eb1b4cf 100644
+--- a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
++++ b/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
+@@ -1,5 +1,6 @@
+ package org.bukkit.craftbukkit.scheduler;
+ 
++import java.time.Duration;
+ import java.util.ArrayList;
+ import java.util.Comparator;
+ import java.util.Iterator;
+@@ -492,4 +493,11 @@ public class CraftScheduler implements BukkitScheduler {
+     public BukkitTask runTaskTimerAsynchronously(Plugin plugin, BukkitRunnable task, long delay, long period) throws IllegalArgumentException {
+         return runTaskTimerAsynchronously(plugin, (Runnable) task, delay, period);
+     }
++
++    private static final Duration TICK = Duration.ofMillis(50);
++
++    @Override
++    public Duration tickDuration() {
++        return TICK;
++    }
+ }
+diff --git a/src/main/java/org/bukkit/craftbukkit/util/CaseInsensitiveNameMap.java b/src/main/java/org/bukkit/craftbukkit/util/CaseInsensitiveNameMap.java
+new file mode 100644
+index 0000000..539bc84
+--- /dev/null
++++ b/src/main/java/org/bukkit/craftbukkit/util/CaseInsensitiveNameMap.java
+@@ -0,0 +1,78 @@
++package org.bukkit.craftbukkit.util;
++
++import java.util.AbstractMap;
++import java.util.AbstractSet;
++import java.util.Collection;
++import java.util.Iterator;
++import java.util.Set;
++import java.util.function.Function;
++
++import com.google.common.collect.Iterators;
++import com.google.common.collect.Maps;
++
++public class CaseInsensitiveNameMap<V> extends AbstractMap<String, V> {
++
++    private final Collection<V> values;
++    private final Function<V, String> nameGetter;
++    private final Set<Entry<String, V>> entries;
++
++    public CaseInsensitiveNameMap(Collection<V> values, Function<V, String> nameGetter) {
++        this.values = values;
++        this.nameGetter = nameGetter;
++
++        this.entries = new AbstractSet<Entry<String, V>>() {
++            @Override
++            public Iterator<Entry<String, V>> iterator() {
++                return Iterators.transform(
++                    values.iterator(),
++                    value -> Maps.immutableEntry(nameGetter.apply(value), value)
++                );
++            }
++
++            @Override
++            public int size() {
++                return values.size();
++            }
++        };
++    }
++
++    @Override
++    public Set<Entry<String, V>> entrySet() {
++        return entries;
++    }
++
++    @Override
++    public Collection<V> values() {
++        return values;
++    }
++
++    @Override
++    public int size() {
++        return values.size();
++    }
++
++    @Override
++    public boolean isEmpty() {
++        return values.isEmpty();
++    }
++
++    @Override
++    public boolean containsValue(Object value) {
++        return values.contains(value);
++    }
++
++    @Override
++    public boolean containsKey(Object key) {
++        return get(key) != null;
++    }
++
++    @Override
++    public V get(Object key) {
++        if(!(key instanceof String)) return null;
++        final String name = (String) key;
++        for(V value : values) {
++            if(name.equalsIgnoreCase(nameGetter.apply(value))) return value;
++        }
++        return null;
++    }
++}
 -- 
 1.9.0
 

--- a/CraftBukkit/0159-Server-suspend-API.patch
+++ b/CraftBukkit/0159-Server-suspend-API.patch
@@ -1,4 +1,4 @@
-From 0de19e074a8717597d1dd3e31b3968fd8e0e7a66 Mon Sep 17 00:00:00 2001
+From 89eecda38369942404569bc03a4c0fe941f957ca Mon Sep 17 00:00:00 2001
 From: Jedediah Smith <jedediah@silencegreys.com>
 Date: Sat, 10 Dec 2016 20:28:26 -0500
 Subject: [PATCH] Server suspend API
@@ -229,7 +229,7 @@ index da6702c..99f49c0 100644
              long j = MinecraftServer.aw();
              long k = j - i;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index db5e399..76a1e7c 100644
+index 1aadad1..940f262 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -6,6 +6,8 @@ import java.io.FileInputStream;
@@ -249,8 +249,8 @@ index db5e399..76a1e7c 100644
 +import javax.annotation.Nullable;
  import javax.imageio.ImageIO;
  
- import net.minecraft.server.*;
-@@ -135,6 +137,7 @@ import io.netty.handler.codec.base64.Base64;
+ import com.google.common.collect.Maps;
+@@ -140,6 +142,7 @@ import io.netty.handler.codec.base64.Base64;
  import jline.console.ConsoleReader;
  import org.bukkit.event.server.TabCompleteEvent;
  import net.md_5.bungee.api.chat.BaseComponent;
@@ -258,7 +258,7 @@ index db5e399..76a1e7c 100644
  import tc.oc.minecraft.api.plugin.PluginFinder;
  
  public final class CraftServer extends CraftBukkitRuntime implements Server {
-@@ -182,6 +185,8 @@ public final class CraftServer extends CraftBukkitRuntime implements Server {
+@@ -191,6 +194,8 @@ public final class CraftServer extends CraftBukkitRuntime implements Server {
      public boolean bungee = false;
      public static final com.google.gson.Gson gson = new com.google.gson.Gson();
  
@@ -267,7 +267,7 @@ index db5e399..76a1e7c 100644
      private final class BooleanWrapper {
          private boolean value = true;
      }
-@@ -661,6 +666,16 @@ public final class CraftServer extends CraftBukkitRuntime implements Server {
+@@ -679,6 +684,16 @@ public final class CraftServer extends CraftBukkitRuntime implements Server {
      }
  
      @Override
@@ -284,7 +284,7 @@ index db5e399..76a1e7c 100644
      public PluginManager getPluginManager() {
          return pluginManager;
      }
-@@ -1878,4 +1893,53 @@ public final class CraftServer extends CraftBukkitRuntime implements Server {
+@@ -1911,4 +1926,53 @@ public final class CraftServer extends CraftBukkitRuntime implements Server {
  
          return task instanceof Wrapped ? task : new Wrapped();
      }

--- a/CraftBukkit/0161-Legacy-protocol-support.patch
+++ b/CraftBukkit/0161-Legacy-protocol-support.patch
@@ -1,4 +1,4 @@
-From 6fe17d596f7e9f117e1b0ca9562e431f1153cbd7 Mon Sep 17 00:00:00 2001
+From cedc426e65fef1e65c4b837f3947171855ba33c6 Mon Sep 17 00:00:00 2001
 From: Jedediah Smith <jedediah@silencegreys.com>
 Date: Sun, 20 Nov 2016 09:44:03 -0500
 Subject: [PATCH] Legacy protocol support
@@ -1348,10 +1348,10 @@ index 2c8fb70..50ccda7 100644
  
      public void a(int i, int j, int k, int l, int i1, int j1) {}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 76a1e7c..8912202 100644
+index 940f262..41d0cce 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -72,6 +72,7 @@ import org.bukkit.craftbukkit.metadata.EntityMetadataStore;
+@@ -77,6 +77,7 @@ import org.bukkit.craftbukkit.metadata.EntityMetadataStore;
  import org.bukkit.craftbukkit.metadata.PlayerMetadataStore;
  import org.bukkit.craftbukkit.metadata.WorldMetadataStore;
  import org.bukkit.craftbukkit.potion.CraftPotionBrewer;
@@ -1359,7 +1359,7 @@ index 76a1e7c..8912202 100644
  import org.bukkit.craftbukkit.scheduler.CraftScheduler;
  import org.bukkit.craftbukkit.scoreboard.CraftScoreboardManager;
  import org.bukkit.craftbukkit.util.CraftIconCache;
-@@ -1851,7 +1852,7 @@ public final class CraftServer extends CraftBukkitRuntime implements Server {
+@@ -1884,7 +1885,7 @@ public final class CraftServer extends CraftBukkitRuntime implements Server {
  
      @Override
      public Set<Integer> getProtocolVersions() {


### PR DESCRIPTION
* Create a Guice `Injector` for the server, with a child `Injector` for each plugin.
* Allow plugin main class to be a Guice `Module` instead of a `Plugin`, in which case the module will be used to create the plugin's private injector, and a generic `Plugin` instance is provided. `ProtectedModule` can be used to get access to the global environment.
* Alternately, `Plugin#configure` can be implemented to configure the plugin's injector. This is intended more for transitional code.
* Many Bukkit services have bindings, some globally and some per-plugin. See `ServerModule` and `PluginModule` for most of these.
* Several things can be registered at configuration time:
* * `Enableable`s which receive lifecycle callbacks
* * `Tickable`s which get periodic callbacks
* * `Listener`s
* * `Permission`s