### PR TITLE
Setting to not tick empty worlds

### DIFF
--- a/Bukkit/0091-Don-t-tick-empty-worlds.patch
+++ b/Bukkit/0091-Don-t-tick-empty-worlds.patch
@@ -1,0 +1,50 @@
+From b7912c0c3acee012016cf004213f801cda3b44ea Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Thu, 29 Dec 2016 23:25:25 -0500
+Subject: [PATCH] Don't tick empty worlds
+
+
+diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
+index 12170b6..f966510 100644
+--- a/src/main/java/org/bukkit/Server.java
++++ b/src/main/java/org/bukkit/Server.java
+@@ -230,6 +230,10 @@ public interface Server extends PluginMessageRecipient, BukkitRuntime, tc.oc.min
+      */
+     public boolean getGenerateStructures();
+ 
++    boolean getKeepSpawnInMemory();
++
++    boolean getTickEmptyWorlds();
++
+     /**
+      * Gets whether this server allows the End or not.
+      *
+diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
+index 25593df..dafcbb1 100644
+--- a/src/main/java/org/bukkit/World.java
++++ b/src/main/java/org/bukkit/World.java
+@@ -312,6 +312,8 @@ public interface World extends PluginMessageRecipient, Metadatable, Physical {
+     @Deprecated
+     public boolean unloadChunk(int x, int z, boolean save, boolean safe);
+ 
++    int unloadAllChunks();
++
+     /**
+      * Safely queues the {@link Chunk} at the specified coordinates for
+      * unloading
+@@ -356,6 +358,12 @@ public interface World extends PluginMessageRecipient, Metadatable, Physical {
+     @Deprecated
+     public boolean refreshChunk(int x, int z);
+ 
++    int getPlayerCount();
++
++    boolean hasPlayers();
++
++    boolean isTicking();
++
+     /**
+      * Drops an item at the specified {@link Location}
+      *
+-- 
+1.9.0
+

--- a/CraftBukkit/0166-Don-t-tick-empty-worlds.patch
+++ b/CraftBukkit/0166-Don-t-tick-empty-worlds.patch
@@ -1,0 +1,120 @@
+From 9ec0b74ee7a13d84770e9222e7f31bae9fae20ae Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Thu, 29 Dec 2016 23:23:45 -0500
+Subject: [PATCH] Don't tick empty worlds
+
+
+diff --git a/src/main/java/net/minecraft/server/ChunkProviderServer.java b/src/main/java/net/minecraft/server/ChunkProviderServer.java
+index e07d08e..cf8e1e8 100644
+--- a/src/main/java/net/minecraft/server/ChunkProviderServer.java
++++ b/src/main/java/net/minecraft/server/ChunkProviderServer.java
+@@ -304,6 +304,16 @@ public class ChunkProviderServer implements IChunkProvider {
+     }
+     // CraftBukkit end
+ 
++    // SportBukkit start
++    public int unloadAllChunks(boolean save) {
++        int count = 0;
++        for(Chunk chunk : new ArrayList<>(chunks.values())) {
++            if(unloadChunk(chunk, save)) count++;
++        }
++        return count;
++    }
++    // SportBukkit end
++
+     public boolean e() {
+         return !this.world.savingDisabled;
+     }
+diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
+index 401b7e4..45eca3a 100644
+--- a/src/main/java/net/minecraft/server/MinecraftServer.java
++++ b/src/main/java/net/minecraft/server/MinecraftServer.java
+@@ -843,6 +843,7 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
+ 
+             // if (i == 0 || this.getAllowNether()) {
+                 WorldServer worldserver = this.worlds.get(i);
++                if(!worldserver.getWorld().checkTicking()) continue; // SportBukkit
+ 
+                 this.methodProfiler.a(worldserver.getWorldData().getName());
+                 /* Drop global time updates
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+index f40306e..24b0c30 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+@@ -601,6 +601,16 @@ public final class CraftServer extends CraftBukkitRuntime implements Server {
+     }
+ 
+     @Override
++    public boolean getKeepSpawnInMemory() {
++        return this.configuration.getBoolean("settings.keep-spawn-loaded", true);
++    }
++
++    @Override
++    public boolean getTickEmptyWorlds() {
++        return this.configuration.getBoolean("settings.tick-empty-worlds", true);
++    }
++
++    @Override
+     public boolean getAllowEnd() {
+         return this.configuration.getBoolean("settings.allow-end");
+     }
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+index 3ff9b63..5e57fba 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+@@ -96,6 +96,40 @@ public class CraftWorld implements World {
+         if (server.chunkGCPeriod > 0) {
+             chunkGCTickCount = rand.nextInt(server.chunkGCPeriod);
+         }
++
++        world.keepSpawnInMemory = world.getServer().getKeepSpawnInMemory();
++    }
++
++    private boolean ticking = false;
++
++    @Override
++    public boolean isTicking() {
++        return ticking;
++    }
++
++    public boolean checkTicking() {
++        if(ticking) {
++            if(!(hasPlayers() || server.getTickEmptyWorlds())) {
++                ticking = false;
++                world.getServer().getLogger().info("Stopping world " + getName());
++                unloadAllChunks();
++            }
++        } else if(hasPlayers()) {
++            ticking = true;
++            world.getServer().getLogger().info("Starting world " + getName());
++            setKeepSpawnInMemory(getKeepSpawnInMemory());
++        }
++        return ticking;
++    }
++
++    @Override
++    public int getPlayerCount() {
++        return getHandle().players.size();
++    }
++
++    @Override
++    public boolean hasPlayers() {
++        return getPlayerCount() > 0;
+     }
+ 
+     @Override
+@@ -219,6 +253,11 @@ public class CraftWorld implements World {
+         return world.getChunkProviderServer().unloadChunk(chunk, chunk.mustSave || save);
+     }
+ 
++    @Override
++    public int unloadAllChunks() {
++        return getHandle().getChunkProviderServer().unloadAllChunks(true);
++    }
++
+     public boolean regenerateChunk(int x, int z) {
+         if (!unloadChunk0(x, z, false)) {
+             return false;
+-- 
+1.9.0
+


### PR DESCRIPTION
Add `settings.tick-empty-worlds` to `bukkit.yml`. If false, worlds with no players unload all chunks and do not tick at all.