### PR TITLE
Async OfflinePlayer lookup

### DIFF
--- a/Bukkit/SportBukkit.patch
+++ b/Bukkit/SportBukkit.patch
@@ -15,35 +15,17 @@ diff --git a/README.md b/README.md
 diff --git a/src/main/java/org/bukkit/OfflinePlayer.java b/src/main/java/org/bukkit/OfflinePlayer.java
 --- a/src/main/java/org/bukkit/OfflinePlayer.java
 +++ b/src/main/java/org/bukkit/OfflinePlayer.java
-@@ -1,6 +1,7 @@
- package org.bukkit;
- 
- import java.util.Date;
-+import java.util.Optional;
- import java.util.UUID;
- 
- import org.bukkit.configuration.serialization.ConfigurationSerializable;
-@@ -10,7 +11,7 @@ import org.bukkit.event.player.PlayerLoginEvent;
+@@ -9,8 +9,9 @@ import org.bukkit.entity.Player;
+ import org.bukkit.event.player.PlayerLoginEvent;
  import org.bukkit.event.player.PlayerQuitEvent;
  import org.bukkit.permissions.ServerOperator;
++import tc.oc.minecraft.api.user.User;
  
 -public interface OfflinePlayer extends ServerOperator, AnimalTamer, ConfigurationSerializable {
-+public interface OfflinePlayer extends ServerOperator, AnimalTamer, ConfigurationSerializable, tc.oc.minecraft.api.entity.OfflinePlayer {
++public interface OfflinePlayer extends ServerOperator, AnimalTamer, ConfigurationSerializable, User {
  
      /**
       * Checks if this player is currently online
-@@ -37,6 +38,11 @@ public interface OfflinePlayer extends ServerOperator, AnimalTamer, Configuratio
-      */
-     public String getName();
- 
-+    @Override
-+    default Optional<String> getLastKnownName() {
-+        return Optional.ofNullable(getName());
-+    }
-+
-     /**
-      * Returns the UUID of this player
-      *
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
@@ -59,29 +41,36 @@ diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Ser
      /**
       * Broadcasts the specified message to every user with the given
       * permission name.
+diff --git a/src/main/java/org/bukkit/ServerModule.java b/src/main/java/org/bukkit/ServerModule.java
+--- a/src/main/java/org/bukkit/ServerModule.java
++++ b/src/main/java/org/bukkit/ServerModule.java
+@@ -18,6 +18,7 @@ import org.bukkit.scoreboard.ScoreboardManager;
+ import tc.oc.inject.SingletonModule;
+ import tc.oc.minecraft.api.plugin.PluginFinder;
+ import tc.oc.minecraft.api.server.LocalServer;
++import tc.oc.minecraft.api.server.MinecraftServerModule;
+ 
+ /**
+  * Bindings for things that belong to a {@link Server}.
+@@ -31,6 +32,7 @@ public class ServerModule extends SingletonModule {
+     @Override
+     protected void configure() {
+         install(new BukkitModule());
++        install(new MinecraftServerModule());
+ 
+         bind(tc.oc.minecraft.api.server.Server.class).to(LocalServer.class);
+         bind(LocalServer.class).to(Server.class);
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2,6 +2,7 @@ package org.bukkit.entity;
+@@ -1,7 +1,6 @@
+ package org.bukkit.entity;
  
  import java.net.InetSocketAddress;
- import java.util.List;
-+import java.util.Optional;
+-import java.util.List;
  import java.util.Set;
  
  import net.md_5.bungee.api.chat.BaseComponent;
-@@ -34,6 +35,11 @@ import org.bukkit.util.Vector;
-  */
- public interface Player extends HumanEntity, Conversable, CommandSender, OfflinePlayer, PluginMessageRecipient, tc.oc.minecraft.api.entity.Player {
- 
-+    @Override
-+    default Optional<String> getLastKnownName() {
-+        return Optional.of(getName());
-+    }
-+
-     /**
-      * Set a fake name for this player when viewed by the given player.
-      * If the name is null then the fake name is cleared.
 diff --git a/src/main/java/org/bukkit/plugin/PluginDescriptionFile.java b/src/main/java/org/bukkit/plugin/PluginDescriptionFile.java
 --- a/src/main/java/org/bukkit/plugin/PluginDescriptionFile.java
 +++ b/src/main/java/org/bukkit/plugin/PluginDescriptionFile.java

--- a/CraftBukkit/Fix-jar-being-shaded-multiple-times.patch
+++ b/CraftBukkit/Fix-jar-being-shaded-multiple-times.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Fix jar being shaded multiple times
 diff --git a/pom.xml b/pom.xml
 --- a/pom.xml
 +++ b/pom.xml
-@@ -141,6 +141,7 @@
+@@ -135,6 +135,7 @@
                  <artifactId>maven-jar-plugin</artifactId>
                  <version>3.0.2</version>
                  <configuration>

--- a/CraftBukkit/SportBukkit.patch
+++ b/CraftBukkit/SportBukkit.patch
@@ -39,7 +39,15 @@ diff --git a/src/main/java/net/minecraft/server/DedicatedServer.java b/src/main/
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -1187,6 +1187,7 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
+@@ -295,6 +295,7 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
+ 
+                 world.a(worldsettings);
+                 this.server.scoreboardManager = new org.bukkit.craftbukkit.scoreboard.CraftScoreboardManager(this, world.getScoreboard());
++                this.server.overworld = world;
+             } else {
+                 String dim = "DIM" + dimension;
+ 
+@@ -1187,6 +1188,7 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
          return this.I;
      }
  
@@ -47,7 +55,7 @@ diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/
      public int P() {
          return this.u;
      }
-@@ -1417,6 +1418,7 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
+@@ -1417,6 +1419,7 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
  
      }
  
@@ -106,6 +114,130 @@ diff --git a/src/main/java/net/minecraft/server/WorldNBTStorage.java b/src/main/
      public NBTTagCompound getPlayerData(String s) {
          try {
              File file1 = new File(this.playerDir, s + ".dat");
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayer.java b/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayer.java
+--- a/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayer.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayer.java
+@@ -2,12 +2,13 @@ package org.bukkit.craftbukkit;
+ 
+ import com.mojang.authlib.GameProfile;
+ import java.io.File;
++import java.time.Instant;
+ import java.util.LinkedHashMap;
+ import java.util.List;
+ import java.util.Map;
++import java.util.Optional;
+ import java.util.UUID;
+ 
+-import net.minecraft.server.EntityPlayer;
+ import net.minecraft.server.NBTTagCompound;
+ import net.minecraft.server.WorldNBTStorage;
+ 
+@@ -21,18 +22,34 @@ import org.bukkit.configuration.serialization.SerializableAs;
+ import org.bukkit.entity.Player;
+ import org.bukkit.metadata.MetadataValue;
+ import org.bukkit.plugin.Plugin;
++import tc.oc.collection.Optionals;
++
++import static com.google.common.base.Preconditions.checkArgument;
++import static com.google.common.base.Preconditions.checkNotNull;
+ 
+ @SerializableAs("Player")
+ public class CraftOfflinePlayer implements OfflinePlayer, ConfigurationSerializable {
+     private final GameProfile profile;
+     private final CraftServer server;
+     private final WorldNBTStorage storage;
++    private final Optional<Instant> updatedAt;
+ 
+     protected CraftOfflinePlayer(CraftServer server, GameProfile profile) {
++        this(server, profile, Optional.empty());
++    }
++
++    protected CraftOfflinePlayer(CraftServer server, GameProfile profile, Optional<Instant> updatedAt) {
++        checkNotNull(profile.getId(), "OfflinePlayer must have a UUID");
++        checkArgument(!(updatedAt.isPresent() && profile.getName() == null), "OfflinePlayer has an update timestamp, but no username");
+         this.server = server;
+         this.profile = profile;
+-        this.storage = (WorldNBTStorage) (server.console.worlds.get(0).getDataManager());
++        this.updatedAt = updatedAt;
++        this.storage = (WorldNBTStorage) (server.overworld.getDataManager());
++    }
+ 
++    @Override
++    public Optional<Instant> updatedAt() {
++        return Optionals.first(lastPlayedAt(), updatedAt);
+     }
+ 
+     public GameProfile getProfile() {
+@@ -213,6 +230,12 @@ public class CraftOfflinePlayer implements OfflinePlayer, ConfigurationSerializa
+         }
+     }
+ 
++    @Override
++    public Optional<Instant> lastPlayedAt() {
++        final long milli = getLastPlayed();
++        return milli == 0 ? Optional.empty() : Optional.of(Instant.ofEpochMilli(milli));
++    }
++
+     public long getLastPlayed() {
+         Player player = getPlayer();
+         if (player != null) return player.getLastPlayed();
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayerFactory.java b/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayerFactory.java
+new file mode 100644
+index 0000000..e9c460e
+--- /dev/null
++++ b/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayerFactory.java
+@@ -0,0 +1,51 @@
++package org.bukkit.craftbukkit;
++
++import java.time.Instant;
++import java.util.Optional;
++import java.util.UUID;
++import javax.inject.Inject;
++import javax.inject.Provider;
++import javax.inject.Singleton;
++
++import com.mojang.authlib.GameProfile;
++import tc.oc.minecraft.api.user.User;
++import tc.oc.minecraft.api.user.UserFactory;
++import tc.oc.minecraft.api.user.UserUtils;
++
++import static com.google.common.base.Preconditions.checkNotNull;
++
++@Singleton
++public class CraftOfflinePlayerFactory implements UserFactory {
++
++    private final Provider<CraftServer> server;
++
++    @Inject CraftOfflinePlayerFactory(Provider<CraftServer> server) {
++        this.server = server;
++    }
++
++    public CraftOfflinePlayer createUser(GameProfile profile, Optional<Instant> updatedAt) {
++        return new CraftOfflinePlayer(server.get(), profile, updatedAt);
++    }
++
++    @Override
++    public CraftOfflinePlayer createUser(UUID id) {
++        return createUser(new GameProfile(checkNotNull(id), null), Optional.empty());
++    }
++
++    @Override
++    public CraftOfflinePlayer createUser(String name) {
++        return createUser(new GameProfile(UserUtils.offlinePlayerId(name), name), Optional.empty());
++    }
++
++    @Override
++    public CraftOfflinePlayer createUser(UUID id, String name, Instant updatedAt) {
++        return createUser(new GameProfile(checkNotNull(id), checkNotNull(name)), Optional.of(updatedAt));
++    }
++
++    @Override
++    public CraftOfflinePlayer copyUser(User user) {
++        return user instanceof CraftOfflinePlayer
++               ? (CraftOfflinePlayer) user
++               : (CraftOfflinePlayer) UserFactory.super.copyUser(user);
++    }
++}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
@@ -119,15 +251,71 @@ diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/ja
  import java.time.Duration;
  import java.time.Instant;
  import java.util.ArrayList;
-@@ -17,6 +20,7 @@ import java.util.LinkedHashMap;
- import java.util.LinkedHashSet;
- import java.util.List;
- import java.util.Map;
-+import java.util.Optional;
- import java.util.Set;
+@@ -21,9 +24,10 @@ import java.util.Set;
  import java.util.UUID;
  import java.util.logging.Level;
-@@ -194,6 +198,7 @@ public final class CraftServer extends CraftBukkitRuntime implements Server {
+ import java.util.logging.Logger;
+-import java.util.regex.Pattern;
+ import javax.annotation.Nullable;
+ import javax.imageio.ImageIO;
++import javax.inject.Inject;
++import javax.inject.Provider;
+ 
+ import com.google.common.collect.Maps;
+ import com.google.inject.Guice;
+@@ -133,7 +137,6 @@ import com.avaje.ebeaninternal.server.lib.sql.TransactionIsolation;
+ import com.google.common.base.Charsets;
+ import com.google.common.collect.ImmutableList;
+ import com.google.common.collect.Lists;
+-import com.google.common.collect.MapMaker;
+ import com.mojang.authlib.GameProfile;
+ 
+ import io.netty.buffer.ByteBuf;
+@@ -143,8 +146,10 @@ import io.netty.handler.codec.base64.Base64;
+ import jline.console.ConsoleReader;
+ import org.bukkit.event.server.TabCompleteEvent;
+ import net.md_5.bungee.api.chat.BaseComponent;
++import tc.oc.inject.Providers;
+ import tc.oc.minecraft.api.configuration.InvalidConfigurationException;
+ import tc.oc.minecraft.api.plugin.PluginFinder;
++import tc.oc.minecraft.api.user.UserFinder;
+ 
+ public final class CraftServer extends CraftBukkitRuntime implements Server {
+     private static final Player[] EMPTY_PLAYER_ARRAY = new Player[0];
+@@ -153,7 +158,8 @@ public final class CraftServer extends CraftBukkitRuntime implements Server {
+     private final String bukkitVersion = Versioning.getBukkitVersion();
+     private final Logger logger = Logger.getLogger("Minecraft");
+     private final ServicesManager servicesManager = new SimpleServicesManager();
+-    private final CraftScheduler scheduler = new CraftScheduler();
++    private @Inject Provider<CraftScheduler> scheduler = Providers.unavailable(CraftScheduler.class);
++    private @Inject Provider<UserFinder> userFinder = Providers.unavailable(UserFinder.class);
+     private final SimpleCommandMap commandMap = new SimpleCommandMap(this);
+     private final SimpleHelpMap helpMap = new SimpleHelpMap(this);
+     private final StandardMessenger messenger = new StandardMessenger();
+@@ -161,6 +167,7 @@ public final class CraftServer extends CraftBukkitRuntime implements Server {
+     private final EventBus eventBus;
+     protected final MinecraftServer console;
+     protected final DedicatedPlayerList playerList;
++    public WorldServer overworld;
+     private final Map<String, World> worlds = new LinkedHashMap<String, World>();
+     private final Map<String, World> worldsView = new CaseInsensitiveNameMap<>(worlds.values(), World::getName);
+     private final Map<UUID, World> worldsById = new LinkedHashMap<>();
+@@ -168,7 +175,6 @@ public final class CraftServer extends CraftBukkitRuntime implements Server {
+     private YamlConfiguration configuration;
+     private YamlConfiguration commandsConfiguration;
+     private final Yaml yaml = new Yaml(new SafeConstructor());
+-    private final Map<UUID, OfflinePlayer> offlinePlayers = new MapMaker().softValues().makeMap();
+     private final EntityMetadataStore entityMetadata = new EntityMetadataStore();
+     private final PlayerMetadataStore playerMetadata = new PlayerMetadataStore();
+     private final WorldMetadataStore worldMetadata = new WorldMetadataStore();
+@@ -187,13 +193,13 @@ public final class CraftServer extends CraftBukkitRuntime implements Server {
+     private boolean printSaveWarning;
+     private CraftIconCache icon;
+     private boolean overrideAllCommandBlockCommands = false;
+-    private final Pattern validUserPattern = Pattern.compile("^[a-zA-Z0-9_]{2,16}$");
+     private final UUID invalidUserUUID = UUID.nameUUIDFromBytes("InvalidUsername".getBytes(Charsets.UTF_8));
+     private final List<CraftPlayer> playerView;
+     private final Map<UUID, Player> playersById;
      public int reloadCount;
      public boolean bungee = false;
      public static final com.google.gson.Gson gson = new com.google.gson.Gson();
@@ -135,7 +323,7 @@ diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/ja
  
      private @Nullable Instant emptySince;
  
-@@ -208,6 +213,7 @@ public final class CraftServer extends CraftBukkitRuntime implements Server {
+@@ -208,6 +214,7 @@ public final class CraftServer extends CraftBukkitRuntime implements Server {
  
      public CraftServer(MinecraftServer console, PlayerList playerList) {
          this.console = console;
@@ -143,7 +331,20 @@ diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/ja
          this.eventBus = new SimpleEventBus(this.console.primaryThread, pluginManager);
          this.playerList = (DedicatedPlayerList) playerList;
          this.playerView = Collections.unmodifiableList(Lists.transform(playerList.players, EntityPlayer::getBukkitEntity));
-@@ -551,7 +557,7 @@ public final class CraftServer extends CraftBukkitRuntime implements Server {
+@@ -329,7 +336,11 @@ public final class CraftServer extends CraftBukkitRuntime implements Server {
+             logger.info("Creating injector in stage " + stage);
+ 
+             try {
+-                injector = Guice.createInjector(stage, new ServerInstanceModule(this, Arrays.asList(plugins)));
++                injector = Guice.createInjector(
++                    stage,
++                    new CraftServerModule(),
++                    new ServerInstanceModule(this, Arrays.asList(plugins))
++                );
+             } catch(RuntimeException ex) {
+                 logger.log(Level.SEVERE, "Injector creation failed, server will shut down", ex);
+                 throw ex;
+@@ -551,7 +562,7 @@ public final class CraftServer extends CraftBukkitRuntime implements Server {
      // so if that changes this will need to as well
      @Override
      public int getPort() {
@@ -152,7 +353,7 @@ diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/ja
      }
  
      @Override
-@@ -561,7 +567,12 @@ public final class CraftServer extends CraftBukkitRuntime implements Server {
+@@ -561,7 +572,12 @@ public final class CraftServer extends CraftBukkitRuntime implements Server {
  
      @Override
      public String getIp() {
@@ -166,7 +367,7 @@ diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/ja
      }
  
      @Override
-@@ -637,6 +648,11 @@ public final class CraftServer extends CraftBukkitRuntime implements Server {
+@@ -637,6 +653,11 @@ public final class CraftServer extends CraftBukkitRuntime implements Server {
      // End Temporary calls
  
      @Override
@@ -178,7 +379,16 @@ diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/ja
      public String getUpdateFolder() {
          return this.configuration.getString("settings.update-folder", "update");
      }
-@@ -1422,6 +1438,11 @@ public final class CraftServer extends CraftBukkitRuntime implements Server {
+@@ -698,7 +719,7 @@ public final class CraftServer extends CraftBukkitRuntime implements Server {
+ 
+     @Override
+     public CraftScheduler getScheduler() {
+-        return scheduler;
++        return scheduler.get();
+     }
+ 
+     @Override
+@@ -1422,6 +1443,11 @@ public final class CraftServer extends CraftBukkitRuntime implements Server {
      }
  
      @Override
@@ -190,7 +400,64 @@ diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/ja
      public int broadcast(String message, String permission) {
          int count = 0;
          Set<Permissible> permissibles = getPluginManager().getPermissionSubscriptions(permission);
-@@ -1614,21 +1635,29 @@ public final class CraftServer extends CraftBukkitRuntime implements Server {
+@@ -1440,53 +1466,16 @@ public final class CraftServer extends CraftBukkitRuntime implements Server {
+     @Override
+     @Deprecated
+     public OfflinePlayer getOfflinePlayer(String name) {
+-        Validate.notNull(name, "Name cannot be null");
+-
+-        // If the name given cannot ever be a valid username give a dummy return, for scoreboard plugins
+-        if (!validUserPattern.matcher(name).matches()) {
+-            return new CraftOfflinePlayer(this, new GameProfile(invalidUserUUID, name));
+-        }
+-
+-        OfflinePlayer result = getPlayerExact(name);
+-        if (result == null) {
+-            // This is potentially blocking :(
+-            GameProfile profile = console.getUserCache().getProfile(name);
+-            if (profile == null) {
+-                // Make an OfflinePlayer using an offline mode UUID since the name has no profile
+-                result = getOfflinePlayer(new GameProfile(UUID.nameUUIDFromBytes(("OfflinePlayer:" + name.toLowerCase()).getBytes(Charsets.UTF_8)), name));
+-            } else {
+-                // Use the GameProfile even when we get a UUID so we ensure we still have a name
+-                result = getOfflinePlayer(profile);
+-            }
+-        } else {
+-            offlinePlayers.remove(result.getUniqueId());
+-        }
+-
+-        return result;
++        return (OfflinePlayer) userFinder.get().findUser(name);
+     }
+ 
+     @Override
+     public OfflinePlayer getOfflinePlayer(UUID id) {
+-        Validate.notNull(id, "UUID cannot be null");
+-
+-        OfflinePlayer result = getPlayer(id);
+-        if (result == null) {
+-            result = offlinePlayers.get(id);
+-            if (result == null) {
+-                result = new CraftOfflinePlayer(this, new GameProfile(id, null));
+-                offlinePlayers.put(id, result);
+-            }
+-        } else {
+-            offlinePlayers.remove(id);
+-        }
+-
+-        return result;
++        return (OfflinePlayer) userFinder.get().findUser(id);
+     }
+ 
+     public OfflinePlayer getOfflinePlayer(GameProfile profile) {
+-        OfflinePlayer player = new CraftOfflinePlayer(this, profile);
+-        offlinePlayers.put(profile.getId(), player);
+-        return player;
++        return new CraftOfflinePlayer(this, profile);
+     }
+ 
+     @Override
+@@ -1614,21 +1603,22 @@ public final class CraftServer extends CraftBukkitRuntime implements Server {
      }
  
      @Override
@@ -215,15 +482,256 @@ diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/ja
 +    }
  
 +    @Override
-+    public Optional<OfflinePlayer> tryOfflinePlayer(UUID id) {
-+        final WorldNBTStorage storage = (WorldNBTStorage) console.worlds.get(0).getDataManager();
-+        return storage.hasPlayerData(id) ? Optional.of(getOfflinePlayer(id))
-+                                         : Optional.empty();
-+    }
-+
-+    @Override
 +    public OfflinePlayer[] getOfflinePlayers() {
 +        final Set<OfflinePlayer> players = getSavedPlayers();
          return players.toArray(new OfflinePlayer[players.size()]);
      }
  
+@@ -1892,6 +1882,11 @@ public final class CraftServer extends CraftBukkitRuntime implements Server {
+     }
+ 
+     @Override
++    public boolean isMainThread() {
++        return getHandle().getServer().isMainThread();
++    }
++
++    @Override
+     public void postToMainThread(Plugin plugin, boolean priority, Runnable task) {
+         getHandle().getServer().addMainThreadTask(priority, wrapTask(plugin, task));
+     }
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServerModule.java b/src/main/java/org/bukkit/craftbukkit/CraftServerModule.java
+new file mode 100644
+index 0000000..5a9bb0a
+--- /dev/null
++++ b/src/main/java/org/bukkit/craftbukkit/CraftServerModule.java
+@@ -0,0 +1,56 @@
++package org.bukkit.craftbukkit;
++
++import javax.inject.Singleton;
++
++import com.google.inject.AbstractModule;
++import com.google.inject.Provides;
++import com.google.inject.multibindings.OptionalBinder;
++import com.mojang.authlib.GameProfileRepository;
++import com.mojang.authlib.minecraft.MinecraftSessionService;
++import net.minecraft.server.MinecraftServer;
++import org.bukkit.Server;
++import org.bukkit.ServerModule;
++import org.bukkit.craftbukkit.event.CraftServerEventRegistry;
++import org.bukkit.craftbukkit.scheduler.CraftScheduler;
++import org.bukkit.craftbukkit.user.MojangUserSource;
++import org.bukkit.craftbukkit.user.UserUpdateListener;
++import tc.oc.minecraft.api.user.UserFactory;
++import tc.oc.minecraft.api.user.UserSourceBinder;
++
++public class CraftServerModule extends AbstractModule {
++
++    @Override
++    protected void configure() {
++        install(new ServerModule());
++
++        bind(CraftServerEventRegistry.class);
++        bind(CraftScheduler.class).in(Singleton.class);
++        bind(UserUpdateListener.class).asEagerSingleton();
++
++        OptionalBinder.newOptionalBinder(binder(), UserFactory.class)
++                      .setBinding().to(CraftOfflinePlayerFactory.class);
++
++        new UserSourceBinder(binder())
++            .addBinding().to(MojangUserSource.class);
++    }
++
++    @Provides
++    CraftServer craftServer(Server server) {
++        return (CraftServer) server;
++    }
++
++    @Provides
++    MinecraftServer minecraftServer(CraftServer craftServer) {
++        return craftServer.getServer();
++    }
++
++    @Provides
++    MinecraftSessionService minecraftSessionService(MinecraftServer minecraftServer) {
++        return minecraftServer.az();
++    }
++
++    @Provides
++    GameProfileRepository gameProfileRepository(MinecraftServer minecraftServer) {
++        return minecraftServer.getGameProfileRepository();
++    }
++}
+diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftServerEventRegistry.java b/src/main/java/org/bukkit/craftbukkit/event/CraftServerEventRegistry.java
+new file mode 100644
+index 0000000..5da2c15
+--- /dev/null
++++ b/src/main/java/org/bukkit/craftbukkit/event/CraftServerEventRegistry.java
+@@ -0,0 +1,16 @@
++package org.bukkit.craftbukkit.event;
++
++import javax.inject.Inject;
++
++import org.bukkit.event.SimpleEventRegistry;
++import tc.oc.minecraft.api.server.ServerExceptionHandler;
++
++/**
++ * Used internally to register event listeners that don't belong to any plugin
++ */
++public class CraftServerEventRegistry extends SimpleEventRegistry {
++
++    @Inject CraftServerEventRegistry(ServerExceptionHandler exceptionHandler) {
++        super(exceptionHandler);
++    }
++}
+diff --git a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java b/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
+--- a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
++++ b/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
+@@ -9,11 +9,11 @@ import java.util.PriorityQueue;
+ import java.util.concurrent.Callable;
+ import java.util.concurrent.ConcurrentHashMap;
+ import java.util.concurrent.Executor;
+-import java.util.concurrent.Executors;
+ import java.util.concurrent.Future;
+ import java.util.concurrent.atomic.AtomicInteger;
+ import java.util.concurrent.atomic.AtomicReference;
+ import java.util.logging.Level;
++import javax.inject.Inject;
+ 
+ import org.apache.commons.lang.Validate;
+ import org.bukkit.plugin.IllegalPluginAccessException;
+@@ -22,6 +22,7 @@ import org.bukkit.scheduler.BukkitRunnable;
+ import org.bukkit.scheduler.BukkitScheduler;
+ import org.bukkit.scheduler.BukkitTask;
+ import org.bukkit.scheduler.BukkitWorker;
++import tc.oc.minecraft.api.scheduler.Async;
+ 
+ /**
+  * The fundamental concepts for this implementation:
+@@ -76,7 +77,7 @@ public class CraftScheduler implements BukkitScheduler {
+      */
+     private final ConcurrentHashMap<Integer, CraftTask> runners = new ConcurrentHashMap<Integer, CraftTask>();
+     private volatile int currentTick = -1;
+-    private final Executor executor = Executors.newCachedThreadPool(new com.google.common.util.concurrent.ThreadFactoryBuilder().setNameFormat("Craft Scheduler Thread - %1$d").build()); // Spigot
++    private @Inject @Async Executor executor;
+     private CraftAsyncDebugger debugHead = new CraftAsyncDebugger(-1, null, null) {@Override StringBuilder debugTo(StringBuilder string) {return string;}};
+     private CraftAsyncDebugger debugTail = debugHead;
+     private static final int RECENT_TICKS;
+diff --git a/src/main/java/org/bukkit/craftbukkit/user/MojangUserSource.java b/src/main/java/org/bukkit/craftbukkit/user/MojangUserSource.java
+new file mode 100644
+index 0000000..655927f
+--- /dev/null
++++ b/src/main/java/org/bukkit/craftbukkit/user/MojangUserSource.java
+@@ -0,0 +1,68 @@
++package org.bukkit.craftbukkit.user;
++
++import java.time.Instant;
++import java.util.Optional;
++import java.util.UUID;
++import java.util.function.Supplier;
++import javax.annotation.Nullable;
++import javax.inject.Inject;
++import javax.inject.Singleton;
++
++import com.mojang.authlib.Agent;
++import com.mojang.authlib.GameProfile;
++import com.mojang.authlib.GameProfileRepository;
++import com.mojang.authlib.ProfileLookupCallback;
++import com.mojang.authlib.minecraft.MinecraftSessionService;
++import org.bukkit.craftbukkit.CraftOfflinePlayer;
++import org.bukkit.craftbukkit.CraftOfflinePlayerFactory;
++import tc.oc.minecraft.api.user.User;
++import tc.oc.minecraft.api.user.UserSearch;
++import tc.oc.minecraft.api.user.UserSource;
++
++@Singleton
++public class MojangUserSource implements UserSource {
++
++    private final CraftOfflinePlayerFactory userFactory;
++    private final MinecraftSessionService sessions;
++    private final GameProfileRepository profiles;
++
++    @Inject MojangUserSource(CraftOfflinePlayerFactory userFactory, MinecraftSessionService sessions, GameProfileRepository profiles) {
++        this.userFactory = userFactory;
++        this.sessions = sessions;
++        this.profiles = profiles;
++    }
++
++    @Override
++    public User search(UserSearch search, Supplier<User> next) {
++        // Never fetch on the main thread
++        if(search.sync()) return next.get();
++
++        final CraftOfflinePlayer op;
++        if(search.query() instanceof UUID) {
++            op = userFactory.createUser(
++                sessions.fillProfileProperties(new GameProfile((UUID) search.query(), null), true),
++                Optional.of(Instant.now())
++            );
++        } else {
++            // Despite the weird callback, this does appear to be entirely synchronous
++            final NameCallback callback = new NameCallback();
++            profiles.findProfilesByNames(new String[] {(String) search.query()}, Agent.MINECRAFT, callback);
++            if(callback.user == null) return next.get();
++            op = callback.user;
++        }
++        return search.filter().test(op) ? op : next.get();
++    }
++
++    private class NameCallback implements ProfileLookupCallback {
++
++        @Nullable CraftOfflinePlayer user;
++
++        @Override
++        public void onProfileLookupSucceeded(GameProfile profile) {
++            user = userFactory.createUser(profile, Optional.of(Instant.now()));
++        }
++
++        @Override
++        public void onProfileLookupFailed(GameProfile profile, Exception e) {}
++    }
++}
+diff --git a/src/main/java/org/bukkit/craftbukkit/user/UserUpdateListener.java b/src/main/java/org/bukkit/craftbukkit/user/UserUpdateListener.java
+new file mode 100644
+index 0000000..c89efb7
+--- /dev/null
++++ b/src/main/java/org/bukkit/craftbukkit/user/UserUpdateListener.java
+@@ -0,0 +1,39 @@
++package org.bukkit.craftbukkit.user;
++
++import java.time.Instant;
++import java.util.ArrayList;
++import java.util.Collections;
++import java.util.List;
++import java.util.Set;
++import javax.inject.Inject;
++
++import org.bukkit.craftbukkit.event.CraftServerEventRegistry;
++import org.bukkit.event.EventException;
++import org.bukkit.event.EventHandler;
++import org.bukkit.event.Listener;
++import org.bukkit.event.player.AsyncPlayerPreLoginEvent;
++import tc.oc.minecraft.api.user.User;
++import tc.oc.minecraft.api.user.UserFactory;
++import tc.oc.minecraft.api.user.UserSource;
++
++/**
++ * Refreshes all {@link UserSource}s when a player logs in
++ */
++public class UserUpdateListener implements Listener {
++
++    private final List<UserSource> userSources;
++    private final UserFactory userFactory;
++
++    @Inject UserUpdateListener(Set<UserSource> userSources, UserFactory userFactory, CraftServerEventRegistry eventRegistry) {
++        this.userSources = new ArrayList<>(userSources);
++        Collections.reverse(this.userSources); // Update sources in the same order as cache propagates
++        this.userFactory = userFactory;
++        eventRegistry.registerListener(this);
++    }
++
++    @EventHandler
++    public void callEvent(AsyncPlayerPreLoginEvent event) throws EventException {
++        final User user = userFactory.createUser(event.getUniqueId(), event.getName(), Instant.now());
++        userSources.forEach(source -> source.update(user));
++    }
++}

--- a/CraftBukkit/Update-the-POM-to-distinguish-SportBukkit-from-Craft.patch
+++ b/CraftBukkit/Update-the-POM-to-distinguish-SportBukkit-from-Craft.patch
@@ -67,7 +67,18 @@ diff --git a/pom.xml b/pom.xml
              <version>${project.version}</version>
              <scope>compile</scope>
          </dependency>
-@@ -57,6 +78,16 @@
+@@ -46,17 +67,21 @@
+             <scope>compile</scope>
+         </dependency>
+         <dependency>
+-            <groupId>org.xerial</groupId>
+-            <artifactId>sqlite-jdbc</artifactId>
+-            <version>3.15.1</version>
+-            <scope>compile</scope>
+-        </dependency>
+-        <dependency>
+             <groupId>mysql</groupId>
+             <artifactId>mysql-connector-java</artifactId>
              <version>5.1.39</version>
              <scope>compile</scope>
          </dependency>
@@ -84,7 +95,7 @@ diff --git a/pom.xml b/pom.xml
          <!-- testing -->
          <dependency>
              <groupId>junit</groupId>
-@@ -70,6 +101,12 @@
+@@ -70,6 +95,12 @@
              <version>1.3</version>
              <scope>test</scope>
          </dependency>
@@ -97,7 +108,7 @@ diff --git a/pom.xml b/pom.xml
      </dependencies>
  
      <!-- required until fixed plexus-compiler-eclipse is deployed -->
-@@ -152,8 +189,8 @@
+@@ -152,8 +183,8 @@
                  <configuration>
                      <signature>
                          <groupId>org.codehaus.mojo.signature</groupId>
@@ -108,7 +119,7 @@ diff --git a/pom.xml b/pom.xml
                      </signature>
                  </configuration>
              </plugin>
-@@ -185,17 +222,6 @@
+@@ -185,17 +216,6 @@
                                      <pattern>org.gjt</pattern>
                                      <shadedPattern>org.bukkit.craftbukkit.libs.org.gjt</shadedPattern>
                                  </relocation>

--- a/snapshot/Bukkit/src/main/java/org/bukkit/OfflinePlayer.java
+++ b/snapshot/Bukkit/src/main/java/org/bukkit/OfflinePlayer.java
@@ -1,7 +1,6 @@
 package org.bukkit;
 
 import java.util.Date;
-import java.util.Optional;
 import java.util.UUID;
 
 import org.bukkit.configuration.serialization.ConfigurationSerializable;
@@ -10,8 +9,9 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerLoginEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.permissions.ServerOperator;
+import tc.oc.minecraft.api.user.User;
 
-public interface OfflinePlayer extends ServerOperator, AnimalTamer, ConfigurationSerializable, tc.oc.minecraft.api.entity.OfflinePlayer {
+public interface OfflinePlayer extends ServerOperator, AnimalTamer, ConfigurationSerializable, User {
 
     /**
      * Checks if this player is currently online
@@ -37,11 +37,6 @@ public interface OfflinePlayer extends ServerOperator, AnimalTamer, Configuratio
      * @return Player name or null if we have not seen a name for this player yet
      */
     public String getName();
-
-    @Override
-    default Optional<String> getLastKnownName() {
-        return Optional.ofNullable(getName());
-    }
 
     /**
      * Returns the UUID of this player

--- a/snapshot/Bukkit/src/main/java/org/bukkit/ServerModule.java
+++ b/snapshot/Bukkit/src/main/java/org/bukkit/ServerModule.java
@@ -18,6 +18,7 @@ import org.bukkit.scoreboard.ScoreboardManager;
 import tc.oc.inject.SingletonModule;
 import tc.oc.minecraft.api.plugin.PluginFinder;
 import tc.oc.minecraft.api.server.LocalServer;
+import tc.oc.minecraft.api.server.MinecraftServerModule;
 
 /**
  * Bindings for things that belong to a {@link Server}.
@@ -31,6 +32,7 @@ public class ServerModule extends SingletonModule {
     @Override
     protected void configure() {
         install(new BukkitModule());
+        install(new MinecraftServerModule());
 
         bind(tc.oc.minecraft.api.server.Server.class).to(LocalServer.class);
         bind(LocalServer.class).to(Server.class);

--- a/snapshot/Bukkit/src/main/java/org/bukkit/entity/Player.java
+++ b/snapshot/Bukkit/src/main/java/org/bukkit/entity/Player.java
@@ -1,8 +1,6 @@
 package org.bukkit.entity;
 
 import java.net.InetSocketAddress;
-import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 
 import net.md_5.bungee.api.chat.BaseComponent;
@@ -34,11 +32,6 @@ import org.bukkit.util.Vector;
  * Represents a player, connected or not
  */
 public interface Player extends HumanEntity, Conversable, CommandSender, OfflinePlayer, PluginMessageRecipient, tc.oc.minecraft.api.entity.Player {
-
-    @Override
-    default Optional<String> getLastKnownName() {
-        return Optional.of(getName());
-    }
 
     /**
      * Set a fake name for this player when viewed by the given player.

--- a/snapshot/CraftBukkit/nms-patches/MinecraftServer.patch
+++ b/snapshot/CraftBukkit/nms-patches/MinecraftServer.patch
@@ -120,7 +120,7 @@
          this.i = new long[this.worldServer.length][100];
          IDataManager idatamanager = this.convertable.a(s, true);
  
-@@ -170,36 +250,108 @@
+@@ -170,36 +250,109 @@
              worlddata.a(s1);
              worldsettings = new WorldSettings(worlddata);
          }
@@ -176,6 +176,7 @@
 -                this.worldServer[j].a(worldsettings);
 +                world.a(worldsettings);
 +                this.server.scoreboardManager = new org.bukkit.craftbukkit.scoreboard.CraftScoreboardManager(this, world.getScoreboard());
++                this.server.overworld = world;
              } else {
 -                this.worldServer[j] = (WorldServer) (new SecondaryWorldServer(this, idatamanager, b0, this.worldServer[0], this.methodProfiler)).b();
 +                String dim = "DIM" + dimension;
@@ -240,7 +241,7 @@
          this.v.setPlayerFileData(this.worldServer);
          this.a(this.getDifficulty());
          this.l();
-@@ -215,25 +367,38 @@
+@@ -215,25 +368,38 @@
          this.b("menu.generatingTerrain");
          boolean flag4 = false;
  
@@ -294,7 +295,7 @@
          this.t();
      }
  
-@@ -273,14 +438,17 @@
+@@ -273,14 +439,17 @@
      protected void t() {
          this.f = null;
          this.g = 0;
@@ -314,7 +315,7 @@
  
              if (worldserver != null) {
                  if (!flag) {
-@@ -289,6 +457,7 @@
+@@ -289,6 +458,7 @@
  
                  try {
                      worldserver.save(true, (IProgressUpdate) null);
@@ -322,7 +323,7 @@
                  } catch (ExceptionWorldConflict exceptionworldconflict) {
                      MinecraftServer.LOGGER.warn(exceptionworldconflict.getMessage());
                  }
-@@ -297,8 +466,24 @@
+@@ -297,8 +467,24 @@
  
      }
  
@@ -348,7 +349,7 @@
          if (this.an() != null) {
              this.an().b();
          }
-@@ -307,6 +492,7 @@
+@@ -307,6 +493,7 @@
              MinecraftServer.LOGGER.info("Saving players");
              this.v.savePlayers();
              this.v.u();
@@ -356,7 +357,7 @@
          }
  
          if (this.worldServer != null) {
-@@ -328,12 +514,14 @@
+@@ -328,12 +515,14 @@
              aworldserver = this.worldServer;
              i = aworldserver.length;
  
@@ -371,7 +372,7 @@
          }
  
          if (this.m.d()) {
-@@ -356,52 +544,137 @@
+@@ -356,52 +545,137 @@
  
      public void safeShutdown() {
          this.isRunning = false;
@@ -535,7 +536,7 @@
              MinecraftServer.LOGGER.error("Encountered an unexpected exception", throwable);
              CrashReport crashreport = null;
  
-@@ -427,6 +700,12 @@
+@@ -427,6 +701,12 @@
              } catch (Throwable throwable1) {
                  MinecraftServer.LOGGER.error("Exception stopping the server", throwable1);
              } finally {
@@ -548,7 +549,7 @@
                  this.B();
              }
  
-@@ -470,7 +749,8 @@
+@@ -470,7 +750,8 @@
  
      public void B() {}
  
@@ -558,7 +559,7 @@
          long i = System.nanoTime();
  
          ++this.ticks;
-@@ -496,7 +776,7 @@
+@@ -496,7 +777,7 @@
              this.q.b().a(agameprofile);
          }
  
@@ -567,7 +568,7 @@
              this.methodProfiler.a("save");
              this.v.savePlayers();
              this.saveChunks(true);
-@@ -507,11 +787,11 @@
+@@ -507,11 +788,11 @@
          this.h[this.ticks % 100] = System.nanoTime() - i;
          this.methodProfiler.b();
          this.methodProfiler.a("snooper");
@@ -581,7 +582,7 @@
              this.m.b();
          }
  
-@@ -520,31 +800,59 @@
+@@ -520,31 +801,59 @@
      }
  
      public void D() {
@@ -644,7 +645,7 @@
  
                  this.methodProfiler.a("tick");
  
-@@ -571,9 +879,9 @@
+@@ -571,9 +880,9 @@
                  worldserver.getTracker().updatePlayers();
                  this.methodProfiler.b();
                  this.methodProfiler.b();
@@ -656,7 +657,7 @@
          }
  
          this.methodProfiler.c("connection");
-@@ -597,10 +905,11 @@
+@@ -597,10 +906,11 @@
          this.o.add(itickable);
      }
  
@@ -669,7 +670,7 @@
              boolean flag = true;
              String s = null;
              String s1 = ".";
-@@ -645,13 +954,16 @@
+@@ -645,13 +955,16 @@
                      ++j;
                  }
              }
@@ -687,7 +688,7 @@
              if (s != null) {
                  dedicatedserver.i(s);
              }
-@@ -682,15 +994,37 @@
+@@ -682,15 +995,37 @@
                      dedicatedserver.stop();
                  }
              });
@@ -725,7 +726,7 @@
      }
  
      public File d(String s) {
-@@ -706,7 +1040,14 @@
+@@ -706,7 +1041,14 @@
      }
  
      public WorldServer getWorldServer(int i) {
@@ -741,7 +742,7 @@
      }
  
      public String getVersion() {
-@@ -730,7 +1071,7 @@
+@@ -730,7 +1072,7 @@
      }
  
      public boolean isDebugging() {
@@ -750,7 +751,7 @@
      }
  
      public void g(String s) {
-@@ -745,7 +1086,7 @@
+@@ -745,7 +1087,7 @@
      }
  
      public String getServerModName() {
@@ -759,7 +760,7 @@
      }
  
      public CrashReport b(CrashReport crashreport) {
-@@ -774,6 +1115,7 @@
+@@ -774,6 +1116,7 @@
      }
  
      public List<String> tabCompleteCommand(ICommandListener icommandlistener, String s, @Nullable BlockPosition blockposition, boolean flag) {
@@ -767,7 +768,7 @@
          ArrayList arraylist = Lists.newArrayList();
          boolean flag1 = s.startsWith("/");
  
-@@ -816,10 +1158,13 @@
+@@ -816,10 +1159,13 @@
  
              return arraylist;
          }
@@ -782,7 +783,7 @@
      }
  
      public String getName() {
-@@ -827,7 +1172,7 @@
+@@ -827,7 +1173,7 @@
      }
  
      public void sendMessage(IChatBaseComponent ichatbasecomponent) {
@@ -791,7 +792,7 @@
      }
  
      public boolean a(int i, String s) {
-@@ -842,6 +1187,7 @@
+@@ -842,6 +1188,7 @@
          return this.I;
      }
  
@@ -799,7 +800,7 @@
      public int P() {
          return this.u;
      }
-@@ -875,11 +1221,13 @@
+@@ -875,11 +1222,13 @@
      }
  
      public void a(EnumDifficulty enumdifficulty) {
@@ -816,7 +817,7 @@
  
              if (worldserver != null) {
                  if (worldserver.getWorldData().isHardcore()) {
-@@ -946,13 +1294,11 @@
+@@ -946,13 +1295,11 @@
          int i = 0;
  
          if (this.worldServer != null) {
@@ -834,7 +835,7 @@
                      WorldData worlddata = worldserver.getWorldData();
  
                      mojangstatisticsgenerator.a("world[" + i + "][dimension]", Integer.valueOf(worldserver.worldProvider.getDimensionManager().getDimensionID()));
-@@ -985,7 +1331,7 @@
+@@ -985,7 +1332,7 @@
      public abstract boolean aa();
  
      public boolean getOnlineMode() {
@@ -843,7 +844,7 @@
      }
  
      public void setOnlineMode(boolean flag) {
-@@ -1065,17 +1411,14 @@
+@@ -1065,17 +1412,14 @@
      }
  
      public void setGamemode(EnumGamemode enumgamemode) {
@@ -865,7 +866,7 @@
      public ServerConnection an() {
          return this.p;
      }
-@@ -1103,7 +1446,7 @@
+@@ -1103,7 +1447,7 @@
      }
  
      public World getWorld() {
@@ -874,7 +875,7 @@
      }
  
      public Entity f() {
-@@ -1130,6 +1473,7 @@
+@@ -1130,6 +1474,7 @@
          return this.e;
      }
  
@@ -882,7 +883,7 @@
      public static long aw() {
          return System.currentTimeMillis();
      }
-@@ -1175,8 +1519,10 @@
+@@ -1175,8 +1520,10 @@
          WorldServer[] aworldserver = this.worldServer;
          int i = aworldserver.length;
  
@@ -895,7 +896,7 @@
  
              if (worldserver != null) {
                  Entity entity = worldserver.getEntity(uuid);
-@@ -1191,7 +1537,7 @@
+@@ -1191,7 +1538,7 @@
      }
  
      public boolean getSendCommandFeedback() {
@@ -904,7 +905,7 @@
      }
  
      public void a(CommandObjectiveExecutor.EnumCommandResult commandobjectiveexecutor_enumcommandresult, int i) {}
-@@ -1206,12 +1552,13 @@
+@@ -1206,12 +1553,13 @@
  
      public <V> ListenableFuture<V> a(Callable<V> callable) {
          Validate.notNull(callable);
@@ -919,7 +920,7 @@
                  return listenablefuturetask;
              }
          } else {
-@@ -1232,6 +1579,48 @@
+@@ -1232,6 +1580,48 @@
          return Thread.currentThread() == this.serverThread;
      }
  
@@ -968,7 +969,7 @@
      public int aG() {
          return 256;
      }
-@@ -1251,4 +1640,11 @@
+@@ -1251,4 +1641,11 @@
      public int a(@Nullable WorldServer worldserver) {
          return worldserver != null ? worldserver.getGameRules().c("spawnRadius") : 10;
      }

--- a/snapshot/CraftBukkit/pom.xml
+++ b/snapshot/CraftBukkit/pom.xml
@@ -67,12 +67,6 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>org.xerial</groupId>
-            <artifactId>sqlite-jdbc</artifactId>
-            <version>3.15.1</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
             <version>5.1.39</version>

--- a/snapshot/CraftBukkit/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayerFactory.java
+++ b/snapshot/CraftBukkit/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayerFactory.java
@@ -1,0 +1,51 @@
+package org.bukkit.craftbukkit;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+import javax.inject.Inject;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+import com.mojang.authlib.GameProfile;
+import tc.oc.minecraft.api.user.User;
+import tc.oc.minecraft.api.user.UserFactory;
+import tc.oc.minecraft.api.user.UserUtils;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+@Singleton
+public class CraftOfflinePlayerFactory implements UserFactory {
+
+    private final Provider<CraftServer> server;
+
+    @Inject CraftOfflinePlayerFactory(Provider<CraftServer> server) {
+        this.server = server;
+    }
+
+    public CraftOfflinePlayer createUser(GameProfile profile, Optional<Instant> updatedAt) {
+        return new CraftOfflinePlayer(server.get(), profile, updatedAt);
+    }
+
+    @Override
+    public CraftOfflinePlayer createUser(UUID id) {
+        return createUser(new GameProfile(checkNotNull(id), null), Optional.empty());
+    }
+
+    @Override
+    public CraftOfflinePlayer createUser(String name) {
+        return createUser(new GameProfile(UserUtils.offlinePlayerId(name), name), Optional.empty());
+    }
+
+    @Override
+    public CraftOfflinePlayer createUser(UUID id, String name, Instant updatedAt) {
+        return createUser(new GameProfile(checkNotNull(id), checkNotNull(name)), Optional.of(updatedAt));
+    }
+
+    @Override
+    public CraftOfflinePlayer copyUser(User user) {
+        return user instanceof CraftOfflinePlayer
+               ? (CraftOfflinePlayer) user
+               : (CraftOfflinePlayer) UserFactory.super.copyUser(user);
+    }
+}

--- a/snapshot/CraftBukkit/src/main/java/org/bukkit/craftbukkit/CraftServerModule.java
+++ b/snapshot/CraftBukkit/src/main/java/org/bukkit/craftbukkit/CraftServerModule.java
@@ -1,0 +1,56 @@
+package org.bukkit.craftbukkit;
+
+import javax.inject.Singleton;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
+import com.google.inject.multibindings.OptionalBinder;
+import com.mojang.authlib.GameProfileRepository;
+import com.mojang.authlib.minecraft.MinecraftSessionService;
+import net.minecraft.server.MinecraftServer;
+import org.bukkit.Server;
+import org.bukkit.ServerModule;
+import org.bukkit.craftbukkit.event.CraftServerEventRegistry;
+import org.bukkit.craftbukkit.scheduler.CraftScheduler;
+import org.bukkit.craftbukkit.user.MojangUserSource;
+import org.bukkit.craftbukkit.user.UserUpdateListener;
+import tc.oc.minecraft.api.user.UserFactory;
+import tc.oc.minecraft.api.user.UserSourceBinder;
+
+public class CraftServerModule extends AbstractModule {
+
+    @Override
+    protected void configure() {
+        install(new ServerModule());
+
+        bind(CraftServerEventRegistry.class);
+        bind(CraftScheduler.class).in(Singleton.class);
+        bind(UserUpdateListener.class).asEagerSingleton();
+
+        OptionalBinder.newOptionalBinder(binder(), UserFactory.class)
+                      .setBinding().to(CraftOfflinePlayerFactory.class);
+
+        new UserSourceBinder(binder())
+            .addBinding().to(MojangUserSource.class);
+    }
+
+    @Provides
+    CraftServer craftServer(Server server) {
+        return (CraftServer) server;
+    }
+
+    @Provides
+    MinecraftServer minecraftServer(CraftServer craftServer) {
+        return craftServer.getServer();
+    }
+
+    @Provides
+    MinecraftSessionService minecraftSessionService(MinecraftServer minecraftServer) {
+        return minecraftServer.az();
+    }
+
+    @Provides
+    GameProfileRepository gameProfileRepository(MinecraftServer minecraftServer) {
+        return minecraftServer.getGameProfileRepository();
+    }
+}

--- a/snapshot/CraftBukkit/src/main/java/org/bukkit/craftbukkit/event/CraftServerEventRegistry.java
+++ b/snapshot/CraftBukkit/src/main/java/org/bukkit/craftbukkit/event/CraftServerEventRegistry.java
@@ -1,0 +1,16 @@
+package org.bukkit.craftbukkit.event;
+
+import javax.inject.Inject;
+
+import org.bukkit.event.SimpleEventRegistry;
+import tc.oc.minecraft.api.server.ServerExceptionHandler;
+
+/**
+ * Used internally to register event listeners that don't belong to any plugin
+ */
+public class CraftServerEventRegistry extends SimpleEventRegistry {
+
+    @Inject CraftServerEventRegistry(ServerExceptionHandler exceptionHandler) {
+        super(exceptionHandler);
+    }
+}

--- a/snapshot/CraftBukkit/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
+++ b/snapshot/CraftBukkit/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
@@ -9,11 +9,11 @@ import java.util.PriorityQueue;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
+import javax.inject.Inject;
 
 import org.apache.commons.lang.Validate;
 import org.bukkit.plugin.IllegalPluginAccessException;
@@ -22,6 +22,7 @@ import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.scheduler.BukkitScheduler;
 import org.bukkit.scheduler.BukkitTask;
 import org.bukkit.scheduler.BukkitWorker;
+import tc.oc.minecraft.api.scheduler.Async;
 
 /**
  * The fundamental concepts for this implementation:
@@ -76,7 +77,7 @@ public class CraftScheduler implements BukkitScheduler {
      */
     private final ConcurrentHashMap<Integer, CraftTask> runners = new ConcurrentHashMap<Integer, CraftTask>();
     private volatile int currentTick = -1;
-    private final Executor executor = Executors.newCachedThreadPool(new com.google.common.util.concurrent.ThreadFactoryBuilder().setNameFormat("Craft Scheduler Thread - %1$d").build()); // Spigot
+    private @Inject @Async Executor executor;
     private CraftAsyncDebugger debugHead = new CraftAsyncDebugger(-1, null, null) {@Override StringBuilder debugTo(StringBuilder string) {return string;}};
     private CraftAsyncDebugger debugTail = debugHead;
     private static final int RECENT_TICKS;

--- a/snapshot/CraftBukkit/src/main/java/org/bukkit/craftbukkit/user/MojangUserSource.java
+++ b/snapshot/CraftBukkit/src/main/java/org/bukkit/craftbukkit/user/MojangUserSource.java
@@ -1,0 +1,68 @@
+package org.bukkit.craftbukkit.user;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Supplier;
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import com.mojang.authlib.Agent;
+import com.mojang.authlib.GameProfile;
+import com.mojang.authlib.GameProfileRepository;
+import com.mojang.authlib.ProfileLookupCallback;
+import com.mojang.authlib.minecraft.MinecraftSessionService;
+import org.bukkit.craftbukkit.CraftOfflinePlayer;
+import org.bukkit.craftbukkit.CraftOfflinePlayerFactory;
+import tc.oc.minecraft.api.user.User;
+import tc.oc.minecraft.api.user.UserSearch;
+import tc.oc.minecraft.api.user.UserSource;
+
+@Singleton
+public class MojangUserSource implements UserSource {
+
+    private final CraftOfflinePlayerFactory userFactory;
+    private final MinecraftSessionService sessions;
+    private final GameProfileRepository profiles;
+
+    @Inject MojangUserSource(CraftOfflinePlayerFactory userFactory, MinecraftSessionService sessions, GameProfileRepository profiles) {
+        this.userFactory = userFactory;
+        this.sessions = sessions;
+        this.profiles = profiles;
+    }
+
+    @Override
+    public User search(UserSearch search, Supplier<User> next) {
+        // Never fetch on the main thread
+        if(search.sync()) return next.get();
+
+        final CraftOfflinePlayer op;
+        if(search.query() instanceof UUID) {
+            op = userFactory.createUser(
+                sessions.fillProfileProperties(new GameProfile((UUID) search.query(), null), true),
+                Optional.of(Instant.now())
+            );
+        } else {
+            // Despite the weird callback, this does appear to be entirely synchronous
+            final NameCallback callback = new NameCallback();
+            profiles.findProfilesByNames(new String[] {(String) search.query()}, Agent.MINECRAFT, callback);
+            if(callback.user == null) return next.get();
+            op = callback.user;
+        }
+        return search.filter().test(op) ? op : next.get();
+    }
+
+    private class NameCallback implements ProfileLookupCallback {
+
+        @Nullable CraftOfflinePlayer user;
+
+        @Override
+        public void onProfileLookupSucceeded(GameProfile profile) {
+            user = userFactory.createUser(profile, Optional.of(Instant.now()));
+        }
+
+        @Override
+        public void onProfileLookupFailed(GameProfile profile, Exception e) {}
+    }
+}

--- a/snapshot/CraftBukkit/src/main/java/org/bukkit/craftbukkit/user/UserUpdateListener.java
+++ b/snapshot/CraftBukkit/src/main/java/org/bukkit/craftbukkit/user/UserUpdateListener.java
@@ -1,0 +1,39 @@
+package org.bukkit.craftbukkit.user;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import javax.inject.Inject;
+
+import org.bukkit.craftbukkit.event.CraftServerEventRegistry;
+import org.bukkit.event.EventException;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.AsyncPlayerPreLoginEvent;
+import tc.oc.minecraft.api.user.User;
+import tc.oc.minecraft.api.user.UserFactory;
+import tc.oc.minecraft.api.user.UserSource;
+
+/**
+ * Refreshes all {@link UserSource}s when a player logs in
+ */
+public class UserUpdateListener implements Listener {
+
+    private final List<UserSource> userSources;
+    private final UserFactory userFactory;
+
+    @Inject UserUpdateListener(Set<UserSource> userSources, UserFactory userFactory, CraftServerEventRegistry eventRegistry) {
+        this.userSources = new ArrayList<>(userSources);
+        Collections.reverse(this.userSources); // Update sources in the same order as cache propagates
+        this.userFactory = userFactory;
+        eventRegistry.registerListener(this);
+    }
+
+    @EventHandler
+    public void callEvent(AsyncPlayerPreLoginEvent event) throws EventException {
+        final User user = userFactory.createUser(event.getUniqueId(), event.getName(), Instant.now());
+        userSources.forEach(source -> source.update(user));
+    }
+}


### PR DESCRIPTION
Implement `OfflinePlayerFinder` from https://github.com/OvercastNetwork/minecraft-api/pull/8

`nms.MinecraftSessionService` is used to fetch profiles from Mojang's API.