### PR TITLE
Add immutable MaterialDatas and ItemStacks

### DIFF
--- a/Bukkit/0001-Update-the-POM-to-distinguish-SportBukkit-from-Bukki.patch
+++ b/Bukkit/0001-Update-the-POM-to-distinguish-SportBukkit-from-Bukki.patch
@@ -1,11 +1,11 @@
-From a2c84b642b5afbedc86ebb0c58eef5c334046100 Mon Sep 17 00:00:00 2001
+From 052a0a02cafa241c1302eb9b8c9272531ef6b71b Mon Sep 17 00:00:00 2001
 From: mrapple <tony@oc.tc>
 Date: Tue, 10 Dec 2013 23:16:10 -0600
 Subject: [PATCH] Update the POM to distinguish SportBukkit from Bukkit
 
 
 diff --git a/pom.xml b/pom.xml
-index f94706a..3304f7e 100644
+index f94706a..bde6cc7 100644
 --- a/pom.xml
 +++ b/pom.xml
 @@ -3,36 +3,34 @@
@@ -61,7 +61,20 @@ index f94706a..3304f7e 100644
          </snapshotRepository>
      </distributionManagement>
  
-@@ -136,8 +134,8 @@
+@@ -97,6 +95,12 @@
+             <version>1.3</version>
+             <scope>test</scope>
+         </dependency>
++        <dependency>
++            <groupId>tc.oc</groupId>
++            <artifactId>test-util</artifactId>
++            <version>1.0-SNAPSHOT</version>
++            <scope>test</scope>
++        </dependency>
+     </dependencies>
+ 
+     <build>
+@@ -136,8 +140,8 @@
                  <configuration>
                      <signature>
                          <groupId>org.codehaus.mojo.signature</groupId>

--- a/Bukkit/0088-New-event-API.patch
+++ b/Bukkit/0088-New-event-API.patch
@@ -1,4 +1,4 @@
-From 0898b6dfc94173474ee9bc28c0ecdb077462ce3d Mon Sep 17 00:00:00 2001
+From 62710ab9c87fefb08fb8c9c8ec195b0e90236c70 Mon Sep 17 00:00:00 2001
 From: Jedediah Smith <jedediah@silencegreys.com>
 Date: Sat, 9 Jul 2016 05:27:03 -0400
 Subject: [PATCH] New event API
@@ -2790,7 +2790,7 @@ index 2d84032..152010a 100644
      public static Server getInstance() {
 diff --git a/src/test/java/org/bukkit/event/EventBusTest.java b/src/test/java/org/bukkit/event/EventBusTest.java
 new file mode 100644
-index 0000000..2b50db6
+index 0000000..efb19e5
 --- /dev/null
 +++ b/src/test/java/org/bukkit/event/EventBusTest.java
 @@ -0,0 +1,275 @@
@@ -2803,12 +2803,12 @@ index 0000000..2b50db6
 +
 +import tc.oc.exception.ExceptionHandler;
 +import org.bukkit.exception.TestExceptionHandler;
-+import org.bukkit.test.TestThread;
++import tc.oc.test.TestThread;
 +import org.junit.After;
 +import org.junit.Before;
 +import org.junit.Test;
 +
-+import static org.bukkit.test.Assert.assertThrows;
++import static tc.oc.test.Assert.*;
 +import static org.junit.Assert.*;
 +
 +public class EventBusTest {
@@ -3071,7 +3071,7 @@ index 0000000..2b50db6
 +}
 diff --git a/src/test/java/org/bukkit/event/EventHandlerMetaTest.java b/src/test/java/org/bukkit/event/EventHandlerMetaTest.java
 new file mode 100644
-index 0000000..05aba89
+index 0000000..7399b06
 --- /dev/null
 +++ b/src/test/java/org/bukkit/event/EventHandlerMetaTest.java
 @@ -0,0 +1,87 @@
@@ -3079,7 +3079,7 @@ index 0000000..05aba89
 +
 +import org.junit.Test;
 +
-+import static org.bukkit.test.Assert.*;
++import static tc.oc.test.Assert.*;
 +import static org.junit.Assert.*;
 +
 +public class EventHandlerMetaTest {
@@ -3164,7 +3164,7 @@ index 0000000..05aba89
 +}
 diff --git a/src/test/java/org/bukkit/event/EventMethodExecutorTest.java b/src/test/java/org/bukkit/event/EventMethodExecutorTest.java
 new file mode 100644
-index 0000000..6227c7b
+index 0000000..d879171
 --- /dev/null
 +++ b/src/test/java/org/bukkit/event/EventMethodExecutorTest.java
 @@ -0,0 +1,135 @@
@@ -3176,10 +3176,10 @@ index 0000000..6227c7b
 +
 +import tc.oc.exception.ExceptionHandler;
 +import org.bukkit.exception.TestExceptionHandler;
-+import org.bukkit.test.TestCodeBlock;
++import tc.oc.test.TestCodeBlock;
 +import org.junit.Test;
 +
-+import static org.bukkit.test.Assert.*;
++import static tc.oc.test.Assert.*;
 +import static org.junit.Assert.*;
 +
 +public class EventMethodExecutorTest {
@@ -3305,7 +3305,7 @@ index 0000000..6227c7b
 +}
 diff --git a/src/test/java/org/bukkit/event/EventRegistryTest.java b/src/test/java/org/bukkit/event/EventRegistryTest.java
 new file mode 100644
-index 0000000..ede5376
+index 0000000..9da2f8d
 --- /dev/null
 +++ b/src/test/java/org/bukkit/event/EventRegistryTest.java
 @@ -0,0 +1,93 @@
@@ -3320,7 +3320,7 @@ index 0000000..ede5376
 +import org.junit.Before;
 +import org.junit.Test;
 +
-+import static org.bukkit.test.Assert.*;
++import static tc.oc.test.Assert.*;
 +import static org.junit.Assert.*;
 +
 +public class EventRegistryTest {
@@ -3404,7 +3404,7 @@ index 0000000..ede5376
 +}
 diff --git a/src/test/java/org/bukkit/event/HandlerListTest.java b/src/test/java/org/bukkit/event/HandlerListTest.java
 new file mode 100644
-index 0000000..d7e97a9
+index 0000000..ff30c1d
 --- /dev/null
 +++ b/src/test/java/org/bukkit/event/HandlerListTest.java
 @@ -0,0 +1,18 @@
@@ -3412,7 +3412,7 @@ index 0000000..d7e97a9
 +
 +import org.junit.Test;
 +
-+import static org.bukkit.test.Assert.*;
++import static tc.oc.test.Assert.*;
 +
 +public class HandlerListTest {
 +
@@ -3622,174 +3622,6 @@ index 7e09892..82aff85 100644
      }
  
      public EbeanServer getDatabase() {
-diff --git a/src/test/java/org/bukkit/test/Assert.java b/src/test/java/org/bukkit/test/Assert.java
-new file mode 100644
-index 0000000..5a44776
---- /dev/null
-+++ b/src/test/java/org/bukkit/test/Assert.java
-@@ -0,0 +1,43 @@
-+package org.bukkit.test;
-+
-+import java.util.Arrays;
-+import java.util.Collection;
-+import java.util.List;
-+
-+import static org.junit.Assert.*;
-+
-+public final class Assert {
-+
-+    public static void assertEmpty(Object[] array) {
-+        assertEmpty(Arrays.asList(array));
-+    }
-+
-+    public static void assertEmpty(Collection collection) {
-+        if(collection.isEmpty()) return;
-+        fail("Expected collection to be empty, but it contains " + collection.size() + " elements");
-+    }
-+
-+    public static void assertSize(int size, Object[] array) {
-+        assertSize(size, Arrays.asList(array));
-+    }
-+
-+    public static void assertSize(int size, Collection collection) {
-+        if(collection.size() == size) return;
-+        fail("Expected collection to contain " + size +
-+             " elements, but it actually contains " + collection.size());
-+    }
-+
-+    public static void assertList(List actual, Object...expected) {
-+        assertEquals(Arrays.asList(expected), actual);
-+    }
-+
-+    public static void assertThrows(Class<? extends Throwable> expected, TestCodeBlock block) throws Throwable {
-+        try {
-+            block.run();
-+        } catch(Throwable throwable) {
-+            if(expected.isInstance(throwable)) return;
-+            throw throwable;
-+        }
-+        fail("Expected " + expected.getSimpleName() + " to be thrown, but nothing was thrown");
-+    }
-+}
-diff --git a/src/test/java/org/bukkit/test/TestCodeBlock.java b/src/test/java/org/bukkit/test/TestCodeBlock.java
-new file mode 100644
-index 0000000..f1101fa
---- /dev/null
-+++ b/src/test/java/org/bukkit/test/TestCodeBlock.java
-@@ -0,0 +1,6 @@
-+package org.bukkit.test;
-+
-+@FunctionalInterface
-+public interface TestCodeBlock {
-+    void run() throws Throwable;
-+}
-diff --git a/src/test/java/org/bukkit/test/TestLogger.java b/src/test/java/org/bukkit/test/TestLogger.java
-new file mode 100644
-index 0000000..9a85863
---- /dev/null
-+++ b/src/test/java/org/bukkit/test/TestLogger.java
-@@ -0,0 +1,49 @@
-+package org.bukkit.test;
-+
-+import java.util.ArrayList;
-+import java.util.Collections;
-+import java.util.List;
-+import java.util.logging.Handler;
-+import java.util.logging.Level;
-+import java.util.logging.LogRecord;
-+import java.util.logging.Logger;
-+
-+import static org.junit.Assert.*;
-+
-+/**
-+ * A {@link Logger} that asserts if an error is logged,
-+ * and retains all {@link LogRecord}s for tests to examine.
-+ */
-+public class TestLogger extends Logger {
-+
-+    final Level failureLevel;
-+    final List<LogRecord> records = new ArrayList<>();
-+    final List<LogRecord> recordsView = Collections.unmodifiableList(records);
-+
-+    public TestLogger() {
-+        this(Level.SEVERE);
-+    }
-+
-+    public TestLogger(Level failureLevel) {
-+        super(null, null);
-+        this.failureLevel = failureLevel;
-+        setUseParentHandlers(false);
-+
-+        addHandler(new Handler() {
-+            @Override
-+            public void publish(LogRecord record) {
-+                if(failureLevel.intValue() <= record.getLevel().intValue()) {
-+                    fail(record.getMessage());
-+                }
-+                records.add(record);
-+            }
-+
-+            @Override public void flush() {}
-+            @Override public void close() throws SecurityException { }
-+        });
-+    }
-+
-+    public List<LogRecord> records() {
-+        return recordsView;
-+    }
-+}
-diff --git a/src/test/java/org/bukkit/test/TestThread.java b/src/test/java/org/bukkit/test/TestThread.java
-new file mode 100644
-index 0000000..6b372c1
---- /dev/null
-+++ b/src/test/java/org/bukkit/test/TestThread.java
-@@ -0,0 +1,46 @@
-+package org.bukkit.test;
-+
-+import javax.annotation.Nullable;
-+
-+public class TestThread extends Thread {
-+
-+    public static TestThread start(TestCodeBlock body) {
-+        final TestThread thread = new TestThread(body);
-+        thread.start();
-+        return thread;
-+    }
-+
-+    public static TestThread join(TestCodeBlock body) throws Throwable {
-+        final TestThread thread = new TestThread(body);
-+        thread.start();
-+        thread.assertJoin();
-+        return thread;
-+    }
-+
-+    private final TestCodeBlock body;
-+    private volatile @Nullable Throwable exception;
-+
-+    public TestThread(TestCodeBlock body) {
-+        this.body = body;
-+    }
-+
-+    @Override
-+    public void run() {
-+        try {
-+            body.run();
-+        } catch(Throwable ex) {
-+            this.exception = ex;
-+        }
-+    }
-+
-+    public void assertJoin() throws Throwable {
-+        join();
-+
-+        if(exception != null) {
-+            if(exception instanceof AssertionError) {
-+                throw exception;
-+            }
-+            throw new AssertionError("Thread " + getName() + " terminated with an exception", exception);
-+        }
-+    }
-+}
 -- 
 1.9.0
 

--- a/Bukkit/0093-Immutable-materials-and-items.patch
+++ b/Bukkit/0093-Immutable-materials-and-items.patch
@@ -1,0 +1,434 @@
+From f2497222ba2f8783000b552238cf94c5a560353a Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Wed, 4 Jan 2017 14:01:56 -0500
+Subject: [PATCH] Immutable materials and items
+
+
+diff --git a/src/main/java/org/bukkit/inventory/ImItemStack.java b/src/main/java/org/bukkit/inventory/ImItemStack.java
+new file mode 100644
+index 0000000..17feb00
+--- /dev/null
++++ b/src/main/java/org/bukkit/inventory/ImItemStack.java
+@@ -0,0 +1,94 @@
++package org.bukkit.inventory;
++
++import java.util.Map;
++import javax.annotation.Nullable;
++
++import org.bukkit.Material;
++import org.bukkit.enchantments.Enchantment;
++import org.bukkit.inventory.meta.ItemMeta;
++import org.bukkit.material.MaterialData;
++
++public class ImItemStack extends ItemStack {
++
++    public static ImItemStack of(Material material) {
++        return of(material, (short) 0);
++    }
++
++    public static ImItemStack of(Material material, int damage) {
++        return of(material, damage, 1);
++    }
++
++    public static ImItemStack of(Material material, int damage, int amount) {
++        return of(material, damage, amount, null);
++    }
++
++    public static ImItemStack of(Material material, int damage, int amount, @Nullable ItemMeta meta) {
++        return new ImItemStack(material, damage, amount, meta);
++    }
++
++    public static ImItemStack of(MaterialData material) {
++        return of(material, 1);
++    }
++
++    public static ImItemStack of(MaterialData material, int amount) {
++        return of(material, amount, null);
++    }
++
++    public static ImItemStack of(MaterialData material, int amount, @Nullable ItemMeta meta) {
++        return new ImItemStack(material, amount, meta);
++    }
++
++    public static ImItemStack copyOf(ItemStack stack) {
++        return stack instanceof ImItemStack ? (ImItemStack) stack : new ImItemStack(stack);
++    }
++
++    ImItemStack(Material material, int damage, int amount, @Nullable ItemMeta meta) {
++        super(material, checkAmount(material, amount), checkDamage(material, damage), null);
++        if(meta != null) {
++            super.setItemMeta(meta);
++        }
++    }
++
++    ImItemStack(MaterialData material, int amount, @Nullable ItemMeta meta) {
++        super(material.getItemType(), checkAmount(material.getItemType(), amount), (short) 0, null);
++        super.setData(material);
++        if(meta != null) {
++            super.setItemMeta(meta);
++        }
++    }
++
++    ImItemStack(ItemStack stack) {
++        super(stack);
++    }
++
++    @Override
++    public boolean isMutable() {
++        return false;
++    }
++
++    @Override
++    public ImItemStack immutableCopy() {
++        return this;
++    }
++
++    @Override
++    public ItemStack clone() {
++        return new ItemStack(this);
++    }
++
++    private UnsupportedOperationException ex() {
++        return new UnsupportedOperationException("This " + ItemStack.class.getSimpleName() + " is immutable");
++    }
++
++    @Override public void setType(Material type) { throw ex(); }
++    @Override public void setTypeId(int type) { throw ex(); }
++    @Override public void setAmount(int amount) { throw ex(); }
++    @Override public void setData(MaterialData data) { throw ex(); }
++    @Override public void setDurability(short durability) { throw ex(); }
++    @Override public void addEnchantments(Map<Enchantment, Integer> enchantments) { throw ex(); }
++    @Override public void addEnchantment(Enchantment ench, int level) { throw ex(); }
++    @Override public void addUnsafeEnchantments(Map<Enchantment, Integer> enchantments) { throw ex(); }
++    @Override public void addUnsafeEnchantment(Enchantment ench, int level) { throw ex(); }
++    @Override public int removeEnchantment(Enchantment ench) { throw ex(); }
++    @Override public boolean setItemMeta(ItemMeta itemMeta) { throw ex(); }
++}
+diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
+index 188ae6d..a8a4c2b 100644
+--- a/src/main/java/org/bukkit/inventory/ItemStack.java
++++ b/src/main/java/org/bukkit/inventory/ItemStack.java
+@@ -3,6 +3,8 @@ package org.bukkit.inventory;
+ import com.google.common.collect.ImmutableMap;
+ import java.util.LinkedHashMap;
+ import java.util.Map;
++import java.util.function.Consumer;
++import javax.annotation.Nullable;
+ 
+ import org.apache.commons.lang.Validate;
+ import org.bukkit.Bukkit;
+@@ -108,7 +110,6 @@ public class ItemStack implements Cloneable, ConfigurationSerializable {
+         this.durability = damage;
+         if (data != null) {
+             createData(data);
+-            this.durability = data;
+         }
+     }
+ 
+@@ -124,6 +125,15 @@ public class ItemStack implements Cloneable, ConfigurationSerializable {
+         this(type.getId(), amount, damage, data);
+     }
+ 
++    public ItemStack(MaterialData material) {
++        this(material, 1);
++    }
++
++    public ItemStack(MaterialData material, int amount) {
++        this(material.getItemTypeId(), checkAmount(material.getItemType(), amount), (short) 0, null);
++        setData(material);
++    }
++
+     /**
+      * Creates a new item stack derived from the specified stack
+      *
+@@ -228,7 +238,7 @@ public class ItemStack implements Cloneable, ConfigurationSerializable {
+     public MaterialData getData() {
+         Material mat = getType();
+         if (data == null && mat != null && mat.getData() != null) {
+-            data = mat.getNewData((byte) this.getDurability());
++            data = mat.getNewData((byte) 0);
+         }
+ 
+         return data;
+@@ -253,6 +263,11 @@ public class ItemStack implements Cloneable, ConfigurationSerializable {
+         }
+     }
+ 
++    public void setMaterial(MaterialData data) {
++        setType(data.getItemType());
++        setData(data);
++    }
++
+     /**
+      * Sets the durability of this item
+      *
+@@ -608,4 +623,113 @@ public class ItemStack implements Cloneable, ConfigurationSerializable {
+ 
+         return true;
+     }
++
++    public boolean isMutable() {
++        return true;
++    }
++
++    public boolean isImmutable() {
++        return !isMutable();
++    }
++
++    public ImItemStack immutableCopy() {
++        return ImItemStack.copyOf(this);
++    }
++
++    protected static short checkDamage(Material material, int damage) {
++        if(damage != 0 && material.getMaxDurability() == 0) {
++            throw new IllegalArgumentException("Material " + material + " does not support damage/durability");
++        }
++        if(damage < Short.MIN_VALUE || damage > Short.MAX_VALUE) {
++            throw new IllegalArgumentException("Damage value " + damage + " is outside the valid range");
++        }
++        return (short) damage;
++    }
++
++    protected static int checkAmount(Material material, int amount) {
++        if(amount < Byte.MIN_VALUE || amount > Byte.MAX_VALUE) {
++            throw new IllegalArgumentException("Amount " + amount + " is outside the valid range");
++        }
++        return amount;
++    }
++
++    public static Builder builder(Material material) {
++        return builder(material, 0);
++    }
++
++    public static Builder builder(Material material, int damage) {
++        Validate.notNull(material);
++        return new Builder(null, material, damage);
++    }
++
++    public static Builder builder(MaterialData material) {
++        Validate.notNull(material);
++        return new Builder(material, null, 0);
++    }
++
++    public static class Builder {
++
++        private final @Nullable MaterialData data;
++        private final @Nullable Material material;
++        private final short damage;
++
++        private int amount = 1;
++        private @Nullable ItemMeta meta = null;
++
++        private Builder(@Nullable MaterialData data, @Nullable Material material, int damage) {
++            this.material = material;
++            this.data = data;
++            this.damage = checkDamage(material(), damage);
++        }
++
++        private Material material() {
++            return material != null ? material : data.getItemType();
++        }
++
++        private void checkMeta(@Nullable ItemMeta meta) {
++            final Material material = material();
++            if(material != null && meta != null && !Bukkit.getItemFactory().isApplicable(meta, material)) {
++                throw new IllegalArgumentException(meta.getClass().getSimpleName() + " is not applicable to material " + material);
++            }
++        }
++
++        public Builder amount(int amount) {
++            this.amount = checkAmount(material(), amount);
++            return this;
++        }
++
++        public Builder meta(@Nullable ItemMeta meta) {
++            checkMeta(meta);
++            this.meta = meta;
++            return this;
++        }
++
++        public Builder meta(Consumer<? super ItemMeta> block) {
++            return meta(ItemMeta.class, block);
++        }
++
++        public <T extends ItemMeta> Builder meta(Class<T> type, Consumer<? super T> block) {
++            final ItemMeta meta = Bukkit.getItemFactory().getItemMeta(material());
++            if(!type.isInstance(meta)) {
++                throw new IllegalArgumentException(type.getSimpleName() + " is not applicable to material " + material());
++            }
++            block.accept((T) meta);
++            this.meta = meta;
++            return this;
++        }
++
++        public ImItemStack immutable() {
++            return data != null ? ImItemStack.of(data, amount, meta)
++                                : ImItemStack.of(material, damage, amount, meta);
++        }
++
++        public ItemStack mutable() {
++            final ItemStack stack = data != null ? new ItemStack(data, amount)
++                                                 : new ItemStack(material, amount, damage);
++            if(meta != null) {
++                stack.setItemMeta(meta);
++            }
++            return stack;
++        }
++    }
+ }
+diff --git a/src/main/java/org/bukkit/material/MaterialData.java b/src/main/java/org/bukkit/material/MaterialData.java
+index 9caf085..f873206 100644
+--- a/src/main/java/org/bukkit/material/MaterialData.java
++++ b/src/main/java/org/bukkit/material/MaterialData.java
+@@ -9,6 +9,7 @@ import org.bukkit.Material;
+ public class MaterialData implements Cloneable {
+     private final int type;
+     private byte data = 0;
++    private boolean mutable = true;
+ 
+     /**
+      * @param type the raw type id
+@@ -63,6 +64,7 @@ public class MaterialData implements Cloneable {
+      */
+     @Deprecated
+     public void setData(byte data) {
++        assertMutable();
+         this.data = data;
+     }
+ 
+@@ -92,7 +94,7 @@ public class MaterialData implements Cloneable {
+      * @return New ItemStack containing a copy of this MaterialData
+      */
+     public ItemStack toItemStack() {
+-        return new ItemStack(type, 0, data);
++        return toItemStack(1);
+     }
+ 
+     /**
+@@ -102,7 +104,11 @@ public class MaterialData implements Cloneable {
+      * @return New ItemStack containing a copy of this MaterialData
+      */
+     public ItemStack toItemStack(int amount) {
+-        return new ItemStack(type, amount, data);
++        return new ItemStack(this, amount);
++    }
++
++    public ItemStack.Builder buildItemStack() {
++        return ItemStack.builder(this);
+     }
+ 
+     @Override
+@@ -129,9 +135,39 @@ public class MaterialData implements Cloneable {
+     @Override
+     public MaterialData clone() {
+         try {
+-            return (MaterialData) super.clone();
++            final MaterialData clone = (MaterialData) super.clone();
++            clone.mutable = true;
++            return clone;
+         } catch (CloneNotSupportedException e) {
+             throw new Error(e);
+         }
+     }
++
++    public boolean isMutable() {
++        return mutable;
++    }
++
++    public boolean isImmutable() {
++        return !mutable;
++    }
++
++    protected void assertMutable() {
++        if(isImmutable()) {
++            throw new UnsupportedOperationException("This " + getClass().getSimpleName() + " is immutable");
++        }
++    }
++
++    public MaterialData immutable() {
++        mutable = false;
++        return this;
++    }
++
++    public MaterialData immutableCopy() {
++        if(isImmutable()) return this;
++        try {
++            return ((MaterialData) super.clone()).immutable();
++        } catch(CloneNotSupportedException e) {
++            throw new Error(e);
++        }
++    }
+ }
+diff --git a/src/test/java/org/bukkit/materials/MaterialDataTest.java b/src/test/java/org/bukkit/materials/MaterialDataTest.java
+index 0e7b666..f2c2b80 100644
+--- a/src/test/java/org/bukkit/materials/MaterialDataTest.java
++++ b/src/test/java/org/bukkit/materials/MaterialDataTest.java
+@@ -10,10 +10,12 @@ import org.bukkit.TreeSpecies;
+ import org.bukkit.block.BlockFace;
+ import org.bukkit.material.Crops;
+ import org.bukkit.material.Comparator;
++import org.bukkit.material.Crops;
+ import org.bukkit.material.Diode;
+ import org.bukkit.material.Door;
+ import org.bukkit.material.Hopper;
+ import org.bukkit.material.Leaves;
++import org.bukkit.material.MaterialData;
+ import org.bukkit.material.Mushroom;
+ import org.bukkit.material.NetherWarts;
+ import org.bukkit.material.Sapling;
+@@ -23,6 +25,9 @@ import org.bukkit.material.WoodenStep;
+ import org.bukkit.material.types.MushroomBlockTexture;
+ import org.junit.Test;
+ 
++import static tc.oc.test.Assert.*;
++import static org.junit.Assert.*;
++
+ public class MaterialDataTest {
+ 
+     @Test
+@@ -430,4 +435,42 @@ public class MaterialDataTest {
+             }
+         }
+     }
++
++    @Test
++    public void testMutableByDefault() {
++        MaterialData md = new MaterialData(Material.AIR);
++        assertTrue(md.isMutable());
++        assertFalse(md.isImmutable());
++    }
++
++    @Test
++    public void testMakeImmutable() {
++        MaterialData original = new MaterialData(Material.AIR);
++        MaterialData immutable = original.immutable();
++        assertSame(original, immutable);
++        assertFalse(immutable.isMutable());
++        assertTrue(immutable.isImmutable());
++    }
++
++    @Test
++    public void testImmutableCopy() {
++        MaterialData original = new MaterialData(Material.AIR);
++        MaterialData immutable = original.immutableCopy();
++        assertNotSame(original, immutable);
++        assertMutuallyEqual(original, immutable);
++        assertFalse(immutable.isMutable());
++        assertTrue(immutable.isImmutable());
++    }
++
++    @Test
++    public void testImmutableCannotBeModified() throws Throwable {
++        MaterialData md = new MaterialData(Material.AIR).immutable();
++        assertThrows(UnsupportedOperationException.class, () -> md.setData((byte) 0));
++    }
++
++    @Test
++    public void testCloneOfImmutableIsMutable() {
++        MaterialData md = new MaterialData(Material.AIR).immutable();
++        assertTrue(md.clone().isMutable());
++    }
+ }
+-- 
+1.9.0
+

--- a/CraftBukkit/0003-Update-the-POM-to-distinguish-SportBukkit-from-Craft.patch
+++ b/CraftBukkit/0003-Update-the-POM-to-distinguish-SportBukkit-from-Craft.patch
@@ -1,11 +1,11 @@
-From 6513d5e0d19067649187deef5afb22608fc3708a Mon Sep 17 00:00:00 2001
+From 9edd1c47b572869f59a007c8085af03cea4261e2 Mon Sep 17 00:00:00 2001
 From: Steve Anton <anxuiz.nx@gmail.com>
 Date: Thu, 2 Aug 2012 17:00:13 -0700
 Subject: [PATCH] Update the POM to distinguish SportBukkit from CraftBukkit.
 
 
 diff --git a/pom.xml b/pom.xml
-index 41ac9d2..cd4bf46 100644
+index 41ac9d2..a50131f 100644
 --- a/pom.xml
 +++ b/pom.xml
 @@ -1,29 +1,39 @@
@@ -75,7 +75,20 @@ index 41ac9d2..cd4bf46 100644
          <!-- testing -->
          <dependency>
              <groupId>junit</groupId>
-@@ -152,8 +172,8 @@
+@@ -70,6 +90,12 @@
+             <version>1.3</version>
+             <scope>test</scope>
+         </dependency>
++        <dependency>
++            <groupId>tc.oc</groupId>
++            <artifactId>test-util</artifactId>
++            <version>1.0-SNAPSHOT</version>
++            <scope>test</scope>
++        </dependency>
+     </dependencies>
+ 
+     <!-- required until fixed plexus-compiler-eclipse is deployed -->
+@@ -152,8 +178,8 @@
                  <configuration>
                      <signature>
                          <groupId>org.codehaus.mojo.signature</groupId>
@@ -86,7 +99,7 @@ index 41ac9d2..cd4bf46 100644
                      </signature>
                  </configuration>
              </plugin>
-@@ -185,17 +205,6 @@
+@@ -185,17 +211,6 @@
                                      <pattern>org.gjt</pattern>
                                      <shadedPattern>org.bukkit.craftbukkit.libs.org.gjt</shadedPattern>
                                  </relocation>

--- a/CraftBukkit/0082-Fix-jar-being-shaded-multiple-times.patch
+++ b/CraftBukkit/0082-Fix-jar-being-shaded-multiple-times.patch
@@ -1,14 +1,14 @@
-From b631987273630e7abee7ac3d4389a941b6cf071c Mon Sep 17 00:00:00 2001
+From 455b78410f504a02038f42e9b69a174d6f6de719 Mon Sep 17 00:00:00 2001
 From: Jedediah Smith <jedediah@silencegreys.com>
 Date: Thu, 30 Apr 2015 22:42:34 -0400
 Subject: [PATCH] Fix jar being shaded multiple times
 
 
 diff --git a/pom.xml b/pom.xml
-index cd4bf46..b423144 100644
+index a50131f..7b6d84c 100644
 --- a/pom.xml
 +++ b/pom.xml
-@@ -124,6 +124,7 @@
+@@ -130,6 +130,7 @@
                  <artifactId>maven-jar-plugin</artifactId>
                  <version>3.0.2</version>
                  <configuration>

--- a/CraftBukkit/0122-Geometry-API.patch
+++ b/CraftBukkit/0122-Geometry-API.patch
@@ -1,4 +1,4 @@
-From 22f252d372d4c0578f226c0dea8c82f6adfe1206 Mon Sep 17 00:00:00 2001
+From e7a1c7a7561830bc98e3614579d5361cde6bd90c Mon Sep 17 00:00:00 2001
 From: Jedediah Smith <jedediah@silencegreys.com>
 Date: Fri, 18 Nov 2016 04:34:02 -0500
 Subject: [PATCH] Geometry API
@@ -742,31 +742,19 @@ index 0000000..30e5c74
 +}
 diff --git a/src/test/java/org/bukkit/util/VectorEqualityTest.java b/src/test/java/org/bukkit/util/VectorEqualityTest.java
 new file mode 100644
-index 0000000..aeb2260
+index 0000000..f404478
 --- /dev/null
 +++ b/src/test/java/org/bukkit/util/VectorEqualityTest.java
-@@ -0,0 +1,38 @@
+@@ -0,0 +1,26 @@
 +package org.bukkit.util;
 +
 +import net.minecraft.server.BlockPosition;
 +import org.junit.Test;
 +
 +import static org.junit.Assert.*;
++import static tc.oc.test.Assert.*;
 +
 +public class VectorEqualityTest {
-+
-+    void assertMutuallyEqual(Object a, Object b) {
-+        assertTrue(a + " should equal " + b, a.equals(b));
-+        assertTrue(b + " should equal " + a, b.equals(a));
-+
-+        assertEquals(a + " and " + b + " should have identical hashCodes",
-+                     a.hashCode(), b.hashCode());
-+    }
-+
-+    void assertMutuallyUnequal(Object a, Object b) {
-+        assertFalse(a + " should not equal " + b, a.equals(b));
-+        assertFalse(b + " should not equal " + a, b.equals(a));
-+    }
 +
 +    @Test
 +    public void coarseEquality() throws Exception {

--- a/CraftBukkit/0167-Add-missing-ItemMeta-clone-overrides.patch
+++ b/CraftBukkit/0167-Add-missing-ItemMeta-clone-overrides.patch
@@ -1,0 +1,60 @@
+From 8c69f41f9f516e3112ac0083a314c092e40e769e Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Wed, 4 Jan 2017 15:16:32 -0500
+Subject: [PATCH] Add missing ItemMeta clone overrides
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBanner.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBanner.java
+index 80f9ffa..00c7a99 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBanner.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBanner.java
+@@ -201,4 +201,11 @@ public class CraftMetaBanner extends CraftMetaItem implements BannerMeta {
+     boolean applicableTo(Material type) {
+         return type == Material.BANNER;
+     }
++
++    @Override
++    public CraftMetaBanner clone() {
++        final CraftMetaBanner that = (CraftMetaBanner) super.clone();
++        that.patterns = new ArrayList<>(this.patterns);
++        return that;
++    }
+ }
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBlockState.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBlockState.java
+index a90ac5d..9a4c7c9 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBlockState.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBlockState.java
+@@ -497,4 +497,13 @@ public class CraftMetaBlockState extends CraftMetaItem implements BlockStateMeta
+         blockEntityTag = new NBTTagCompound();
+         te.save(blockEntityTag);
+     }
++
++    @Override
++    public CraftMetaBlockState clone() {
++        final CraftMetaBlockState that = (CraftMetaBlockState) super.clone();
++        if(this.blockEntityTag != null) {
++            that.blockEntityTag = (NBTTagCompound) this.blockEntityTag.clone();
++        }
++        return that;
++    }
+ }
+diff --git a/src/test/java/org/bukkit/craftbukkit/inventory/ItemMetaImplementationOverrideTest.java b/src/test/java/org/bukkit/craftbukkit/inventory/ItemMetaImplementationOverrideTest.java
+index f1b4ec0..d3c4ee0 100644
+--- a/src/test/java/org/bukkit/craftbukkit/inventory/ItemMetaImplementationOverrideTest.java
++++ b/src/test/java/org/bukkit/craftbukkit/inventory/ItemMetaImplementationOverrideTest.java
+@@ -47,7 +47,11 @@ public class ItemMetaImplementationOverrideTest {
+                     new Object[] {
+                         new Callable<Method>() {
+                             public Method call() throws Exception {
+-                                return clazz.getDeclaredMethod(method.getName(), method.getParameterTypes());
++                                final Method override = clazz.getDeclaredMethod(method.getName(), method.getParameterTypes());
++                                if(override.isSynthetic() || override.isBridge()) {
++                                    throw new NoSuchMethodException("Override " + override + " is not a real method");
++                                }
++                                return override;
+                             }
+                         },
+                         clazz.getSimpleName() + " contains " + method.getName()
+-- 
+1.9.0
+

--- a/CraftBukkit/0168-Immutable-materials-and-items.patch
+++ b/CraftBukkit/0168-Immutable-materials-and-items.patch
@@ -1,0 +1,273 @@
+From c98c9520ffa996e2bc5f44f6091522df0ce3e399 Mon Sep 17 00:00:00 2001
+From: Jedediah Smith <jedediah@silencegreys.com>
+Date: Wed, 4 Jan 2017 13:57:10 -0500
+Subject: [PATCH] Immutable materials and items
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
+index 5246e22..da46b76 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
+@@ -40,7 +40,12 @@ public final class CraftItemStack extends ItemStack {
+             return net.minecraft.server.ItemStack.a;
+         }
+ 
+-        net.minecraft.server.ItemStack stack = new net.minecraft.server.ItemStack(item, original.getAmount(), original.getDurability());
++        net.minecraft.server.ItemStack stack = new net.minecraft.server.ItemStack(item, original.getAmount());
++        if(stack.usesData()) {
++            stack.setData(original.getData().getData());
++        } else if(stack.getItem().usesDurability()) {
++            stack.setData(original.getDurability());
++        }
+         if (original.hasItemMeta()) {
+             setItemMeta(stack, original.getItemMeta());
+         }
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
+index ac039ab..0154dfb 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
+@@ -79,7 +79,7 @@ import org.apache.commons.codec.binary.Base64;
+  * <li> SerializableMeta.Deserializers deserializer()
+  */
+ @DelegateDeserialization(CraftMetaItem.SerializableMeta.class)
+-class CraftMetaItem implements ItemMeta, Repairable {
++public class CraftMetaItem implements ItemMeta, Repairable {
+ 
+     static class ItemMetaKey {
+ 
+@@ -807,6 +807,20 @@ class CraftMetaItem implements ItemMeta, Repairable {
+         canPlaceOn = ImmutableMaterialSet.of(materials);
+     }
+ 
++    /**
++     * This map contains any NBT tags NOT handled by the Bukkit API.
++     * These tags will be loaded and saved verbatim to items.
++     * The returned map can be modified by brave/evil code, in order
++     * to implement custom item state.
++     *
++     * It is not recommended to use this map to interact with standard
++     * tags before Bukkit supports them, because once that support is
++     * added, the tags will disappear from this map.
++     */
++    public Map<String, NBTBase> getUnhandledTags() {
++        return unhandledTags;
++    }
++
+     @Override
+     public final boolean equals(Object object) {
+         if (object == null) {
+diff --git a/src/test/java/org/bukkit/craftbukkit/inventory/ImItemStackTest.java b/src/test/java/org/bukkit/craftbukkit/inventory/ImItemStackTest.java
+new file mode 100644
+index 0000000..0dd64b3
+--- /dev/null
++++ b/src/test/java/org/bukkit/craftbukkit/inventory/ImItemStackTest.java
+@@ -0,0 +1,98 @@
++package org.bukkit.craftbukkit.inventory;
++
++import org.bukkit.DyeColor;
++import org.bukkit.Material;
++import org.bukkit.inventory.ImItemStack;
++import org.bukkit.inventory.ItemStack;
++import org.bukkit.material.Wool;
++import org.junit.Test;
++
++import static org.junit.Assert.*;
++import static tc.oc.test.Assert.*;
++
++public class ImItemStackTest {
++
++    @Test
++    public void testCreationWithDamage() {
++        ImItemStack stack = ImItemStack.of(Material.STONE_SWORD, 123, 45);
++        assertTrue(stack.isImmutable());
++        assertEquals(Material.STONE_SWORD, stack.getType());
++        assertEquals(123, stack.getDurability());
++        assertEquals(45, stack.getAmount());
++    }
++
++    @Test
++    public void testCreationWithData() {
++        Wool wool = new Wool(DyeColor.PINK);
++        ImItemStack stack = ImItemStack.of(wool, 45);
++        assertTrue(stack.isImmutable());
++        assertEquals(wool, stack.getData());
++        assertEquals(wool.getItemType(), stack.getType());
++        assertEquals(45, stack.getAmount());
++    }
++
++    @Test
++    public void testCreationWithBuilder() {
++        Wool wool = new Wool(DyeColor.PINK);
++        ImItemStack stack = wool.buildItemStack().amount(45).immutable();
++        assertTrue(stack.isImmutable());
++        assertEquals(wool.getItemType(), stack.getType());
++        assertEquals(wool, stack.getData());
++        assertEquals(45, stack.getAmount());
++    }
++
++    @Test
++    public void testImmutableCopy() throws Throwable {
++        ItemStack mutable = new ItemStack(Material.STONE_SWORD, 45, (short) 123);
++        ItemStack immutable = mutable.immutableCopy();
++        assertTrue(mutable.isMutable());
++        assertTrue(immutable.isImmutable());
++        assertNotSame(mutable, immutable);
++        assertEquals(mutable, immutable);
++    }
++
++    @Test
++    public void testCloneOfImmutableIsMutable() throws Throwable {
++        ItemStack immutable = ImItemStack.of(Material.STONE_SWORD, 45, (short) 123);
++        ItemStack mutable = immutable.clone();
++        assertTrue(mutable.isMutable());
++        assertTrue(immutable.isImmutable());
++        assertNotSame(mutable, immutable);
++        assertEquals(mutable, immutable);
++    }
++
++    @Test
++    public void testImmutability() throws Throwable {
++        ImItemStack stack = ImItemStack.of(Material.DIRT);
++        assertFalse(stack.isMutable());
++        assertTrue(stack.isImmutable());
++
++        assertThrows(UnsupportedOperationException.class, () -> stack.setType(Material.STONE));
++        assertThrows(UnsupportedOperationException.class, () -> stack.setTypeId(Material.STONE.getId()));
++        assertThrows(UnsupportedOperationException.class, () -> stack.setDurability((short) 123));
++        assertThrows(UnsupportedOperationException.class, () -> stack.setAmount(45));
++        assertThrows(UnsupportedOperationException.class, () -> stack.setData(new Wool(DyeColor.PINK)));
++        assertThrows(UnsupportedOperationException.class, () -> stack.setMaterial(new Wool(DyeColor.PINK)));
++        assertThrows(UnsupportedOperationException.class, () -> stack.setItemMeta(stack.getItemMeta()));
++    }
++
++    @Test
++    public void testDamageItemTypeCheck() throws Throwable {
++        assertThrows(IllegalArgumentException.class, () -> ImItemStack.of(Material.DIRT, 123));
++        assertThrows(IllegalArgumentException.class, () -> ItemStack.builder(Material.DIRT, 123));
++    }
++
++    @Test
++    public void testDamageRangeCheck() throws Throwable {
++        ImItemStack.of(Material.STONE_SWORD, Short.MIN_VALUE);
++        ImItemStack.of(Material.STONE_SWORD, Short.MAX_VALUE);
++        assertThrows(IllegalArgumentException.class, () -> ImItemStack.of(Material.STONE_SWORD, Short.MIN_VALUE - 1));
++        assertThrows(IllegalArgumentException.class, () -> ImItemStack.of(Material.STONE_SWORD, Short.MAX_VALUE + 1));
++    }
++
++    @Test
++    public void testAmountRangeCheck() throws Throwable {
++        ImItemStack.of(Material.DIRT, 0, Byte.MAX_VALUE);
++        assertThrows(IllegalArgumentException.class, () -> ImItemStack.of(Material.DIRT, 0, Byte.MAX_VALUE + 1));
++    }
++}
+diff --git a/src/test/java/org/bukkit/craftbukkit/inventory/ItemStackTest.java b/src/test/java/org/bukkit/craftbukkit/inventory/ItemStackTest.java
+index 6140ede..8935fcc 100644
+--- a/src/test/java/org/bukkit/craftbukkit/inventory/ItemStackTest.java
++++ b/src/test/java/org/bukkit/craftbukkit/inventory/ItemStackTest.java
+@@ -3,6 +3,7 @@ package org.bukkit.craftbukkit.inventory;
+ import static org.bukkit.support.Matchers.sameHash;
+ import static org.junit.Assert.*;
+ import static org.hamcrest.Matchers.*;
++import static tc.oc.test.Assert.*;
+ 
+ import java.io.ByteArrayInputStream;
+ import java.io.ByteArrayOutputStream;
+@@ -15,12 +16,16 @@ import java.util.HashMap;
+ import java.util.List;
+ import java.util.Map;
+ 
++import org.bukkit.DyeColor;
+ import org.bukkit.Material;
+ import org.bukkit.configuration.InvalidConfigurationException;
+ import org.bukkit.configuration.file.YamlConfiguration;
+ import org.bukkit.inventory.ItemFactory;
+ import org.bukkit.inventory.ItemStack;
++import org.bukkit.inventory.meta.BannerMeta;
+ import org.bukkit.inventory.meta.ItemMeta;
++import org.bukkit.material.MaterialData;
++import org.bukkit.material.Wool;
+ import org.bukkit.support.AbstractTestingBase;
+ import org.bukkit.util.io.BukkitObjectInputStream;
+ import org.bukkit.util.io.BukkitObjectOutputStream;
+@@ -490,4 +495,47 @@ public class ItemStackTest extends AbstractTestingBase {
+         assertThat(information, primaryRead, is(not(unequalOriginal)));
+         assertThat(information, primaryRead, is(not(unequalRead)));
+     }
++
++    @Test
++    public void testMutability() throws Throwable {
++        ItemStack stack = new ItemStack(Material.DIRT);
++        assertTrue(stack.isMutable());
++        assertFalse(stack.isImmutable());
++    }
++
++    @Test
++    public void testMaterialDataAndDurabilityAreIndependent() throws Throwable {
++        Wool wool = new Wool(DyeColor.PINK);
++        ItemStack stack = new ItemStack(wool.getItemType(), 1, (short) 123, wool.getData());
++        assertEquals("Material data and durability should be independent",
++                     wool, stack.getData());
++        assertEquals("Material data and durability should be independent",
++                     123, stack.getDurability());
++
++        stack.setDurability((short) 456);
++        assertEquals("Setting durability should not change material data",
++                     wool, stack.getData());
++
++        stack.setMaterial(wool);
++        assertEquals("Setting material data should not change durability",
++                     456, stack.getDurability());
++    }
++
++    @Test
++    public void testCreationWithBuilder() throws Throwable {
++        MaterialData wool = new Wool(DyeColor.PINK);
++        ItemStack stack = wool.buildItemStack().amount(45).mutable();
++        assertEquals(wool, stack.getData());
++        assertEquals(45, stack.getAmount());
++        assertTrue(stack.isMutable());
++    }
++
++    @Test
++    public void testItemMetaBuilder() throws Throwable {
++        ItemStack banner = ItemStack.builder(Material.BANNER).meta(BannerMeta.class, meta -> {
++            meta.setBaseColor(DyeColor.PINK);
++        }).mutable();
++
++        assertEquals(DyeColor.PINK, ((BannerMeta) banner.getItemMeta()).getBaseColor());
++    }
+ }
+diff --git a/src/test/java/org/bukkit/craftbukkit/inventory/NMSCraftItemStackTest.java b/src/test/java/org/bukkit/craftbukkit/inventory/NMSCraftItemStackTest.java
+index 1f5a6a3..c6e2da0 100644
+--- a/src/test/java/org/bukkit/craftbukkit/inventory/NMSCraftItemStackTest.java
++++ b/src/test/java/org/bukkit/craftbukkit/inventory/NMSCraftItemStackTest.java
+@@ -4,7 +4,8 @@ import static org.junit.Assert.*;
+ import static org.hamcrest.Matchers.*;
+ 
+ import net.minecraft.server.Enchantments;
+-
++import org.bukkit.Material;
++import org.bukkit.inventory.ImItemStack;
+ import org.bukkit.inventory.ItemStack;
+ import org.bukkit.support.AbstractTestingBase;
+ import org.junit.Test;
+@@ -33,4 +34,16 @@ public class NMSCraftItemStackTest extends AbstractTestingBase {
+         ItemStack clone = itemStack.clone();
+         assertThat(clone, is(itemStack));
+     }
++
++    @Test
++    public void testDamagePreservedOnDamageableItem() throws Throwable {
++        net.minecraft.server.ItemStack stack = CraftItemStack.asNMSCopy(ImItemStack.of(Material.STONE_SWORD, 123));
++        assertEquals(123, stack.getData());
++    }
++
++    @Test
++    public void testDamageIgnoredOnNonDamageableItem() throws Throwable {
++        net.minecraft.server.ItemStack stack = CraftItemStack.asNMSCopy(new ItemStack(Material.DIRT, 1, (short) 123));
++        assertEquals(0, stack.getData());
++    }
+ }
+-- 
+1.9.0
+


### PR DESCRIPTION
* Support immutability in `MaterialData` with an internal flag.
* Add `ImItemStack`, immutable subclass of `ItemStack`.
* Add `ItemStack.Builder`, a nice way to construct `ItemStack`s and `ImItemStack`s.
* Make `ItemStack` durability effectively independent from material data values i.e. don't let them affect each other. When converting to `CraftItemStack`, use the item type to decide which one to use.
* Add raw NBT access to `CraftMetaItem`, so hacky code has a way to put custom NBT on `ImItemStack`s.
* Move test support code into `test-util` module https://github.com/OvercastNetwork/test-util